### PR TITLE
Link live dark-pattern demo site in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,9 @@ Load `extension/dist/` as unpacked at `chrome://extensions`.
 
 ### Demo site
 
+Live deployment: <https://shield-dark-pattern-demo.vercel.app/>. To run it
+locally:
+
 ```sh
 cd demo-site
 bun install

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ that deliberately packs the threats and dark patterns agent-browser-shield
 defends against onto a few pages. Load it with and without the extension to see
 the before/after difference.
 
+Live deployment:
+<https://shield-dark-pattern-demo.vercel.app/>
+
+To run it locally instead:
+
 ```sh
 cd demo-site
 bun install

--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ that deliberately packs the threats and dark patterns agent-browser-shield
 defends against onto a few pages. Load it with and without the extension to see
 the before/after difference.
 
-Live deployment:
-<https://shield-dark-pattern-demo.vercel.app/>
+Live deployment: <https://shield-dark-pattern-demo.vercel.app/>
 
 To run it locally instead:
 

--- a/demo-site/README.md
+++ b/demo-site/README.md
@@ -8,6 +8,8 @@ not loading) the extension produces an immediate visible difference.
 This site is **not** part of the benchmark. It exists so reviewers can open it
 in a browser and see "before / after" by toggling the extension on or off.
 
+Live deployment: <https://shield-dark-pattern-demo.vercel.app/>
+
 ## What's embedded
 
 | Page                            | Rules exercised                                                                                                                                              |


### PR DESCRIPTION
## Summary

- Adds the deployed demo site URL (<https://shield-dark-pattern-demo.vercel.app/>) to the top-level `README.md`, `CONTRIBUTING.md`, and `demo-site/README.md`.
- Reviewers can now try the before/after toggle without cloning the repo and running Vite locally; local-dev instructions are still there for contributors.

## Test plan

- [ ] Rendered Markdown links resolve and the live URL loads
- [ ] `demo-site/README.md` still reads correctly with the new line above "What's embedded"

🤖 Generated with [Claude Code](https://claude.com/claude-code)