### PR TITLE
ci: package and upload extension zip artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,14 @@ jobs:
         run: bun run test
       - name: Build
         run: bun run build
+      - name: Package extension zip
+        run: bun run package
+      - name: Upload extension zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-zip
+          path: output/extension.zip
+          if-no-files-found: error
 
   demo-site:
     name: Demo site (build)


### PR DESCRIPTION
## Summary
- Run `bun run package` (which invokes `scripts/package-extension.ts`) after the extension build in CI
- Upload the resulting `output/extension.zip` as the `extension-zip` artifact on every run
- Zip is 1-layer with `manifest.json` at the root, matching Browserbase's required layout

## Test plan
- [ ] CI passes on this PR
- [ ] `extension-zip` artifact is downloadable from the workflow run
- [ ] Downloaded zip extracts with `manifest.json` at the top level (no nested folder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)