### PR TITLE
Run rule engine in all frames

### DIFF
--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,8 +1,14 @@
+import { isTopFrame } from "./lib/frame";
 import { injectOptionsBadge } from "./lib/options-badge";
 import { start } from "./lib/rule-engine";
 
+// Content script runs in every frame (`all_frames: true`). The rule engine
+// applies frame-appropriate rules in each; the badge is a single UI affordance
+// that belongs only on the top frame so the user doesn't get one per iframe.
 start().catch((error) => {
   console.error("[abs] failed to start rule engine", error);
 });
 
-injectOptionsBadge();
+if (isTopFrame()) {
+  injectOptionsBadge();
+}

--- a/extension/src/lib/__tests__/rule-engine.test.ts
+++ b/extension/src/lib/__tests__/rule-engine.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { Rule } from "../../rules/types";
+
+// Storage and RULES are mocked because the real engine pulls in the full rule
+// catalog (and via that, the EasyList stylesheet — multi-MB of CSS text). The
+// engine module itself is the unit under test; we want to assert how it
+// chooses what to apply, not exercise every shipped rule.
+
+const buildRule = (id: string, overrides: Partial<Rule> = {}): Rule => ({
+  id,
+  label: id,
+  description: id,
+  defaultEnabled: true,
+  apply: jest.fn(),
+  teardown: jest.fn(),
+  ...overrides,
+});
+
+const allFrameRule = buildRule("all-frame-rule");
+const topOnlyRule = buildRule("top-only-rule", { topFrameOnly: true });
+const unavailableRule = buildRule("unavailable-rule", { available: false });
+
+const FAKE_RULES: readonly Rule[] = [
+  allFrameRule,
+  topOnlyRule,
+  unavailableRule,
+];
+
+jest.mock("../../rules", () => ({
+  RULES: FAKE_RULES,
+}));
+
+jest.mock("../storage", () => ({
+  getRuleStates: jest.fn(),
+  subscribe: jest.fn(() => () => undefined),
+}));
+
+jest.mock("../frame", () => ({
+  isTopFrame: jest.fn(),
+}));
+
+import { isTopFrame } from "../frame";
+import { start } from "../rule-engine";
+import { getRuleStates } from "../storage";
+
+const getRuleStatesMock = getRuleStates as jest.MockedFunction<
+  typeof getRuleStates
+>;
+const isTopFrameMock = isTopFrame as jest.MockedFunction<typeof isTopFrame>;
+
+const allEnabled = {
+  "all-frame-rule": true,
+  "top-only-rule": true,
+  "unavailable-rule": true,
+};
+
+function setFrame(isTop: boolean): void {
+  // jsdom locks `window.top` as a non-configurable getter, so we mock the
+  // helper module instead of trying to override the global. The engine reads
+  // through `isTopFrame()`, which makes this both safer and faster.
+  isTopFrameMock.mockReturnValue(isTop);
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "<main></main>";
+  (allFrameRule.apply as jest.Mock).mockClear();
+  (topOnlyRule.apply as jest.Mock).mockClear();
+  (unavailableRule.apply as jest.Mock).mockClear();
+  getRuleStatesMock.mockResolvedValue(allEnabled);
+});
+
+describe("rule engine — frame gating", () => {
+  it("applies both top-only and frame-agnostic rules in the top frame", async () => {
+    setFrame(true);
+    await start();
+    expect(allFrameRule.apply).toHaveBeenCalledTimes(1);
+    expect(topOnlyRule.apply).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips top-only rules in subframes", async () => {
+    setFrame(false);
+    await start();
+    expect(allFrameRule.apply).toHaveBeenCalledTimes(1);
+    expect(topOnlyRule.apply).not.toHaveBeenCalled();
+  });
+
+  it("never applies rules marked unavailable, regardless of frame", async () => {
+    setFrame(true);
+    await start();
+    expect(unavailableRule.apply).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/lib/frame.ts
+++ b/extension/src/lib/frame.ts
@@ -1,0 +1,24 @@
+// Detect whether the current document is the top-level browsing context.
+//
+// With `all_frames: true` in the manifest, the content script runs once per
+// frame (top frame + every same-origin iframe + every cross-origin iframe
+// whose URL is covered by the manifest's `matches`). Most defenses make sense
+// in every frame — PII in a reviews iframe is just as sensitive as PII on the
+// host page — but a few are inherently top-frame concepts (the site footer,
+// cookie/newsletter overlays, the per-host search-URL recipe, the floating
+// options badge). Those rules opt into top-frame-only behavior via the rule
+// definition; this helper is the single source of truth for the check.
+//
+// Accessing `window.top` from a cross-origin iframe throws a SecurityError on
+// some properties, but the strict equality check between the `Window` proxy
+// returned by `window.top` and the local `window` is allowed and behaves
+// correctly (returns false for any nested frame).
+export function isTopFrame(): boolean {
+  try {
+    return window === window.top;
+  } catch {
+    // Defensive fallback — if even the equality check throws, we are
+    // definitionally not the top frame.
+    return false;
+  }
+}

--- a/extension/src/lib/rule-engine.ts
+++ b/extension/src/lib/rule-engine.ts
@@ -1,4 +1,5 @@
 import { RULES, type Rule } from "../rules";
+import { isTopFrame } from "./frame";
 import { log } from "./log";
 import { LABEL_CLASS, PLACEHOLDER_CLASS, revealAll } from "./placeholder";
 import { getRuleStates, type RuleStates, subscribe } from "./storage";
@@ -76,13 +77,37 @@ function isAvailable(rule: Rule): boolean {
   return rule.available !== false;
 }
 
-function applyEnabled(states: RuleStates): void {
+function isApplicableHere(rule: Rule, topFrame: boolean): boolean {
+  if (!isAvailable(rule)) return false;
+  // topFrameOnly rules target page-wide concepts (site footer, cookie/newsletter
+  // overlays, per-host URL recipes). Running them in subframes would either
+  // be a no-op (selectors don't match) or actively harmful (duplicate
+  // landmark injection into every iframe's body).
+  if (rule.topFrameOnly && !topFrame) return false;
+  return true;
+}
+
+function applyEnabled(states: RuleStates, topFrame: boolean): void {
+  // document.body may be missing in some about:blank / about:srcdoc iframes
+  // at document_idle if the parent injects the frame without children. Skip
+  // rule application entirely in that case — there's nothing to scan, and
+  // attempting to pass a null body would TypeError every rule.
+  if (!document.body) {
+    log("rule engine skipping — no document.body", {
+      url: window.location.href,
+    });
+    return;
+  }
   const enabled = RULES.filter(
-    (rule) => isAvailable(rule) && states[rule.id],
+    (rule) => isApplicableHere(rule, topFrame) && states[rule.id],
   ).map((r) => r.id);
-  log("initial rule application", { enabled, url: window.location.href });
+  log("initial rule application", {
+    enabled,
+    url: window.location.href,
+    topFrame,
+  });
   for (const rule of RULES) {
-    if (!isAvailable(rule)) continue;
+    if (!isApplicableHere(rule, topFrame)) continue;
     if (states[rule.id]) {
       log("applying rule", { ruleId: rule.id });
       rule.apply(document.body);
@@ -90,9 +115,14 @@ function applyEnabled(states: RuleStates): void {
   }
 }
 
-function reconcile(next: RuleStates, previous: RuleStates): void {
+function reconcile(
+  next: RuleStates,
+  previous: RuleStates,
+  topFrame: boolean,
+): void {
+  if (!document.body) return;
   for (const rule of RULES) {
-    if (!isAvailable(rule)) continue;
+    if (!isApplicableHere(rule, topFrame)) continue;
     const wasEnabled = previous[rule.id];
     const isEnabled = next[rule.id];
     if (isEnabled === wasEnabled) continue;
@@ -108,14 +138,15 @@ function reconcile(next: RuleStates, previous: RuleStates): void {
 }
 
 export async function start(): Promise<void> {
-  log("rule engine starting", { url: window.location.href });
+  const topFrame = isTopFrame();
+  log("rule engine starting", { url: window.location.href, topFrame });
   injectStyles();
   const initial = await getRuleStates();
-  applyEnabled(initial);
+  applyEnabled(initial, topFrame);
 
   let current = initial;
   subscribe((next) => {
-    reconcile(next, current);
+    reconcile(next, current, topFrame);
     current = next;
   });
 }

--- a/extension/src/lib/selector-hide-rule.ts
+++ b/extension/src/lib/selector-hide-rule.ts
@@ -48,6 +48,9 @@ interface SelectorHideRuleOptions {
   // widgets, newsletter modals) that have no natural in-flow position —
   // a placeholder there would just be dead space.
   removeEntirely?: boolean;
+  // Propagated to the Rule. See `Rule.topFrameOnly` for semantics. Default
+  // is false: the rule runs in every frame the content script reaches.
+  topFrameOnly?: boolean;
 }
 
 export interface SelectorHideRule {
@@ -71,6 +74,7 @@ export function createSelectorHideRule(
     candidateFilter,
     watchSubtrees = false,
     removeEntirely = false,
+    topFrameOnly = false,
   } = options;
 
   if (!removeEntirely && hideLabel === undefined) {
@@ -154,10 +158,11 @@ export function createSelectorHideRule(
         label,
         description,
         defaultEnabled,
+        topFrameOnly,
         apply,
         teardown: () => watcher.stop(),
       }
-    : { id, label, description, defaultEnabled, apply };
+    : { id, label, description, defaultEnabled, topFrameOnly, apply };
 
   return { rule, selectorsFor };
 }

--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -21,7 +21,9 @@
     {
       "matches": ["<all_urls>"],
       "js": ["content.js"],
-      "run_at": "document_idle"
+      "run_at": "document_idle",
+      "all_frames": true,
+      "match_origin_as_fallback": true
     }
   ]
 }

--- a/extension/src/rules/chat-widget-hide.ts
+++ b/extension/src/rules/chat-widget-hide.ts
@@ -57,6 +57,12 @@ const { rule, selectorsFor } = createSelectorHideRule({
   // (HubSpot's conversations-embed.js, Intercom's loader, etc.) — re-scan on
   // DOM mutations.
   watchSubtrees: true,
+  // The wrapper element (`#intercom-frame`, `#hubspot-messages-iframe-container`,
+  // Zendesk's `iframe#launcher`, etc.) always lives on the top frame — the
+  // widget's own iframe content is reached by hiding the wrapper, not by
+  // descending into it. Running this rule inside vendor iframes would also
+  // try to delete the vendor's own UI.
+  topFrameOnly: true,
 });
 
 export { selectorsFor };

--- a/extension/src/rules/cookie-banner-hide.ts
+++ b/extension/src/rules/cookie-banner-hide.ts
@@ -66,6 +66,9 @@ const { rule, selectorsFor } = createSelectorHideRule({
   // CMP scripts (OneTrust, Cookiebot, Sourcepoint, etc.) typically inject the
   // banner after document_idle once the consent state has been resolved.
   watchSubtrees: true,
+  // Cookie banners are full-page overlays mounted on the top document; CMPs
+  // never inject one into a content iframe.
+  topFrameOnly: true,
 });
 
 export { selectorsFor };

--- a/extension/src/rules/footer-hide.ts
+++ b/extension/src/rules/footer-hide.ts
@@ -48,6 +48,9 @@ const { rule, selectorsFor } = createSelectorHideRule({
   ],
   siteRules: FOOTER_HIDE_SITE_RULES,
   candidateFilter: isPageFooter,
+  // Per-frame footers don't exist in practice — the rule only targets the
+  // page-level footer, which lives on the top frame.
+  topFrameOnly: true,
   // Costco (Next.js) wraps the footer in a Suspense boundary that bails to
   // CSR — at document_idle the SSR <footer> exists, but React then tears down
   // the boundary subtree and re-mounts the footer client-side, wiping any

--- a/extension/src/rules/irrelevant-sections-hide.ts
+++ b/extension/src/rules/irrelevant-sections-hide.ts
@@ -311,6 +311,9 @@ export const irrelevantSectionsHideRule = {
   defaultEnabled: false,
   available: false,
   unavailableReason: "LLM-based detection is turned off in this build.",
+  // Page-level recommendation rails live on the top frame; classifying the
+  // contents of every iframe would multiply LLM cost without benefit.
+  topFrameOnly: true,
   apply,
   teardown,
 } satisfies Rule;

--- a/extension/src/rules/newsletter-modal-hide.ts
+++ b/extension/src/rules/newsletter-modal-hide.ts
@@ -83,6 +83,9 @@ const { rule, selectorsFor } = createSelectorHideRule({
   // Newsletter modals commonly inject after a 5–30s timer or scroll-depth
   // trigger, well after document_idle.
   watchSubtrees: true,
+  // Modals are full-page overlays mounted on the top document; vendor
+  // scripts never inject them into a nested iframe's body.
+  topFrameOnly: true,
 });
 
 export { selectorsFor };

--- a/extension/src/rules/search-url-helper.ts
+++ b/extension/src/rules/search-url-helper.ts
@@ -72,6 +72,11 @@ export const searchUrlHelperRule = {
   description:
     "On covered hosts (Amazon, Best Buy, Etsy, IKEA, Home Depot, REI, GitHub, Wikipedia, Hacker News, MDN, npm, weather.gov, arXiv, Python docs, BBC), embed a screen-reader-only landmark at the top of the page describing how to run searches, filters, sorts, and direct lookups via URL. Lets agents navigate by URL instead of typing into search boxes and clicking facets. No visible affordance — landmark is preserved by `hidden-text-strip` via the `sr-only` class allowlist and the 1×1 + overflow:hidden + position:absolute envelope.",
   defaultEnabled: true,
+  // Recipes are URL navigation hints for the page the agent is viewing —
+  // the top-level URL — not for whatever third-party content happens to be
+  // iframed in. Injecting a landmark into every same-origin iframe would
+  // pollute their a11y trees with off-topic instructions.
+  topFrameOnly: true,
   apply,
   teardown,
 } satisfies Rule;

--- a/extension/src/rules/types.ts
+++ b/extension/src/rules/types.ts
@@ -13,6 +13,12 @@ export interface Rule {
   // Optional note rendered alongside the disabled toggle when `available` is
   // false, explaining why the rule is unavailable.
   unavailableReason?: string;
+  // When true, the rule is only applied in the top-level browsing context.
+  // Set this for rules whose targets are inherently page-wide (site footer,
+  // cookie/newsletter overlays, per-host URL recipes) so they don't fire
+  // pointlessly — or, worse, inject duplicate UI — in every same-origin or
+  // covered cross-origin iframe.
+  topFrameOnly?: boolean;
   apply(root: ParentNode): void;
   // Release any long-lived resources (mutation observers, throttled callbacks,
   // pending timeouts) that `apply` set up. Called by the engine when the rule


### PR DESCRIPTION
## Summary
- Enable `all_frames: true` in the content script manifest (with `match_origin_as_fallback` so `about:blank` / `about:srcdoc` iframes are covered) so PII/secrets masking, prompt-injection hiding, ads-hide, hidden-text-strip, comments/reviews hiding, and the rest of the rule catalog actually reach content that lives inside iframes (Disqus, Trustpilot, AdSense, third-party comment widgets, etc.).
- Add a `topFrameOnly` opt-in on the `Rule` type — set on the rules whose targets are inherently page-wide so they don't fire pointlessly in every subframe: `footer-hide`, `cookie-banner-hide`, `newsletter-modal-hide`, `chat-widget-hide`, `search-url-helper`, `irrelevant-sections-hide`.
- Gate the floating options badge to the top frame only (no more N badges per page).
- New `lib/frame.ts` is the single source of truth for "are we the top frame", with a defensive `try/catch` around the cross-origin `window.top` access.
- New unit test (`lib/__tests__/rule-engine.test.ts`) covers the three frame-gating branches (top-frame + frame-agnostic rule applied, top-only rule skipped in subframes, unavailable rule never applied).

## Notes
- No new host permissions required — `<all_urls>` in `matches` already covers every origin the script needs to inject into.
- `ads-hide` deliberately runs in subframes too — many ad networks render the actual ad content inside their iframe, so the EasyList stylesheet needs to be present in each frame. Per-frame stylesheet cost (~600KB CSS text per frame) is a known tradeoff worth a follow-up perf pass.
- Demo-site iframe fixtures are out of scope for this PR; they can land separately once a real iframe-bearing page exists in the demo.

## Test plan
- [x] `bun run check` (biome) — passes (one pre-existing unrelated warning in `Options.tsx`, untouched)
- [x] `bun run test` — 385/385 pass, including the 3 new frame-gating tests
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run build` — produces `dist/manifest.json` with `all_frames: true` and `match_origin_as_fallback: true`
- [ ] Manual: load unpacked into Chrome, visit a page with a same-origin iframe (e.g. Disqus comments embedded via iframe), confirm `comments-hide` / `reviews-hide` placeholders appear inside the iframe and that only one options badge renders on the top frame
- [ ] Manual: confirm `cookie-banner-hide` / `newsletter-modal-hide` still fire normally on the top frame and do not log anything inside subframes

🤖 Generated with [Claude Code](https://claude.com/claude-code)