### PR TITLE
ci: stop double-zipping extension artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Upload extension zip
         uses: actions/upload-artifact@v7
         with:
-          name: extension-zip
           path: output/extension.zip
+          archive: false
           if-no-files-found: error
 
   demo-site:


### PR DESCRIPTION
## Summary
- `actions/upload-artifact` always wraps the uploaded path in a zip, so uploading `output/extension.zip` produced an `extension-zip.zip` containing `extension.zip` — users had to unzip twice before they could upload to Browserbase or load unpacked in Chrome.
- v7 (just bumped in #6) added an `archive: false` option for single-file uploads that sends the file as-is. Switching to it makes the download a plain `extension.zip`. The `name` input is ignored in this mode (artifact name comes from the file), so it's removed.

## Test plan
- [ ] CI runs green on this PR
- [ ] Download the `extension.zip` artifact from the run, confirm it unzips directly to `manifest.json` + bundle (no nested zip)
- [ ] Spot-check the unzipped folder loads in Chrome via "Load unpacked"

🤖 Generated with [Claude Code](https://claude.com/claude-code)