### PR TITLE
docs: add Hermes Agent integration page

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -21,6 +21,7 @@ export default defineConfig({
         { label: "Install", slug: "install" },
         { label: "Use with Browserbase (Python)", slug: "browserbase-python" },
         { label: "Use with OpenClaw", slug: "openclaw" },
+        { label: "Use with Hermes Agent", slug: "hermes-agent" },
       ],
     }),
   ],

--- a/docs/src/content/docs/hermes-agent.md
+++ b/docs/src/content/docs/hermes-agent.md
@@ -4,26 +4,25 @@ description: Run agent-browser-shield alongside Nous Research's Hermes Agent by 
 ---
 
 [Hermes Agent](https://github.com/NousResearch/hermes-agent) drives a browser
-either through a cloud provider (Browserbase, Browser Use, Firecrawl) or a
-local Chromium it controls via CDP. None of those default paths load an
-unpacked Chromium extension, so `agent-browser-shield` has to ride along on a
-browser that Hermes *attaches* to.
+either through a cloud provider (Browserbase, Browser Use, Firecrawl) or a local
+Chromium it controls via CDP. None of those default paths load an unpacked
+Chromium extension, so `agent-browser-shield` has to ride along on a browser
+that Hermes *attaches* to.
 
 ## Local Chromium via `/browser connect`
 
 ### 1. Install the extension
 
 Follow [Install](/agent-browser-shield/install/) through `bun run build`. You
-will load `extension/dist/` into the Chromium profile that Hermes attaches to
-in step 3 — not your default Chrome profile.
+will load `extension/dist/` into the Chromium profile that Hermes attaches to in
+step 3 — not your default Chrome profile.
 
 ### 2. Launch Chrome with remote debugging on a dedicated user-data-dir
 
 Hermes' `/browser connect` attaches over CDP at `localhost:9222`. The
-`--user-data-dir` flag is **not optional**: launching a Chromium-family
-browser while a regular instance is already running will reuse that running
-process, which was not started with `--remote-debugging-port`, so port 9222
-never opens.
+`--user-data-dir` flag is **not optional**: launching a Chromium-family browser
+while a regular instance is already running will reuse that running process,
+which was not started with `--remote-debugging-port`, so port 9222 never opens.
 
 macOS:
 
@@ -45,10 +44,9 @@ brave-browser \
   --no-default-browser-check &
 ```
 
-Because this is a fresh user-data-dir, load the extension into *this*
-profile: open `chrome://extensions`, enable **Developer mode**, click **Load
-unpacked**, and select `extension/dist/`. Pin the shield icon so you can
-confirm it's live.
+Because this is a fresh user-data-dir, load the extension into *this* profile:
+open `chrome://extensions`, enable **Developer mode**, click **Load unpacked**,
+and select `extension/dist/`. Pin the shield icon so you can confirm it's live.
 
 ### 3. Attach from the Hermes CLI
 
@@ -70,16 +68,16 @@ Then, at the interactive prompt:
 
 - **Hybrid routing can intercept public URLs.** If `~/.hermes/.env` has cloud
   credentials set (e.g., `BROWSERBASE_API_KEY`), Hermes' default routing
-  (`browser.auto_local_for_private_urls: true`) sends only private/LAN URLs
-  to the local browser — public URLs go to the cloud provider, which is
-  *not* the browser you installed the shield into. For a pure local-attach
-  run, leave cloud credentials out of `~/.hermes/.env`.
+  (`browser.auto_local_for_private_urls: true`) sends only private/LAN URLs to
+  the local browser — public URLs go to the cloud provider, which is *not* the
+  browser you installed the shield into. For a pure local-attach run, leave
+  cloud credentials out of `~/.hermes/.env`.
 - **Your cookies are in scope.** Anything the agent navigates to is acting as
   whoever's logged into the dedicated profile. Treat it like any other
   session-bearing browser.
 - **Extension reloads need a tab refresh.** After `bun run watch` rebuilds,
-  click the reload icon at `chrome://extensions` and refresh the agent's
-  tabs — Hermes won't do it for you.
+  click the reload icon at `chrome://extensions` and refresh the agent's tabs —
+  Hermes won't do it for you.
 
 ## Headless / cloud runs
 
@@ -88,9 +86,8 @@ For runs that can't keep a local browser open, see
 for the package / upload / create-session flow that produces a Browserbase
 `connectUrl` with the extension already attached. Hermes documents
 `/browser connect` only with a `ws://host:port` form; whether its connector
-accepts the `wss://…?apiKey=…&sessionId=…` URL Browserbase returns hasn't
-been verified here, so this page doesn't prescribe a remote-attach recipe
-yet.
+accepts the `wss://…?apiKey=…&sessionId=…` URL Browserbase returns hasn't been
+verified here, so this page doesn't prescribe a remote-attach recipe yet.
 
 ## Verify
 
@@ -99,8 +96,7 @@ On the first non-trivial page load, look for:
 - A circular shield-icon badge in the bottom-right corner (a11y name *"Open
   Agent Browser Shield options"*).
 - `[data-abs-rule="<rule-id>"]` attributes in the DOM.
-- Inline `[PII masked]` / `[secret masked]` chips on pages with sensitive
-  data.
+- Inline `[PII masked]` / `[secret masked]` chips on pages with sensitive data.
 
 If none of those markers appear, the extension is not attached. Confirm the
 shield is loaded in the Chrome instance running against
@@ -110,9 +106,9 @@ endpoint.
 
 ## Why not Hermes' default browser providers?
 
-Hermes' first-party browser providers — Browserbase via its own session
-manager, Browser Use, Firecrawl, and the Camofox local fallback — all
-create browsers that Hermes provisions itself, and none of them expose a
-hook for loading an unpacked Chromium extension. The path above works
-around that by handing Hermes a browser whose extension was loaded at
-launch and letting Hermes attach instead of provision.
+Hermes' first-party browser providers — Browserbase via its own session manager,
+Browser Use, Firecrawl, and the Camofox local fallback — all create browsers
+that Hermes provisions itself, and none of them expose a hook for loading an
+unpacked Chromium extension. The path above works around that by handing Hermes
+a browser whose extension was loaded at launch and letting Hermes attach instead
+of provision.

--- a/docs/src/content/docs/hermes-agent.md
+++ b/docs/src/content/docs/hermes-agent.md
@@ -1,0 +1,118 @@
+---
+title: Use with Hermes Agent
+description: Run agent-browser-shield alongside Nous Research's Hermes Agent by attaching Hermes to a local Chromium that has the extension installed.
+---
+
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) drives a browser
+either through a cloud provider (Browserbase, Browser Use, Firecrawl) or a
+local Chromium it controls via CDP. None of those default paths load an
+unpacked Chromium extension, so `agent-browser-shield` has to ride along on a
+browser that Hermes *attaches* to.
+
+## Local Chromium via `/browser connect`
+
+### 1. Install the extension
+
+Follow [Install](/agent-browser-shield/install/) through `bun run build`. You
+will load `extension/dist/` into the Chromium profile that Hermes attaches to
+in step 3 — not your default Chrome profile.
+
+### 2. Launch Chrome with remote debugging on a dedicated user-data-dir
+
+Hermes' `/browser connect` attaches over CDP at `localhost:9222`. The
+`--user-data-dir` flag is **not optional**: launching a Chromium-family
+browser while a regular instance is already running will reuse that running
+process, which was not started with `--remote-debugging-port`, so port 9222
+never opens.
+
+macOS:
+
+```sh
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.hermes/chrome-debug" \
+  --no-first-run \
+  --no-default-browser-check &
+```
+
+Linux (Brave shown — same flags for Chrome / Chromium / Edge):
+
+```sh
+brave-browser \
+  --remote-debugging-port=9222 \
+  --user-data-dir=$HOME/.hermes/chrome-debug \
+  --no-first-run \
+  --no-default-browser-check &
+```
+
+Because this is a fresh user-data-dir, load the extension into *this*
+profile: open `chrome://extensions`, enable **Developer mode**, click **Load
+unpacked**, and select `extension/dist/`. Pin the shield icon so you can
+confirm it's live.
+
+### 3. Attach from the Hermes CLI
+
+```sh
+hermes
+```
+
+Then, at the interactive prompt:
+
+```text
+/browser connect
+/browser status
+```
+
+`/browser status` should report a connection to `localhost:9222`. Skip to
+[Verify](#verify) to confirm the shield woke up on the first page load.
+
+### Caveats for the local-attach path
+
+- **Hybrid routing can intercept public URLs.** If `~/.hermes/.env` has cloud
+  credentials set (e.g., `BROWSERBASE_API_KEY`), Hermes' default routing
+  (`browser.auto_local_for_private_urls: true`) sends only private/LAN URLs
+  to the local browser — public URLs go to the cloud provider, which is
+  *not* the browser you installed the shield into. For a pure local-attach
+  run, leave cloud credentials out of `~/.hermes/.env`.
+- **Your cookies are in scope.** Anything the agent navigates to is acting as
+  whoever's logged into the dedicated profile. Treat it like any other
+  session-bearing browser.
+- **Extension reloads need a tab refresh.** After `bun run watch` rebuilds,
+  click the reload icon at `chrome://extensions` and refresh the agent's
+  tabs — Hermes won't do it for you.
+
+## Headless / cloud runs
+
+For runs that can't keep a local browser open, see
+[Use with OpenClaw → Using a Browserbase remote CDP session](/agent-browser-shield/openclaw/#using-a-browserbase-remote-cdp-session)
+for the package / upload / create-session flow that produces a Browserbase
+`connectUrl` with the extension already attached. Hermes documents
+`/browser connect` only with a `ws://host:port` form; whether its connector
+accepts the `wss://…?apiKey=…&sessionId=…` URL Browserbase returns hasn't
+been verified here, so this page doesn't prescribe a remote-attach recipe
+yet.
+
+## Verify
+
+On the first non-trivial page load, look for:
+
+- A circular shield-icon badge in the bottom-right corner (a11y name *"Open
+  Agent Browser Shield options"*).
+- `[data-abs-rule="<rule-id>"]` attributes in the DOM.
+- Inline `[PII masked]` / `[secret masked]` chips on pages with sensitive
+  data.
+
+If none of those markers appear, the extension is not attached. Confirm the
+shield is loaded in the Chrome instance running against
+`$HOME/.hermes/chrome-debug` (or whatever user-data-dir you used), not your
+default profile. `/browser status` from the Hermes CLI confirms the CDP
+endpoint.
+
+## Why not Hermes' default browser providers?
+
+Hermes' first-party browser providers — Browserbase via its own session
+manager, Browser Use, Firecrawl, and the Camofox local fallback — all
+create browsers that Hermes provisions itself, and none of them expose a
+hook for loading an unpacked Chromium extension. The path above works
+around that by handing Hermes a browser whose extension was loaded at
+launch and letting Hermes attach instead of provision.


### PR DESCRIPTION
## Summary
- Adds `docs/src/content/docs/hermes-agent.md` covering how to run `agent-browser-shield` alongside Nous Research's [Hermes Agent](https://github.com/NousResearch/hermes-agent).
- Documents the local-attach path: launch Chrome with `--remote-debugging-port=9222 --user-data-dir=$HOME/.hermes/chrome-debug`, load `extension/dist/` into that profile, then `/browser connect` from the Hermes CLI.
- Defers the Browserbase remote-attach recipe to a short "see also" pointer at the existing OpenClaw page — Hermes documents `/browser connect ws://host:port` only, and its compatibility with the `wss://…?apiKey=…&sessionId=…` URL Browserbase returns hasn't been verified.
- Registers the page in the Starlight sidebar after the OpenClaw entry.

## Test plan
- [x] `bun run build` in `docs/` succeeds and emits `/hermes-agent/index.html`.
- [ ] Visual check of the rendered page (sidebar entry, internal link to OpenClaw section, code blocks render).
- [ ] Smoke-test the documented local-attach flow against a real Hermes install before promoting the Browserbase pointer to a full recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)