### PR TITLE
ci: publish extension ZIP to S3 on release

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,0 +1,72 @@
+name: Release extension
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and upload extension ZIP
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.x
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Verify tag matches manifest.json version
+        working-directory: extension
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          MANIFEST_VERSION=$(jq -r .version src/manifest.json)
+          if [ "${TAG#v}" != "$MANIFEST_VERSION" ]; then
+            echo "::error::Release tag $TAG does not match extension/src/manifest.json version $MANIFEST_VERSION"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        working-directory: extension
+        run: bun install --frozen-lockfile
+      - name: Build
+        working-directory: extension
+        run: bun run build
+      - name: Package extension zip
+        working-directory: extension
+        run: bun run package
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Upload versioned ZIP
+        run: |
+          aws s3 cp output/extension.zip \
+            s3://agent-browser-shield/${{ github.event.release.tag_name }}/extension.zip \
+            --content-type application/zip \
+            --content-disposition 'attachment; filename="extension.zip"' \
+            --cache-control 'public, max-age=31536000, immutable'
+
+      - name: Upload latest pointer
+        run: |
+          aws s3 cp output/extension.zip \
+            s3://agent-browser-shield/latest/extension.zip \
+            --content-type application/zip \
+            --content-disposition 'attachment; filename="extension.zip"' \
+            --cache-control 'public, max-age=300'
+
+      - name: Attach ZIP to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: output/extension.zip


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-extension.yml` to publish the built extension ZIP to the public `agent-browser-shield` S3 bucket whenever a GitHub Release is published, giving users a stable login-free download URL.
- Uploads to both `s3://agent-browser-shield/<tag>/extension.zip` (immutable, `max-age=31536000`) and `s3://agent-browser-shield/latest/extension.zip` (short-cache pointer for docs/SKILL.md to link to).
- Verifies the release tag matches `extension/src/manifest.json` version before building, so a tag mismatch fails fast instead of shipping a ZIP that installs as the wrong version in Chrome.
- Also attaches the ZIP to the GitHub Release itself via `softprops/action-gh-release`.
- Authenticates to AWS via OIDC (no long-lived credentials in GitHub), matching the OIDC pattern `docs-deploy.yml` already uses for Pages.

## Required setup before merging / first run

### 1. GitHub OIDC provider in AWS

If `IAM → Identity providers` doesn't already list one for GitHub:
- Provider URL: `https://token.actions.githubusercontent.com`
- Audience: `sts.amazonaws.com`

### 2. IAM role `gha-agent-browser-shield-release`

**Trust policy** (replace `<ACCOUNT_ID>` with your AWS account id):

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
      },
      "Action": "sts:AssumeRoleWithWebIdentity",
      "Condition": {
        "StringEquals": {
          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
        },
        "StringLike": {
          "token.actions.githubusercontent.com:sub": "repo:pixiebrix/agent-browser-shield:*"
        }
      }
    }
  ]
}
```

**Permission policy** (write-only, scoped to this one bucket):

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": ["s3:PutObject"],
      "Resource": "arn:aws:s3:::agent-browser-shield/*"
    }
  ]
}
```

If the bucket relies on per-object ACLs instead of a public-read bucket policy, also add `s3:PutObjectAcl` here and append `--acl public-read` to the `aws s3 cp` steps in the workflow — but bucket-policy public read is the modern AWS-recommended pattern.

### 3. Bucket policy on `agent-browser-shield`

Grants anonymous read so the public URL works without authentication:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "PublicReadGetObject",
      "Effect": "Allow",
      "Principal": "*",
      "Action": "s3:GetObject",
      "Resource": "arn:aws:s3:::agent-browser-shield/*"
    }
  ]
}
```

The bucket also needs `Block Public Access → Block public access via new public bucket or access point policies` set to **off** before this policy will attach.

### 4. GitHub Actions Variables

`Settings → Secrets and variables → Actions → Variables` (not Secrets — role ARNs and region names aren't sensitive):
- `AWS_ROLE_TO_ASSUME` = `arn:aws:iam::<ACCOUNT_ID>:role/gha-agent-browser-shield-release`
- `AWS_REGION` = bucket region (e.g., `us-east-1`)

## Test plan
- [ ] Confirm IAM role + bucket policy + GitHub variables are in place.
- [ ] Cut a smoke-test release `v0.0.0-test` (matching a temporary manifest bump) and watch the workflow run green at `Actions → Release extension`.
- [ ] `curl -I https://agent-browser-shield.s3.<region>.amazonaws.com/v0.0.0-test/extension.zip` returns 200 with `Content-Type: application/zip`, `Content-Disposition: attachment; filename="extension.zip"`, `Cache-Control: public, max-age=31536000, immutable`.
- [ ] Same for `latest/extension.zip`, with `max-age=300`.
- [ ] Anonymous (logged-out) browser can download `latest/extension.zip` and Chrome loads the unpacked contents.
- [ ] Push a release whose tag doesn't match `manifest.json` — workflow fails at the verification step before uploading.
- [ ] Delete the smoke-test release / tag / S3 objects once verified.

## Follow-ups (separate PRs)
- Update `skills/agent-browser-shield-install/SKILL.md` to point at `https://agent-browser-shield.s3.<region>.amazonaws.com/latest/extension.zip` (currently references the older `agent-guard-extension-dev` bucket).
- Sync `extension/package.json` (`0.1.0-alpha.1`) with `extension/src/manifest.json` (`0.1.0`) and add a CONTRIBUTING note about bumping both before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)