### PR TITLE
ci: workflow-driven CalVer release for the extension

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,20 +1,19 @@
 name: Release extension
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: write
   id-token: write
 
 concurrency:
-  group: release-${{ github.event.release.tag_name }}
+  group: release-extension
   cancel-in-progress: false
 
 jobs:
   publish:
-    name: Build and upload extension ZIP
+    name: Build and publish extension release
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -25,15 +24,32 @@ jobs:
         with:
           node-version: 24
 
-      - name: Verify tag matches manifest.json version
-        working-directory: extension
+      - name: Compute version
+        id: version
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
-          MANIFEST_VERSION=$(jq -r .version src/manifest.json)
-          if [ "${TAG#v}" != "$MANIFEST_VERSION" ]; then
-            echo "::error::Release tag $TAG does not match extension/src/manifest.json version $MANIFEST_VERSION"
-            exit 1
-          fi
+          # CalVer + GitHub Actions run_number. Chrome accepts up to 4 integer
+          # segments and compares them numerically, so a monotonically
+          # increasing run_number guarantees every release looks "newer" to
+          # Chrome's auto-update — even multiple releases on the same day.
+          version="$(date -u +%Y.%-m.%-d).${RUN_NUMBER}"
+          tag="v${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Releasing ${tag} (manifest version ${version})"
+
+      - name: Patch manifest version
+        working-directory: extension
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # CI is the source of truth for shipped versions; the version field
+          # in src/manifest.json is a dev placeholder for unpacked loads.
+          tmp=$(mktemp)
+          jq --arg v "$VERSION" '.version = $v' src/manifest.json > "$tmp"
+          mv "$tmp" src/manifest.json
+          jq '{version, name}' src/manifest.json
 
       - name: Install dependencies
         working-directory: extension
@@ -51,9 +67,11 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Upload versioned ZIP
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           aws s3 cp output/extension.zip \
-            s3://agent-browser-shield/${{ github.event.release.tag_name }}/extension.zip \
+            "s3://agent-browser-shield/${TAG}/extension.zip" \
             --content-type application/zip \
             --content-disposition 'attachment; filename="extension.zip"' \
             --cache-control 'public, max-age=31536000, immutable'
@@ -66,7 +84,13 @@ jobs:
             --content-disposition 'attachment; filename="extension.zip"' \
             --cache-control 'public, max-age=300'
 
-      - name: Attach ZIP to GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: output/extension.zip
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          gh release create "$TAG" \
+            output/extension.zip \
+            --title "$TAG" \
+            --generate-notes \
+            --target "$GITHUB_SHA"

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Cut a release of the agent-browser-shield extension.
+#
+# Triggers .github/workflows/release-extension.yml on main. The workflow
+# computes the version (YYYY.M.D.<run_number>), patches the manifest, builds,
+# uploads to S3, and creates the GitHub Release.
+#
+# Usage:
+#   scripts/cut-release.sh           # dispatch and print the run URL
+#   scripts/cut-release.sh --watch   # also tail the run until it finishes
+
+set -euo pipefail
+
+WATCH=0
+for arg in "$@"; do
+  case "$arg" in
+    --watch) WATCH=1 ;;
+    -h|--help)
+      sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 2 ;;
+  esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found. Install from https://cli.github.com/." >&2
+  exit 1
+fi
+
+gh auth status >/dev/null
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" != "main" ]; then
+  echo "Not on main (on $branch). Releases must be cut from main." >&2
+  exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Working tree is dirty. Commit, stash, or revert before releasing." >&2
+  exit 1
+fi
+
+git fetch origin main --quiet
+local_sha=$(git rev-parse HEAD)
+remote_sha=$(git rev-parse origin/main)
+if [ "$local_sha" != "$remote_sha" ]; then
+  echo "Local main ($local_sha) differs from origin/main ($remote_sha)." >&2
+  echo "Pull or push so they match before releasing." >&2
+  exit 1
+fi
+
+repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+
+# Capture the most-recent run id before dispatch so we can identify the new one.
+before=$(gh run list \
+  --workflow=release-extension.yml \
+  --limit=1 \
+  --json databaseId \
+  --jq '.[0].databaseId // 0')
+
+gh workflow run release-extension.yml --ref main
+echo "Dispatched release-extension.yml on main."
+
+# Wait for the new run to appear (workflow_dispatch can take a few seconds to
+# register the run).
+run_id=""
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  sleep 2
+  candidate=$(gh run list \
+    --workflow=release-extension.yml \
+    --limit=1 \
+    --json databaseId \
+    --jq '.[0].databaseId // 0')
+  if [ "$candidate" != "$before" ] && [ "$candidate" != "0" ]; then
+    run_id="$candidate"
+    break
+  fi
+done
+
+if [ -z "$run_id" ]; then
+  echo "Workflow dispatched, but couldn't locate the new run within 20s." >&2
+  echo "Check https://github.com/${repo}/actions/workflows/release-extension.yml" >&2
+  exit 0
+fi
+
+echo "Run: https://github.com/${repo}/actions/runs/${run_id}"
+
+if [ "$WATCH" -eq 1 ]; then
+  gh run watch "$run_id" --exit-status
+  echo
+  echo "Latest release:"
+  gh release view --json tagName,url --jq '"  " + .tagName + "  " + .url'
+fi

--- a/skills/agent-browser-shield-release/SKILL.md
+++ b/skills/agent-browser-shield-release/SKILL.md
@@ -5,29 +5,29 @@ description: Cut a release of the agent-browser-shield Chromium extension. CalVe
 
 # Releasing agent-browser-shield
 
-Releases are produced by `.github/workflows/release-extension.yml`. The
-workflow computes the version, builds the extension, creates the GitHub
-Release with the ZIP attached, and uploads the ZIP to S3 (both a versioned
-path and the `latest/` pointer that the install skill points consumers at).
+Releases are produced by `.github/workflows/release-extension.yml`. The workflow
+computes the version, builds the extension, creates the GitHub Release with the
+ZIP attached, and uploads the ZIP to S3 (both a versioned path and the `latest/`
+pointer that the install skill points consumers at).
 
 Nothing is tagged or version-bumped in the source tree. The tag, the manifest
-`version` field in the shipped ZIP, and the GitHub Release are all created by
-CI at the moment of release.
+`version` field in the shipped ZIP, and the GitHub Release are all created by CI
+at the moment of release.
 
 ## Version format
 
 `YYYY.M.D.<github.run_number>` — e.g. `2026.5.30.42`. Tag is `v2026.5.30.42`.
 
-- Chrome compares `manifest.version` numerically segment-by-segment, so a
-  larger `run_number` is always "newer" — multiple releases on the same day
-  still trigger auto-update correctly.
+- Chrome compares `manifest.version` numerically segment-by-segment, so a larger
+  `run_number` is always "newer" — multiple releases on the same day still
+  trigger auto-update correctly.
 - `github.run_number` is monotonic per-repo across all workflows and never
   resets, so the version is guaranteed to increase even across calendar-edge
   cases.
 - The `version` in `extension/src/manifest.json` (currently `0.1.0`) is a dev
-  placeholder used when devs sideload `extension/dist/` unpacked. CI
-  overwrites it during the release build — **do not** bump it manually as
-  part of cutting a release.
+  placeholder used when devs sideload `extension/dist/` unpacked. CI overwrites
+  it during the release build — **do not** bump it manually as part of cutting a
+  release.
 
 ## Cutting a release
 
@@ -65,8 +65,8 @@ gh workflow run release-extension.yml --ref main
 4. Uploads to:
    - `s3://agent-browser-shield/${tag}/extension.zip` (immutable, cached 1y)
    - `s3://agent-browser-shield/latest/extension.zip` (5-minute cache)
-5. Creates the GitHub Release at `$GITHUB_SHA` with auto-generated notes and
-   the ZIP attached.
+5. Creates the GitHub Release at `$GITHUB_SHA` with auto-generated notes and the
+   ZIP attached.
 
 ## Rolling back / re-releasing
 
@@ -81,18 +81,18 @@ The new release will have a higher `run_number` than anything before it, so
 Chrome will auto-update to it. The previous "bad" S3 versioned URL is left in
 place (immutable); only `latest/` moves.
 
-The script `scripts/cut-release.sh` refuses to run off `main`. To release from
-a SHA or branch, invoke `gh workflow run` directly — be sure you know what
-you're shipping.
+The script `scripts/cut-release.sh` refuses to run off `main`. To release from a
+SHA or branch, invoke `gh workflow run` directly — be sure you know what you're
+shipping.
 
 ## When NOT to use this skill
 
-- Editing rule code, selectors, or `extension/data/sites/*.yaml` → just edit
-  and merge. CI ships them on the next release.
+- Editing rule code, selectors, or `extension/data/sites/*.yaml` → just edit and
+  merge. CI ships them on the next release.
 - Local-only testing → `cd extension && bun run build`, then load
   `extension/dist/` unpacked in `chrome://extensions`. No release needed.
 - Bumping the source `manifest.json` version → unnecessary, CI overrides it.
 - Changes to the release workflow itself → edit
-  `.github/workflows/release-extension.yml`. Note that dispatching it (even on
-  a branch) **does create a real release** — there is no dry-run mode. Test
+  `.github/workflows/release-extension.yml`. Note that dispatching it (even on a
+  branch) **does create a real release** — there is no dry-run mode. Test
   changes by reading the YAML carefully, not by running it.

--- a/skills/agent-browser-shield-release/SKILL.md
+++ b/skills/agent-browser-shield-release/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: agent-browser-shield-release
+description: Cut a release of the agent-browser-shield Chromium extension. CalVer YYYY.M.D.<github.run_number> versioning, workflow-driven — .github/workflows/release-extension.yml computes the version, patches the manifest, builds the ZIP, creates the GitHub Release, and uploads to S3. Use when the user asks to ship, release, publish, or push a new build of the extension. NOT for editing rule code, running benchmarks, or local-only testing.
+---
+
+# Releasing agent-browser-shield
+
+Releases are produced by `.github/workflows/release-extension.yml`. The
+workflow computes the version, builds the extension, creates the GitHub
+Release with the ZIP attached, and uploads the ZIP to S3 (both a versioned
+path and the `latest/` pointer that the install skill points consumers at).
+
+Nothing is tagged or version-bumped in the source tree. The tag, the manifest
+`version` field in the shipped ZIP, and the GitHub Release are all created by
+CI at the moment of release.
+
+## Version format
+
+`YYYY.M.D.<github.run_number>` — e.g. `2026.5.30.42`. Tag is `v2026.5.30.42`.
+
+- Chrome compares `manifest.version` numerically segment-by-segment, so a
+  larger `run_number` is always "newer" — multiple releases on the same day
+  still trigger auto-update correctly.
+- `github.run_number` is monotonic per-repo across all workflows and never
+  resets, so the version is guaranteed to increase even across calendar-edge
+  cases.
+- The `version` in `extension/src/manifest.json` (currently `0.1.0`) is a dev
+  placeholder used when devs sideload `extension/dist/` unpacked. CI
+  overwrites it during the release build — **do not** bump it manually as
+  part of cutting a release.
+
+## Cutting a release
+
+Preconditions:
+
+- On `main`, working tree clean, in sync with `origin/main`.
+- `gh` CLI installed and authenticated (`gh auth status`).
+- Every change you want shipped is already merged to `main`.
+
+Run:
+
+```sh
+scripts/cut-release.sh           # dispatch and print the run URL
+scripts/cut-release.sh --watch   # also block until the workflow finishes
+```
+
+The script preflight-checks branch/cleanliness/sync, dispatches the workflow,
+finds the new run id, and prints the Actions URL. With `--watch` it tails the
+run and prints the resulting release URL at the end.
+
+Direct equivalent:
+
+```sh
+gh workflow run release-extension.yml --ref main
+```
+
+## What the workflow does
+
+1. Computes `version = $(date -u +%Y.%-m.%-d).${{ github.run_number }}` and
+   `tag = v${version}`.
+2. `jq`-patches `extension/src/manifest.json` `version` in the runner's
+   checkout. Never committed back.
+3. `bun install --frozen-lockfile`, `bun run build`, `bun run package` →
+   `output/extension.zip`.
+4. Uploads to:
+   - `s3://agent-browser-shield/${tag}/extension.zip` (immutable, cached 1y)
+   - `s3://agent-browser-shield/latest/extension.zip` (5-minute cache)
+5. Creates the GitHub Release at `$GITHUB_SHA` with auto-generated notes and
+   the ZIP attached.
+
+## Rolling back / re-releasing
+
+There is no "rollback" — every release gets a new version. To ship an older
+commit, re-trigger the workflow on that SHA:
+
+```sh
+gh workflow run release-extension.yml --ref <sha-or-branch>
+```
+
+The new release will have a higher `run_number` than anything before it, so
+Chrome will auto-update to it. The previous "bad" S3 versioned URL is left in
+place (immutable); only `latest/` moves.
+
+The script `scripts/cut-release.sh` refuses to run off `main`. To release from
+a SHA or branch, invoke `gh workflow run` directly — be sure you know what
+you're shipping.
+
+## When NOT to use this skill
+
+- Editing rule code, selectors, or `extension/data/sites/*.yaml` → just edit
+  and merge. CI ships them on the next release.
+- Local-only testing → `cd extension && bun run build`, then load
+  `extension/dist/` unpacked in `chrome://extensions`. No release needed.
+- Bumping the source `manifest.json` version → unnecessary, CI overrides it.
+- Changes to the release workflow itself → edit
+  `.github/workflows/release-extension.yml`. Note that dispatching it (even on
+  a branch) **does create a real release** — there is no dry-run mode. Test
+  changes by reading the YAML carefully, not by running it.


### PR DESCRIPTION
## Summary

- Switches `.github/workflows/release-extension.yml` from `release: published` (build-on-tag) to `workflow_dispatch` (workflow creates the release). CI computes `version = YYYY.M.D.${{ github.run_number }}`, `jq`-patches `extension/src/manifest.json` in the runner, builds, uploads to S3, and calls `gh release create` itself.
- The source `extension/src/manifest.json` `version` (`0.1.0`) is now a permanent dev placeholder for unpacked loads — CI overwrites it. No manual version bump is needed to cut a release.
- Adds `scripts/cut-release.sh` for dispatching the workflow from a clean `main` (preflights gh auth, branch, dirty tree, sync with origin; `--watch` tails the run).
- Adds `skills/agent-browser-shield-release/SKILL.md` covering the version format, the cut-release flow, and rollback (re-dispatch on an older SHA).

### Why CalVer + run_number

- Chrome compares `manifest.version` numerically segment-by-segment with a 4-segment max. `2026.6.1 > 2026.5.31` and `2026.5.30.43 > 2026.5.30.42` both hold.
- `github.run_number` is monotonic per-repo and never resets, so every release is guaranteed to look newer than the previous one — including multiple same-day releases.
- Run numbers are only knowable at workflow time, which is why the workflow has to create the release rather than react to a hand-cut tag.

## Test plan

- [ ] Merge, then run `scripts/cut-release.sh --watch` from a clean `main` and confirm the workflow:
  - [ ] Computes a version of the form `YYYY.M.D.<run_number>` and the matching `v…` tag.
  - [ ] Patches `extension/src/manifest.json` (visible in the "Patch manifest version" step log via the trailing `jq '{version, name}'`).
  - [ ] Uploads ZIPs to `s3://agent-browser-shield/${tag}/extension.zip` and `s3://agent-browser-shield/latest/extension.zip`.
  - [ ] Creates a GitHub Release at the workflow's `GITHUB_SHA` with the ZIP attached and auto-generated notes.
- [ ] Unzip the published artifact and confirm `manifest.json` `version` matches the tag (minus the `v` prefix).
- [ ] Load the unzipped extension in Chrome at `chrome://extensions` and confirm the displayed version matches.
- [ ] Re-run `scripts/cut-release.sh` immediately and confirm the second release gets a higher `run_number` segment, and Chrome treats it as an update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)