### PR TITLE
ci: read AWS config from secrets in release workflow

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -63,8 +63,8 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Upload versioned ZIP
         env:


### PR DESCRIPTION
## Summary
- Switch `release-extension.yml` to read `AWS_ROLE_TO_ASSUME` and `AWS_REGION` from `secrets.*` instead of `vars.*` — both values are configured as repository secrets, so the `vars.*` references resolved to empty strings.
- Unblocks the release workflow, which failed at `aws-actions/configure-aws-credentials` with `Input required and not supplied: aws-region` (see run [26689824563](https://github.com/pixiebrix/agent-browser-shield/actions/runs/26689824563)).

## Test plan
- [ ] Re-run `Release extension` workflow on `main` after merge and confirm the `configure-aws-credentials` step succeeds and the ZIP lands in S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)