### PR TITLE
docs: point install instructions at hosted prebuilt extension ZIP

### DIFF
--- a/docs/src/content/docs/browserbase-python.md
+++ b/docs/src/content/docs/browserbase-python.md
@@ -45,8 +45,10 @@ attach Playwright to the same `connect_url` for surgical interventions.
 
 ## Prerequisites
 
-- A packaged extension zip — follow [Install](/agent-browser-shield/install/)
-  through `bun run package` to produce `output/extension.zip`.
+- A packaged extension zip — download the
+  [prebuilt ZIP](/agent-browser-shield/install/#download-a-prebuilt-zip), or
+  follow [Install](/agent-browser-shield/install/) through `bun run package` to
+  produce `output/extension.zip` from source.
 - `BROWSERBASE_API_KEY` and `BROWSERBASE_PROJECT_ID` from *Settings → API Keys*
   at <https://www.browserbase.com>.
 - Python ≥ 3.11 with the [`browserbase`](https://pypi.org/project/browserbase/)

--- a/docs/src/content/docs/hermes-agent.md
+++ b/docs/src/content/docs/hermes-agent.md
@@ -13,9 +13,12 @@ that Hermes *attaches* to.
 
 ### 1. Install the extension
 
-Follow [Install](/agent-browser-shield/install/) through `bun run build`. You
-will load `extension/dist/` into the Chromium profile that Hermes attaches to in
-step 3 — not your default Chrome profile.
+Get the extension directory — either build from source (follow
+[Install](/agent-browser-shield/install/) through `bun run build` for
+`extension/dist/`) or download and unzip the
+[prebuilt ZIP](/agent-browser-shield/install/#download-a-prebuilt-zip). You will
+load that directory into the Chromium profile that Hermes attaches to in step 3
+— not your default Chrome profile.
 
 ### 2. Launch Chrome with remote debugging on a dedicated user-data-dir
 
@@ -46,7 +49,8 @@ brave-browser \
 
 Because this is a fresh user-data-dir, load the extension into *this* profile:
 open `chrome://extensions`, enable **Developer mode**, click **Load unpacked**,
-and select `extension/dist/`. Pin the shield icon so you can confirm it's live.
+and select the directory from step 1. Pin the shield icon so you can confirm
+it's live.
 
 ### 3. Attach from the Hermes CLI
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -18,9 +18,9 @@ https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip
 ```
 
 `manifest.json` is at the archive root, so the ZIP can be uploaded straight to
-[Browserbase](#using-it-with-browserbase), or unzipped and loaded into Chrome
-as an unpacked extension (see [Load it into Chrome](#load-it-into-chrome)). Do
-not re-zip after unpacking.
+[Browserbase](#using-it-with-browserbase), or unzipped and loaded into Chrome as
+an unpacked extension (see [Load it into Chrome](#load-it-into-chrome)). Do not
+re-zip after unpacking.
 
 Build from source instead if you're iterating on rules or want a specific
 commit.
@@ -62,7 +62,8 @@ After each rebuild, click the reload icon for the extension at
 
 ## Using it with Browserbase
 
-The [Browserbase extensions API](https://docs.browserbase.com/platform/browser/core-features/browser-extensions#browser-extensions)
+The
+[Browserbase extensions API](https://docs.browserbase.com/platform/browser/core-features/browser-extensions#browser-extensions)
 accepts the prebuilt ZIP directly — download it from
 `https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip`
 and upload as-is.

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -5,8 +5,25 @@ description: Build the agent-browser-shield extension and load it into Chromium.
 
 ## Prerequisites
 
-- **Node** ≥ 24 and **Bun** ≥ 1.3 — for the extension build.
-- **Chrome / Chromium 148+** — to load the unpacked extension.
+- **Chrome / Chromium 148+** — to load the extension.
+- **Node** ≥ 24 and **Bun** ≥ 1.3 — only needed if you're building from source.
+
+## Download a prebuilt ZIP
+
+Each release publishes the packaged extension to S3. The `latest/` pointer
+follows the most recent release:
+
+```text
+https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip
+```
+
+`manifest.json` is at the archive root, so the ZIP can be uploaded straight to
+[Browserbase](#using-it-with-browserbase), or unzipped and loaded into Chrome
+as an unpacked extension (see [Load it into Chrome](#load-it-into-chrome)). Do
+not re-zip after unpacking.
+
+Build from source instead if you're iterating on rules or want a specific
+commit.
 
 ## Build the extension
 
@@ -25,7 +42,8 @@ Build output is written to `extension/dist/`.
 
 1. Open `chrome://extensions`.
 2. Enable **Developer mode** (top right).
-3. Click **Load unpacked** and select the `extension/dist/` directory.
+3. Click **Load unpacked** and select either `extension/dist/` (built from
+   source) or the directory you unzipped the prebuilt ZIP into.
 
 The extension is now active. Reload any open tabs to pick up the content script.
 
@@ -44,8 +62,12 @@ After each rebuild, click the reload icon for the extension at
 
 ## Using it with Browserbase
 
-Package the build into a ZIP suitable for the
-[Browserbase extensions API](https://docs.browserbase.com/platform/browser/core-features/browser-extensions#browser-extensions):
+The [Browserbase extensions API](https://docs.browserbase.com/platform/browser/core-features/browser-extensions#browser-extensions)
+accepts the prebuilt ZIP directly — download it from
+`https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip`
+and upload as-is.
+
+To build the ZIP from source instead:
 
 ```sh
 cd extension

--- a/docs/src/content/docs/openclaw.md
+++ b/docs/src/content/docs/openclaw.md
@@ -24,12 +24,15 @@ attaches via CDP and inherits whatever's already loaded.
 
 ### 1. Install the extension into the profile
 
-Follow [Install](/agent-browser-shield/install/) through `bun run build`, then
-in the Chromium-based browser whose profile OpenClaw will drive:
+Get the extension directory — either build from source (follow
+[Install](/agent-browser-shield/install/) through `bun run build` for
+`extension/dist/`) or download and unzip the
+[prebuilt ZIP](/agent-browser-shield/install/#download-a-prebuilt-zip). Then, in
+the Chromium-based browser whose profile OpenClaw will drive:
 
 1. Open `chrome://extensions` (or `brave://extensions`, `edge://extensions`).
 2. Enable **Developer mode**.
-3. Click **Load unpacked** and select `extension/dist/`.
+3. Click **Load unpacked** and select that directory.
 4. Pin the shield icon so it's easy to confirm the extension is live.
 
 Use a dedicated browser profile for agent runs if you don't want OpenClaw
@@ -106,11 +109,13 @@ The flow:
    connect URL.
 4. Configure OpenClaw to use that URL as a remote CDP profile.
 
-### 1. Package the extension
+### 1. Get the extension ZIP
 
-Follow [Install](/agent-browser-shield/install/) through `bun run package`.
-You'll end up with `output/extension.zip` whose `manifest.json` sits at the
-archive root.
+Download the
+[prebuilt ZIP](/agent-browser-shield/install/#download-a-prebuilt-zip), or
+follow [Install](/agent-browser-shield/install/) through `bun run package` to
+build one yourself at `output/extension.zip`. Either way, `manifest.json` sits
+at the archive root — do not re-zip it.
 
 ### 2. Upload to Browserbase
 

--- a/skills/agent-browser-shield-install/SKILL.md
+++ b/skills/agent-browser-shield-install/SKILL.md
@@ -21,13 +21,13 @@ only covers getting the extension loaded.
 | Attaching via CDP / MCP to a Chrome the user already controls | **Path C** |
 
 The hosted ZIP is at
-`https://agent-guard-extension-dev.s3.us-east-1.amazonaws.com/extension.zip` and
-has `manifest.json` at the archive root. Do not re-zip it.
+`https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip`
+and has `manifest.json` at the archive root. Do not re-zip it.
 
 ## Path A — Local headed Chromium, unpacked load
 
 1. Download
-   `https://agent-guard-extension-dev.s3.us-east-1.amazonaws.com/extension.zip`
+   `https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip`
    and unzip to a stable directory, e.g.
    `~/.cache/agent-browser-shield/extension/`. The unzipped directory must
    contain `manifest.json` directly (no nested folder).
@@ -62,7 +62,7 @@ has `manifest.json` at the archive root. Do not re-zip it.
    ```
 
 2. **Download** the ZIP from
-   `https://agent-guard-extension-dev.s3.us-east-1.amazonaws.com/extension.zip`.
+   `https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip`.
    Do not unzip.
 
 3. **Upload** the ZIP and capture the returned `id`. Pick one of the four
@@ -131,7 +131,7 @@ attaches.
 
 1. Tell the user (once, then remember it's done):
    1. Download
-      `https://agent-guard-extension-dev.s3.us-east-1.amazonaws.com/extension.zip`
+      `https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip`
       and unzip somewhere stable.
    2. Open `chrome://extensions`, enable **Developer mode**, click **Load
       unpacked**, select the unzipped directory.


### PR DESCRIPTION
## Summary

- Updates `skills/agent-browser-shield-install/SKILL.md` to point at the new ZIP URL `https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip` (was the old `agent-guard-extension-dev` bucket).
- Adds a **Download a prebuilt ZIP** section to `docs/install.md` and references it from the OpenClaw, Browserbase Python, and Hermes Agent integration docs as an alternative to `bun run build` / `bun run package`.

## Test plan

- [x] `bun run build` in `docs/` succeeds with no broken intra-site links
- [ ] Spot-check rendered pages locally (`bun run dev`) to confirm anchor links resolve to the new install section

🤖 Generated with [Claude Code](https://claude.com/claude-code)