### PR TITLE
docs: show sidebar on homepage and drop alpha warning

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,28 +1,16 @@
 ---
 title: agent-browser-shield
 description: Browser extension prototypes for improving browser-use agent performance.
-template: splash
-hero:
-  tagline: Prototype browser extension capabilities that make browser-use agents faster, safer, and more accurate.
-  actions:
-    - text: Install
-      link: /agent-browser-shield/install/
-      icon: right-arrow
-      variant: primary
-    - text: Browse the rules
-      link: /agent-browser-shield/rules/
-      icon: open-book
-    - text: View on GitHub
-      link: https://github.com/pixiebrix/agent-browser-shield
-      icon: external
 ---
 
-import { Card, CardGrid } from "@astrojs/starlight/components";
+import { Card, CardGrid, LinkButton } from "@astrojs/starlight/components";
 
-:::caution[Alpha prototype]
-APIs, rule contracts, and trace formats may change without notice. Pin a commit
-if you need stability.
-:::
+Prototype browser extension capabilities that make browser-use agents faster,
+safer, and more accurate.
+
+<LinkButton href="/agent-browser-shield/install/" icon="right-arrow" variant="primary">Install</LinkButton>
+<LinkButton href="/agent-browser-shield/rules/" icon="open-book">Browse the rules</LinkButton>
+<LinkButton href="https://github.com/pixiebrix/agent-browser-shield" icon="external">View on GitHub</LinkButton>
 
 ## What it explores
 


### PR DESCRIPTION
## Summary
- Switch the docs index off the `splash` template so the standard left nav sidebar (Install, Rules reference, integration pages) appears on the homepage alongside the intro content.
- Replace the hero block with a tagline plus `LinkButton`s for Install / Browse the rules / View on GitHub so those actions are preserved.
- Remove the "Alpha prototype" caution callout.

## Test plan
- [ ] `bun run build` in `docs/` succeeds.
- [ ] Visit the homepage locally and confirm the left nav sidebar is visible and the action buttons still work.
- [ ] Confirm the alpha-prototype callout no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)