### PR TITLE
feat(extension): per-rule icons on reveal placeholders + display-mode option

### DIFF
--- a/extension/src/lib/__tests__/rule-engine.test.ts
+++ b/extension/src/lib/__tests__/rule-engine.test.ts
@@ -37,6 +37,12 @@ jest.mock("../storage", () => ({
   subscribe: jest.fn(() => () => undefined),
 }));
 
+jest.mock("../placeholder-display", () => ({
+  getPlaceholderDisplayMode: jest.fn(() => Promise.resolve("icon")),
+  subscribePlaceholderDisplayMode: jest.fn(() => () => undefined),
+  PLACEHOLDER_DISPLAY_MODE_DEFAULT: "icon",
+}));
+
 jest.mock("../frame", () => ({
   isTopFrame: jest.fn(),
 }));

--- a/extension/src/lib/placeholder-display.ts
+++ b/extension/src/lib/placeholder-display.ts
@@ -1,0 +1,41 @@
+// Stored separately from rule states so changing the cosmetic display mode
+// doesn't churn the rule-state listener path used by the engine and UIs.
+
+const STORAGE_KEY = "agent-browser-shield.placeholder-display-mode";
+
+export type PlaceholderDisplayMode = "icon" | "button";
+
+export const PLACEHOLDER_DISPLAY_MODE_DEFAULT: PlaceholderDisplayMode = "icon";
+
+function normalize(raw: unknown): PlaceholderDisplayMode {
+  return raw === "button" || raw === "icon"
+    ? raw
+    : PLACEHOLDER_DISPLAY_MODE_DEFAULT;
+}
+
+export async function getPlaceholderDisplayMode(): Promise<PlaceholderDisplayMode> {
+  const stored = await chrome.storage.local.get(STORAGE_KEY);
+  return normalize(stored[STORAGE_KEY]);
+}
+
+export async function setPlaceholderDisplayMode(
+  mode: PlaceholderDisplayMode,
+): Promise<void> {
+  await chrome.storage.local.set({ [STORAGE_KEY]: mode });
+}
+
+export function subscribePlaceholderDisplayMode(
+  listener: (mode: PlaceholderDisplayMode) => void,
+): () => void {
+  const handler = (
+    changes: Record<string, chrome.storage.StorageChange>,
+    areaName: string,
+  ) => {
+    if (areaName !== "local") return;
+    const change = changes[STORAGE_KEY];
+    if (!change) return;
+    listener(normalize(change.newValue));
+  };
+  chrome.storage.onChanged.addListener(handler);
+  return () => chrome.storage.onChanged.removeListener(handler);
+}

--- a/extension/src/lib/placeholder.ts
+++ b/extension/src/lib/placeholder.ts
@@ -3,6 +3,8 @@ import type { RuleId } from "./storage";
 
 export const PLACEHOLDER_CLASS = "abs-placeholder";
 export const LABEL_CLASS = "abs-placeholder__label";
+export const LABEL_TEXT_CLASS = "abs-placeholder__text";
+export const LABEL_ICON_CLASS = "abs-placeholder__icon";
 export const RULE_ATTR = "data-abs-rule";
 // Stamped onto the original element after the user clicks to reveal, so a
 // rule's subtree watcher doesn't immediately re-hide it on the next scan.
@@ -61,13 +63,63 @@ function attachReveal(container: HTMLElement, original: Node): void {
   container.addEventListener("click", reveal);
 }
 
-function createRevealButton(label: string): HTMLButtonElement {
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+// 24×24 viewBox SVG paths, stroke-style (no fill) so they read well at 14px.
+// Each path stands alone — multi-path icons would need to render multiple
+// children, and the visual differentiation we want is fine with a single
+// expressive silhouette per rule. Default shield is used when no rule-specific
+// icon is registered.
+const SHIELD_PATH = "M12 21a9 9 0 0 1-9-9V5l9-3 9 3v7a9 9 0 0 1-9 9z";
+
+const RULE_ICON_PATHS: Partial<Record<RuleId, string>> = {
+  "reviews-hide":
+    "M12 2.5l2.6 6.3 6.8.5-5.2 4.4 1.7 6.6L12 16.9l-5.9 3.4 1.7-6.6L2.6 9.3l6.8-.5L12 2.5z",
+  "comments-hide":
+    "M3 6a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v9a3 3 0 0 1-3 3h-5l-5 4v-4H6a3 3 0 0 1-3-3V6z",
+  "prompt-injection-hide": "M12 3l10 18H2L12 3zM12 10v5M12 17.5v.01",
+  "countdown-timer-hide": "M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18zM12 7v5l3 3",
+  "scarcity-hide":
+    "M12 22c-4 0-7-3-7-7 0-3 2-5 3-6-1 4 2 6 2 6 1-3 3-6 3-9 4 3 6 6 6 10 0 4-3 7-7 7z",
+  "footer-hide": "M4 5h16v10H4zM4 19h16",
+  "social-embed-hide": "M5 9h14M5 15h14M10 5l-2 14M16 5l-2 14",
+  "irrelevant-sections-hide": "M3 4h18l-7 9v6l-4 2v-8L3 4z",
+};
+
+function createIcon(ruleId: RuleId): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("class", LABEL_ICON_CLASS);
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "1.75");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.setAttribute("aria-hidden", "true");
+  svg.setAttribute("focusable", "false");
+  const path = document.createElementNS(SVG_NS, "path");
+  path.setAttribute("d", RULE_ICON_PATHS[ruleId] ?? SHIELD_PATH);
+  svg.appendChild(path);
+  return svg;
+}
+
+function createRevealButton(ruleId: RuleId, label: string): HTMLButtonElement {
   const button = document.createElement("button");
   // type="button" prevents form submission when the placeholder happens to be
   // inserted inside a <form>.
   button.type = "button";
   button.className = LABEL_CLASS;
-  button.textContent = label;
+  // aria-label and title carry the descriptor in icon-only mode where the text
+  // span is hidden by CSS. In button mode the visible text repeats the label;
+  // screen readers prefer aria-label when both are present so there's no
+  // double-announcement.
+  button.setAttribute("aria-label", label);
+  button.title = label;
+  button.appendChild(createIcon(ruleId));
+  const text = document.createElement("span");
+  text.className = LABEL_TEXT_CLASS;
+  text.textContent = label;
+  button.appendChild(text);
   return button;
 }
 
@@ -87,7 +139,7 @@ export function replaceWithBlockPlaceholder(
   placeholder.className = `${PLACEHOLDER_CLASS} ${PLACEHOLDER_CLASS}--block`;
   placeholder.setAttribute(RULE_ATTR, ruleId);
 
-  placeholder.appendChild(createRevealButton(label));
+  placeholder.appendChild(createRevealButton(ruleId, label));
 
   placeholder.style.width = `${rect.width}px`;
   placeholder.style.minHeight = `${rect.height}px`;

--- a/extension/src/lib/rule-engine.ts
+++ b/extension/src/lib/rule-engine.ts
@@ -1,8 +1,22 @@
 import { RULES, type Rule } from "../rules";
 import { isTopFrame } from "./frame";
 import { log } from "./log";
-import { LABEL_CLASS, PLACEHOLDER_CLASS, revealAll } from "./placeholder";
+import {
+  LABEL_CLASS,
+  LABEL_ICON_CLASS,
+  LABEL_TEXT_CLASS,
+  PLACEHOLDER_CLASS,
+  revealAll,
+} from "./placeholder";
+import {
+  getPlaceholderDisplayMode,
+  PLACEHOLDER_DISPLAY_MODE_DEFAULT,
+  type PlaceholderDisplayMode,
+  subscribePlaceholderDisplayMode,
+} from "./placeholder-display";
 import { getRuleStates, type RuleStates, subscribe } from "./storage";
+
+const PLACEHOLDER_MODE_ATTR = "data-abs-placeholder-mode";
 
 // Inline placeholders and the inner .${LABEL_CLASS} of block placeholders are
 // <button> elements so screen readers and browser-use agents see them as
@@ -45,7 +59,9 @@ const PLACEHOLDER_STYLES = `
   -webkit-appearance: none;
   position: sticky;
   top: 8px;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   padding: 4px 8px;
   background: #fff;
   border: 1px solid #999;
@@ -53,6 +69,21 @@ const PLACEHOLDER_STYLES = `
   color: inherit;
   font: inherit;
   cursor: pointer;
+}
+.${LABEL_ICON_CLASS} {
+  width: 14px;
+  height: 14px;
+  flex: none;
+  display: inline-block;
+}
+.${LABEL_TEXT_CLASS} {
+  display: inline;
+}
+[${PLACEHOLDER_MODE_ATTR}="icon"] .${LABEL_TEXT_CLASS} {
+  display: none;
+}
+[${PLACEHOLDER_MODE_ATTR}="icon"] .${LABEL_CLASS} {
+  padding: 4px;
 }
 .${PLACEHOLDER_CLASS}:hover {
   background: #fff8c5;
@@ -137,10 +168,20 @@ function reconcile(
   }
 }
 
+function applyDisplayMode(mode: PlaceholderDisplayMode): void {
+  document.documentElement.setAttribute(PLACEHOLDER_MODE_ATTR, mode);
+}
+
 export async function start(): Promise<void> {
   const topFrame = isTopFrame();
   log("rule engine starting", { url: window.location.href, topFrame });
   injectStyles();
+  // Set the default synchronously so any placeholder created before storage
+  // resolves gets the right CSS scoping.
+  applyDisplayMode(PLACEHOLDER_DISPLAY_MODE_DEFAULT);
+  void getPlaceholderDisplayMode().then(applyDisplayMode);
+  subscribePlaceholderDisplayMode(applyDisplayMode);
+
   const initial = await getRuleStates();
   applyEnabled(initial, topFrame);
 

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -229,6 +229,49 @@
       .section.section--unavailable {
         background: #fafafa;
       }
+      .radio-group {
+        border: 0;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .radio {
+        display: flex;
+        gap: 8px;
+        align-items: flex-start;
+        cursor: pointer;
+        padding: 6px;
+        border-radius: 4px;
+      }
+      .radio:hover {
+        background: #f4f4f5;
+      }
+      .radio input {
+        margin-top: 2px;
+      }
+      .radio strong {
+        display: block;
+        font-weight: 600;
+      }
+      .radio p {
+        margin: 2px 0 0;
+        font-size: 11px;
+        color: #666;
+        line-height: 1.3;
+      }
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
       .section.section--unavailable .api-key-input,
       .section.section--unavailable button {
         opacity: 0.6;

--- a/extension/src/options/Options.tsx
+++ b/extension/src/options/Options.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 import { getUserApiKey, setUserApiKey } from "../lib/api-key-storage";
 import {
+  getPlaceholderDisplayMode,
+  type PlaceholderDisplayMode,
+  setPlaceholderDisplayMode,
+  subscribePlaceholderDisplayMode,
+} from "../lib/placeholder-display";
+import {
   getRuleStates,
   RULE_IDS,
   type RuleId,
@@ -62,6 +68,9 @@ export function Options() {
   const [status, setStatus] = useState<string | null>(null);
   const [apiKeyDraft, setApiKeyDraft] = useState("");
   const [apiKeyStatus, setApiKeyStatus] = useState<string | null>(null);
+  const [displayMode, setDisplayMode] = useState<PlaceholderDisplayMode | null>(
+    null,
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -71,12 +80,19 @@ export function Options() {
     getUserApiKey().then((key) => {
       if (!cancelled) setApiKeyDraft(key);
     });
+    getPlaceholderDisplayMode().then((mode) => {
+      if (!cancelled) setDisplayMode(mode);
+    });
     const unsubscribe = subscribe((next) => {
       setStates(next);
+    });
+    const unsubscribeMode = subscribePlaceholderDisplayMode((mode) => {
+      setDisplayMode(mode);
     });
     return () => {
       cancelled = true;
       unsubscribe();
+      unsubscribeMode();
     };
   }, []);
 
@@ -117,6 +133,11 @@ export function Options() {
     setTimeout(() => setApiKeyStatus(null), 1500);
   };
 
+  const handleDisplayModeChange = (mode: PlaceholderDisplayMode) => {
+    setDisplayMode(mode);
+    void setPlaceholderDisplayMode(mode);
+  };
+
   return (
     <div className="options">
       <h1>Agent Browser Shield — Options</h1>
@@ -124,6 +145,7 @@ export function Options() {
       <nav className="toc" aria-label="Sections">
         <a href="#apply">Apply configuration</a>
         <a href="#export">Export configuration</a>
+        <a href="#display">Placeholder display</a>
         <a href="#api-key">OpenAI API key</a>
         <a href="#rules">Rules</a>
       </nav>
@@ -181,6 +203,61 @@ export function Options() {
             Export JSON
           </button>
         </div>
+      </section>
+
+      <section id="display" className="section">
+        <h2>
+          <a
+            href="#display"
+            className="anchor"
+            aria-label="Link to Placeholder display"
+          >
+            #
+          </a>
+          Placeholder display
+        </h2>
+        <p className="hint">
+          How the reveal control on each placeholder is rendered. The
+          descriptive label (e.g., what kind of content was hidden) is always
+          exposed to screen readers and agents via <code>aria-label</code>.
+        </p>
+        <fieldset className="radio-group">
+          <legend className="visually-hidden">Reveal control style</legend>
+          <label className="radio">
+            <input
+              type="radio"
+              name="placeholder-display-mode"
+              value="icon"
+              checked={displayMode === "icon"}
+              disabled={displayMode === null}
+              onChange={() => handleDisplayModeChange("icon")}
+            />
+            <div>
+              <strong>Icon only</strong>
+              <p>
+                Compact shield icon. Best when placeholders would otherwise grow
+                larger than the content they replace.
+              </p>
+            </div>
+          </label>
+          <label className="radio">
+            <input
+              type="radio"
+              name="placeholder-display-mode"
+              value="button"
+              checked={displayMode === "button"}
+              disabled={displayMode === null}
+              onChange={() => handleDisplayModeChange("button")}
+            />
+            <div>
+              <strong>Button with label</strong>
+              <p>
+                Shield icon plus a visible label describing what was hidden.
+                Larger, but visually self-explanatory.
+              </p>
+            </div>
+          </label>
+        </fieldset>
       </section>
 
       <section id="api-key" className="section section--unavailable">

--- a/skills/agent-browser-shield-diagnose/SKILL.md
+++ b/skills/agent-browser-shield-diagnose/SKILL.md
@@ -112,9 +112,10 @@ Once you see *what* the agent saw differently, read its `reasoning` text on the
 step immediately after the diverging `ariaTree`. That's where the agent decided
 what to do with the new view of the page. Common failure shapes:
 
-- **Misread placeholder** — agent treats `[… hidden — click to reveal]` as the
-  literal answer instead of clicking through. Check the `agent-browser-shield`
-  skill's "Required behavior" section for the contract.
+- **Misread placeholder** — agent treats the placeholder's descriptor
+  (`[… hidden — click to reveal]`, on the button's `aria-label`) as the literal
+  answer instead of clicking through. Check the `agent-browser-shield` skill's
+  "Required behavior" section for the contract.
 - **Lost landmark** — agent can't find the element the baseline used; falls back
   to a worse heuristic and lands on the wrong row/listing/price.
 - **Step exhaustion** — guarded run hits `max_steps` because the agent burns

--- a/skills/agent-browser-shield/SKILL.md
+++ b/skills/agent-browser-shield/SKILL.md
@@ -13,12 +13,17 @@ surfaces **before you see the page**.
 
 - `[data-abs-rule="<rule-id>"]` — any element this extension inserted; the
   attribute value names the rule.
-- `.abs-placeholder` with button text `[<thing> hidden — click to reveal]` —
-  reveal-on-click placeholder replacing hidden content. The
+- `.abs-placeholder` — reveal-on-click placeholder replacing hidden content.
+  Each placeholder has a `<button>` whose `aria-label` (and `title`) describes
+  what was hidden: `[<thing> hidden — click to reveal]`. The
   `irrelevant-sections-hide` rule embeds an AI-generated one-sentence summary
   instead: `[hidden: <summary> — click to reveal]` (e.g.
   `[hidden: Carousel of 6 related kitchen knives with prices and ratings — click to reveal]`).
-  Use that summary to decide whether to reveal.
+  Use that descriptor to decide whether to reveal. The same string appears as
+  visible button text only when the user has selected "Button with label" on
+  the options page; in the default "Icon only" display mode the button shows
+  just a rule-specific shield-style SVG icon and the visible text is hidden by
+  CSS, so always read the descriptor from `aria-label`, not `textContent`.
 - `.abs-cart-addon-flag` — warning chip prepended into a cart line item flagged
   as a likely sneak-into-basket add-on (protection plan, warranty, insurance,
   donation, round-up, gift wrap, carbon offset, shipping protection, driver tip,

--- a/skills/agent-browser-shield/SKILL.md
+++ b/skills/agent-browser-shield/SKILL.md
@@ -20,10 +20,10 @@ surfaces **before you see the page**.
   instead: `[hidden: <summary> — click to reveal]` (e.g.
   `[hidden: Carousel of 6 related kitchen knives with prices and ratings — click to reveal]`).
   Use that descriptor to decide whether to reveal. The same string appears as
-  visible button text only when the user has selected "Button with label" on
-  the options page; in the default "Icon only" display mode the button shows
-  just a rule-specific shield-style SVG icon and the visible text is hidden by
-  CSS, so always read the descriptor from `aria-label`, not `textContent`.
+  visible button text only when the user has selected "Button with label" on the
+  options page; in the default "Icon only" display mode the button shows just a
+  rule-specific shield-style SVG icon and the visible text is hidden by CSS, so
+  always read the descriptor from `aria-label`, not `textContent`.
 - `.abs-cart-addon-flag` — warning chip prepended into a cart line item flagged
   as a likely sneak-into-basket add-on (protection plan, warranty, insurance,
   donation, round-up, gift wrap, carbon offset, shipping protection, driver tip,


### PR DESCRIPTION
## Summary

- Block placeholders' reveal button now renders a rule-specific SVG icon
  (star, chat bubble, clock, flame, warning triangle, hashtag, funnel,
  page-divider; shield as fallback). Icons live in a registry in
  `extension/src/lib/placeholder.ts` keyed by `RuleId`.
- New options-page setting (`Placeholder display`) toggles between
  **Icon only** (default) and **Button with label**. Default switches to
  icon-only to fix cases where the reveal button's wrapped text was taller
  than the original element it replaced.
- Descriptor (`[<thing> hidden — click to reveal]`) is always exposed on the
  button's `aria-label`/`title`, so screen readers and a11y-tree-based agents
  see the same information in either mode.
- Updated `skills/agent-browser-shield/SKILL.md` and
  `skills/agent-browser-shield-diagnose/SKILL.md` to point agents at
  `aria-label` rather than visible text for the placeholder descriptor.

## Test plan

- [x] `bun run test` — 385 passing
- [x] `bun run build` — clean
- [x] `bun run check` — clean (one pre-existing unused-`status` warning unrelated to this change)
- [ ] Manual: load `extension/dist/` unpacked, visit a page with reviews/comments — confirm icon shows in default mode, switching to "Button with label" on the options page shows icon + label live
- [ ] Manual: confirm `aria-label` on the reveal button reads correctly via screen reader / DevTools a11y panel in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)