### PR TITLE
feat(extension): toolbar badge count + global enforcement toggle

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,6 +1,81 @@
+import { subscribeEnforcementEnabled } from "./lib/enforcement";
 import { handleClassify } from "./lib/llm-background";
 
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+// Per-tab, per-frame placeholder counts. Each content script reports its own
+// frame's tally; the badge shows the sum across frames for that tab.
+const tabCounts = new Map<number, Map<number, number>>();
+
+// Pleasant blue — clearly an extension affordance, not a warning/error.
+const BADGE_COLOR = "#2563eb";
+
+function totalForTab(tabId: number): number {
+  const frames = tabCounts.get(tabId);
+  if (!frames) return 0;
+  let sum = 0;
+  for (const value of frames.values()) sum += value;
+  return sum;
+}
+
+function formatBadge(total: number): string {
+  if (total <= 0) return "";
+  if (total > 999) return "999+";
+  return String(total);
+}
+
+function setBadge(tabId: number, total: number): void {
+  const text = formatBadge(total);
+  chrome.action.setBadgeText({ tabId, text }).catch(() => {});
+  if (text) {
+    chrome.action
+      .setBadgeBackgroundColor({ tabId, color: BADGE_COLOR })
+      .catch(() => {});
+  }
+}
+
+function recordFrameCount(tabId: number, frameId: number, count: number): void {
+  let frames = tabCounts.get(tabId);
+  if (!frames) {
+    frames = new Map();
+    tabCounts.set(tabId, frames);
+  }
+  if (count <= 0) {
+    frames.delete(frameId);
+    if (frames.size === 0) tabCounts.delete(tabId);
+  } else {
+    frames.set(frameId, count);
+  }
+  setBadge(tabId, totalForTab(tabId));
+}
+
+function clearTab(tabId: number): void {
+  tabCounts.delete(tabId);
+  setBadge(tabId, 0);
+}
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  tabCounts.delete(tabId);
+});
+
+// On a top-level navigation, drop stale per-frame counts so the new document
+// starts from zero. The content script will report fresh numbers as rules run.
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.status === "loading") {
+    clearTab(tabId);
+  }
+});
+
+// Re-render every tab's badge when enforcement is toggled. When disabled, the
+// rule engine reveals everything in each frame, which will eventually push
+// zero counts back — but doing this synchronously keeps the badge from
+// looking stale for the duration of those mutation observer cycles.
+subscribeEnforcementEnabled((enabled) => {
+  if (enabled) return;
+  for (const tabId of Array.from(tabCounts.keys())) {
+    clearTab(tabId);
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (!message || typeof message !== "object") return undefined;
 
   if (message.type === "open-options") {
@@ -8,6 +83,21 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       sendResponse({ ok: true });
     });
     return true;
+  }
+
+  if (message.type === "placeholder-count") {
+    const tabId = sender.tab?.id;
+    const frameId = sender.frameId;
+    const raw = (message as { count?: unknown }).count;
+    if (
+      typeof tabId === "number" &&
+      typeof frameId === "number" &&
+      typeof raw === "number" &&
+      Number.isFinite(raw)
+    ) {
+      recordFrameCount(tabId, frameId, Math.max(0, Math.floor(raw)));
+    }
+    return undefined;
   }
 
   if (message.type === "classify-irrelevant-sections") {

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,5 +1,6 @@
 import { isTopFrame } from "./lib/frame";
 import { injectOptionsBadge } from "./lib/options-badge";
+import { startPlaceholderCountReporter } from "./lib/placeholder-count";
 import { start } from "./lib/rule-engine";
 
 // Content script runs in every frame (`all_frames: true`). The rule engine
@@ -8,6 +9,10 @@ import { start } from "./lib/rule-engine";
 start().catch((error) => {
   console.error("[abs] failed to start rule engine", error);
 });
+
+// Per-frame placeholder reporter — background aggregates across frames into
+// the toolbar badge total.
+startPlaceholderCountReporter();
 
 if (isTopFrame()) {
   injectOptionsBadge();

--- a/extension/src/lib/__tests__/rule-engine.test.ts
+++ b/extension/src/lib/__tests__/rule-engine.test.ts
@@ -47,6 +47,12 @@ jest.mock("../frame", () => ({
   isTopFrame: jest.fn(),
 }));
 
+jest.mock("../enforcement", () => ({
+  getEnforcementEnabled: jest.fn(() => Promise.resolve(true)),
+  subscribeEnforcementEnabled: jest.fn(() => () => undefined),
+  ENFORCEMENT_ENABLED_DEFAULT: true,
+}));
+
 import { isTopFrame } from "../frame";
 import { start } from "../rule-engine";
 import { getRuleStates } from "../storage";

--- a/extension/src/lib/enforcement.ts
+++ b/extension/src/lib/enforcement.ts
@@ -1,0 +1,40 @@
+// Global on/off switch for the extension's enforcement. When disabled, the
+// rule engine reveals all placeholders and tears down rules without mutating
+// any per-rule state — so flipping it back on restores the previous selection.
+//
+// Stored separately from rule states so toggling enforcement doesn't churn the
+// rule-state listener path and so the per-rule preferences survive across
+// disable/enable cycles.
+
+const STORAGE_KEY = "agent-browser-shield.enforcement-enabled";
+
+export const ENFORCEMENT_ENABLED_DEFAULT = true;
+
+function normalize(raw: unknown): boolean {
+  return typeof raw === "boolean" ? raw : ENFORCEMENT_ENABLED_DEFAULT;
+}
+
+export async function getEnforcementEnabled(): Promise<boolean> {
+  const stored = await chrome.storage.local.get(STORAGE_KEY);
+  return normalize(stored[STORAGE_KEY]);
+}
+
+export async function setEnforcementEnabled(enabled: boolean): Promise<void> {
+  await chrome.storage.local.set({ [STORAGE_KEY]: enabled });
+}
+
+export function subscribeEnforcementEnabled(
+  listener: (enabled: boolean) => void,
+): () => void {
+  const handler = (
+    changes: Record<string, chrome.storage.StorageChange>,
+    areaName: string,
+  ) => {
+    if (areaName !== "local") return;
+    const change = changes[STORAGE_KEY];
+    if (!change) return;
+    listener(normalize(change.newValue));
+  };
+  chrome.storage.onChanged.addListener(handler);
+  return () => chrome.storage.onChanged.removeListener(handler);
+}

--- a/extension/src/lib/placeholder-count.ts
+++ b/extension/src/lib/placeholder-count.ts
@@ -1,0 +1,83 @@
+// Per-frame tally of hidden/masked elements, reported to the background so it
+// can render the total as a toolbar badge. Counts both placeholders that ship
+// with a reveal control and elements hidden in-place via display:none.
+//
+// We watch document.body with a single MutationObserver and recount on each
+// throttled batch. Recounting via querySelectorAll is cheap relative to the
+// work the rules themselves do, and avoids us having to instrument every
+// placeholder construction/destruction site individually.
+
+import throttle from "lodash/throttle";
+import { HIDDEN_ATTR, PLACEHOLDER_CLASS } from "./placeholder";
+
+const COUNT_SELECTOR = `.${PLACEHOLDER_CLASS}, [${HIDDEN_ATTR}]`;
+const REPORT_THROTTLE_MS = 250;
+
+export interface PlaceholderCountMessage {
+  type: "placeholder-count";
+  count: number;
+}
+
+function currentCount(): number {
+  if (!document.body) return 0;
+  return document.body.querySelectorAll(COUNT_SELECTOR).length;
+}
+
+function send(count: number): void {
+  const message: PlaceholderCountMessage = {
+    type: "placeholder-count",
+    count,
+  };
+  // Service worker may be asleep / receiver not yet ready — swallow the
+  // resulting "Receiving end does not exist" rejection so it doesn't surface
+  // as an unhandled promise warning on every page load.
+  chrome.runtime.sendMessage(message).catch(() => {});
+}
+
+export function startPlaceholderCountReporter(): void {
+  let lastReported = -1;
+  const reportIfChanged = () => {
+    const count = currentCount();
+    if (count === lastReported) return;
+    lastReported = count;
+    send(count);
+  };
+
+  const throttled = throttle(reportIfChanged, REPORT_THROTTLE_MS, {
+    leading: true,
+    trailing: true,
+  });
+
+  // Initial report — fires whether or not any rule has run yet, so the badge
+  // clears on pages with no matches.
+  reportIfChanged();
+
+  const observer = new MutationObserver(() => {
+    throttled();
+  });
+
+  const startObserving = () => {
+    if (!document.body) return;
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: [HIDDEN_ATTR],
+    });
+  };
+
+  if (document.body) {
+    startObserving();
+  } else {
+    document.addEventListener("DOMContentLoaded", startObserving, {
+      once: true,
+    });
+  }
+
+  // Flush a final zero on unload so the background can decrement this frame's
+  // contribution before the new document's content script registers itself.
+  window.addEventListener("pagehide", () => {
+    throttled.cancel();
+    send(0);
+  });
+}

--- a/extension/src/lib/rule-engine.ts
+++ b/extension/src/lib/rule-engine.ts
@@ -1,4 +1,8 @@
 import { RULES, type Rule } from "../rules";
+import {
+  getEnforcementEnabled,
+  subscribeEnforcementEnabled,
+} from "./enforcement";
 import { isTopFrame } from "./frame";
 import { log } from "./log";
 import {
@@ -172,6 +176,14 @@ function applyDisplayMode(mode: PlaceholderDisplayMode): void {
   document.documentElement.setAttribute(PLACEHOLDER_MODE_ATTR, mode);
 }
 
+const ALL_DISABLED: RuleStates = Object.fromEntries(
+  RULES.map((rule) => [rule.id, false]),
+) as RuleStates;
+
+function mask(states: RuleStates, enforcementEnabled: boolean): RuleStates {
+  return enforcementEnabled ? states : ALL_DISABLED;
+}
+
 export async function start(): Promise<void> {
   const topFrame = isTopFrame();
   log("rule engine starting", { url: window.location.href, topFrame });
@@ -182,12 +194,29 @@ export async function start(): Promise<void> {
   void getPlaceholderDisplayMode().then(applyDisplayMode);
   subscribePlaceholderDisplayMode(applyDisplayMode);
 
-  const initial = await getRuleStates();
-  applyEnabled(initial, topFrame);
+  const [rawStates, enforcementInitial] = await Promise.all([
+    getRuleStates(),
+    getEnforcementEnabled(),
+  ]);
+  let rawCurrent = rawStates;
+  let enforcementCurrent = enforcementInitial;
+  applyEnabled(mask(rawCurrent, enforcementCurrent), topFrame);
 
-  let current = initial;
+  let effectiveCurrent = mask(rawCurrent, enforcementCurrent);
+
+  function applyChange(nextRaw: RuleStates, nextEnforcement: boolean): void {
+    const nextEffective = mask(nextRaw, nextEnforcement);
+    reconcile(nextEffective, effectiveCurrent, topFrame);
+    effectiveCurrent = nextEffective;
+    rawCurrent = nextRaw;
+    enforcementCurrent = nextEnforcement;
+  }
+
   subscribe((next) => {
-    reconcile(next, current, topFrame);
-    current = next;
+    applyChange(next, enforcementCurrent);
+  });
+  subscribeEnforcementEnabled((enabled) => {
+    log("enforcement toggle changed", { enabled });
+    applyChange(rawCurrent, enabled);
   });
 }

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -21,6 +21,95 @@
         font-size: 14px;
         font-weight: 600;
       }
+      .enforcement {
+        margin: 0 0 12px;
+        padding: 8px 10px;
+        border: 1px solid #e4e4e7;
+        border-radius: 6px;
+        background: #fafafa;
+      }
+      .enforcement--on {
+        border-color: #bfdbfe;
+        background: #eff6ff;
+      }
+      .enforcement--off {
+        border-color: #fde68a;
+        background: #fffbeb;
+      }
+      .enforcement__label {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        cursor: pointer;
+        margin: 0;
+      }
+      .enforcement__text {
+        display: inline-flex;
+        flex-direction: column;
+        gap: 1px;
+        flex: 1;
+      }
+      .enforcement__text strong {
+        font-size: 13px;
+      }
+      .enforcement__state {
+        font-size: 11px;
+        color: #555;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .enforcement--off .enforcement__state {
+        color: #92400e;
+      }
+      .enforcement__hint {
+        margin: 6px 0 0;
+        font-size: 11px;
+        color: #92400e;
+        line-height: 1.3;
+      }
+      .switch {
+        position: relative;
+        display: inline-block;
+        width: 32px;
+        height: 18px;
+        flex: none;
+      }
+      .switch input {
+        position: absolute;
+        inset: 0;
+        opacity: 0;
+        margin: 0;
+        cursor: pointer;
+      }
+      .switch__track {
+        position: absolute;
+        inset: 0;
+        background: #d4d4d8;
+        border-radius: 999px;
+        transition: background 120ms ease;
+      }
+      .switch__track::after {
+        content: "";
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 14px;
+        height: 14px;
+        background: #fff;
+        border-radius: 50%;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+        transition: transform 120ms ease;
+      }
+      .switch input:checked + .switch__track {
+        background: #2563eb;
+      }
+      .switch input:checked + .switch__track::after {
+        transform: translateX(14px);
+      }
+      .switch input:focus-visible + .switch__track {
+        outline: 2px solid #2563eb;
+        outline-offset: 2px;
+      }
       .rules {
         list-style: none;
         margin: 0;
@@ -28,6 +117,9 @@
         display: flex;
         flex-direction: column;
         gap: 8px;
+      }
+      .rules--enforcement-off {
+        opacity: 0.55;
       }
       .rules label {
         display: flex;

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
 import {
+  getEnforcementEnabled,
+  setEnforcementEnabled,
+  subscribeEnforcementEnabled,
+} from "../lib/enforcement";
+import {
   getRuleStates,
   type RuleStates,
   setRuleEnabled,
@@ -9,31 +14,88 @@ import { RULES } from "../rules";
 
 export function Popup() {
   const [states, setStates] = useState<RuleStates | null>(null);
+  const [enforcementEnabled, setEnforcementState] = useState<boolean | null>(
+    null,
+  );
 
   useEffect(() => {
     let cancelled = false;
     getRuleStates().then((initial) => {
       if (!cancelled) setStates(initial);
     });
+    getEnforcementEnabled().then((value) => {
+      if (!cancelled) setEnforcementState(value);
+    });
     const unsubscribe = subscribe((next) => {
       setStates(next);
+    });
+    const unsubscribeEnforcement = subscribeEnforcementEnabled((value) => {
+      setEnforcementState(value);
     });
     return () => {
       cancelled = true;
       unsubscribe();
+      unsubscribeEnforcement();
     };
   }, []);
 
-  if (!states) {
+  if (!states || enforcementEnabled === null) {
     return <div className="loading">Loading…</div>;
   }
+
+  const handleEnforcementToggle = (enabled: boolean) => {
+    setEnforcementState(enabled);
+    void setEnforcementEnabled(enabled);
+  };
 
   return (
     <div className="popup">
       <h1>Agent Browser Shield</h1>
-      <ul className="rules">
+      <div
+        className={
+          enforcementEnabled
+            ? "enforcement enforcement--on"
+            : "enforcement enforcement--off"
+        }
+      >
+        <label className="enforcement__label">
+          <span className="enforcement__text">
+            <strong>Enforcement</strong>
+            <span className="enforcement__state">
+              {enforcementEnabled ? "On" : "Off"}
+            </span>
+          </span>
+          <span
+            className="switch"
+            role="presentation"
+            aria-hidden={enforcementEnabled === null}
+          >
+            <input
+              type="checkbox"
+              checked={enforcementEnabled}
+              onChange={(event) =>
+                handleEnforcementToggle(event.target.checked)
+              }
+              aria-label="Enable enforcement"
+            />
+            <span className="switch__track" />
+          </span>
+        </label>
+        {!enforcementEnabled && (
+          <p className="enforcement__hint">
+            All rules are paused for every tab. Your per-rule selection below is
+            preserved and restored when you turn enforcement back on.
+          </p>
+        )}
+      </div>
+      <ul
+        className={
+          enforcementEnabled ? "rules" : "rules rules--enforcement-off"
+        }
+      >
         {RULES.map((rule) => {
           const unavailable = rule.available === false;
+          const disabled = unavailable || !enforcementEnabled;
           return (
             <li
               key={rule.id}
@@ -43,7 +105,7 @@ export function Popup() {
                 <input
                   type="checkbox"
                   checked={unavailable ? false : states[rule.id]}
-                  disabled={unavailable}
+                  disabled={disabled}
                   onChange={(event) => {
                     const enabled = event.target.checked;
                     setStates((prev) =>


### PR DESCRIPTION
## Summary
- Toolbar badge shows the per-tab count of hidden / masked elements. Each frame's content script counts placeholders (`.abs-placeholder`) and hidden-in-place nodes (`[data-abs-hidden]`) via a throttled MutationObserver; the background aggregates by `(tabId, frameId)` and writes the sum with `chrome.action.setBadgeText`. Counts clear on tab close, navigation (`tabs.onUpdated` `status: 'loading'`), and when enforcement is turned off.
- Popup gets a global enforcement switch backed by a new `chrome.storage.local` key (default on). When off, the rule engine masks all rule states to false — reusing the existing reconcile path to reveal placeholders and tear rules down — without mutating per-rule selections, so flipping it back on restores the prior state. The per-rule list dims and its checkboxes are disabled while off.
- No new manifest permissions needed: `chrome.action.setBadge*` ships with the existing `action` key, and the `tabs.on*` listeners we use don't require the `tabs` permission since we don't read URLs.

## Test plan
- [ ] `bun run build` — clean
- [ ] `bun run check` — clean (one pre-existing unused-var warning in `Options.tsx` unrelated to this change)
- [ ] `bun run test` — 385/385
- [ ] Load unpacked; open a page with matches (e.g. an Amazon product page): badge shows non-zero count
- [ ] Toggle enforcement off in popup: badge clears, placeholders disappear, per-rule list dims
- [ ] Toggle enforcement on: prior rule selection restored, badge repopulates
- [ ] Navigate to a fresh tab: badge resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)