### PR TITLE
feat(extension): allow user-supplied OpenAI key to enable LLM rule

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -219,8 +219,9 @@ the page. Referenced sprites are preserved so icons keep working.
 - **ID:** `irrelevant-sections-hide`
 - **Default:** off
 - **Scope:** top frame only
-- **Availability:** disabled in shipped builds (requires `OPENAI_API_KEY` at
-  build time)
+- **Availability:** requires an OpenAI API key — either bundled at build time
+  via `OPENAI_API_KEY`, or saved on the extension's options page. Until a key is
+  configured the rule shows as Unavailable in the popup and options.
 
 Use a small LLM to identify engagement/exploration rails (related products, "you
 might also like", recommended articles, trending now, etc.) and replace them

--- a/extension/src/lib/api-key-storage.ts
+++ b/extension/src/lib/api-key-storage.ts
@@ -7,6 +7,11 @@
 
 const API_KEY_STORAGE_KEY = "agent-browser-shield.openai-api-key";
 
+// True when the build was produced with an OPENAI_API_KEY bundled in.
+// Substituted at build time via Bun `define` (see globals.d.ts / build.ts).
+export const HAS_BUILT_IN_OPENAI_KEY =
+  process.env.HAS_BUILT_IN_OPENAI_KEY === "true";
+
 export async function getUserApiKey(): Promise<string> {
   const stored = await chrome.storage.local.get(API_KEY_STORAGE_KEY);
   const value = stored[API_KEY_STORAGE_KEY];
@@ -15,4 +20,21 @@ export async function getUserApiKey(): Promise<string> {
 
 export async function setUserApiKey(key: string): Promise<void> {
   await chrome.storage.local.set({ [API_KEY_STORAGE_KEY]: key });
+}
+
+export function subscribeUserApiKey(
+  listener: (key: string) => void,
+): () => void {
+  const handler = (
+    changes: Record<string, chrome.storage.StorageChange>,
+    areaName: string,
+  ) => {
+    if (areaName !== "local") return;
+    const change = changes[API_KEY_STORAGE_KEY];
+    if (!change) return;
+    const value = change.newValue;
+    listener(typeof value === "string" ? value : "");
+  };
+  chrome.storage.onChanged.addListener(handler);
+  return () => chrome.storage.onChanged.removeListener(handler);
 }

--- a/extension/src/lib/availability.ts
+++ b/extension/src/lib/availability.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Shared resolution logic for `Rule.available`. A rule can be statically
+// available, statically unavailable (build-time), or reactively gated on
+// runtime state (e.g. user-supplied API key). This module hides the three-way
+// split behind a snapshot map so the engine, popup, and options page don't
+// each duplicate the resolution.
+
+import { RULES, type RuleId } from "../rules";
+import type {
+  AvailabilitySnapshot,
+  Rule,
+  RuleAvailability,
+} from "../rules/types";
+import {
+  getUserApiKey,
+  HAS_BUILT_IN_OPENAI_KEY,
+  subscribeUserApiKey,
+} from "./api-key-storage";
+
+export type RuleAvailabilityStates = Record<RuleId, AvailabilitySnapshot>;
+
+const ALWAYS_AVAILABLE: AvailabilitySnapshot = { available: true };
+
+function isReactive(value: Rule["available"]): value is RuleAvailability {
+  return typeof value === "object" && value !== null;
+}
+
+export async function resolveAvailability(
+  rule: Rule,
+): Promise<AvailabilitySnapshot> {
+  const accessor = rule.available;
+  if (isReactive(accessor)) return accessor.get();
+  if (accessor === false) {
+    return { available: false, reason: rule.unavailableReason };
+  }
+  return ALWAYS_AVAILABLE;
+}
+
+export async function getRuleAvailabilityStates(): Promise<RuleAvailabilityStates> {
+  const entries = await Promise.all(
+    RULES.map(
+      async (rule) => [rule.id, await resolveAvailability(rule)] as const,
+    ),
+  );
+  return Object.fromEntries(entries) as RuleAvailabilityStates;
+}
+
+// Subscribe to changes in any rule's reactive availability. The listener is
+// invoked with a freshly-resolved snapshot map whenever an underlying source
+// signals a change.
+export function subscribeRuleAvailability(
+  listener: (next: RuleAvailabilityStates) => void,
+): () => void {
+  const unsubs: Array<() => void> = [];
+  const refresh = () => {
+    void getRuleAvailabilityStates().then(listener);
+  };
+  for (const rule of RULES) {
+    if (!isReactive(rule.available)) continue;
+    unsubs.push(rule.available.subscribe(refresh));
+  }
+  return () => {
+    for (const unsub of unsubs) unsub();
+  };
+}
+
+// Factory for rules that depend on the OpenAI API key being available — either
+// bundled at build time or supplied by the user via the options page. The
+// snapshot recomputes when the stored user key changes so the popup/options
+// flip the toggle from "Unavailable" the moment a key is saved.
+export function createApiKeyAvailability(reason: string): RuleAvailability {
+  return {
+    async get() {
+      if (HAS_BUILT_IN_OPENAI_KEY) return { available: true };
+      const userKey = await getUserApiKey();
+      return userKey ? { available: true } : { available: false, reason };
+    },
+    subscribe(listener) {
+      return subscribeUserApiKey(listener);
+    },
+  };
+}

--- a/extension/src/lib/rule-engine.ts
+++ b/extension/src/lib/rule-engine.ts
@@ -3,6 +3,11 @@
 
 import { RULES, type Rule } from "../rules";
 import {
+  getRuleAvailabilityStates,
+  type RuleAvailabilityStates,
+  subscribeRuleAvailability,
+} from "./availability";
+import {
   getEnforcementEnabled,
   subscribeEnforcementEnabled,
 } from "./enforcement";
@@ -111,12 +116,12 @@ function injectStyles(): void {
   document.documentElement.appendChild(style);
 }
 
-function isAvailable(rule: Rule): boolean {
-  return rule.available !== false;
-}
-
-function isApplicableHere(rule: Rule, topFrame: boolean): boolean {
-  if (!isAvailable(rule)) return false;
+function isApplicableHere(
+  rule: Rule,
+  topFrame: boolean,
+  availability: RuleAvailabilityStates,
+): boolean {
+  if (!availability[rule.id]?.available) return false;
   // topFrameOnly rules target page-wide concepts (site footer, cookie/newsletter
   // overlays, per-host URL recipes). Running them in subframes would either
   // be a no-op (selectors don't match) or actively harmful (duplicate
@@ -125,7 +130,11 @@ function isApplicableHere(rule: Rule, topFrame: boolean): boolean {
   return true;
 }
 
-function applyEnabled(states: RuleStates, topFrame: boolean): void {
+function applyEnabled(
+  states: RuleStates,
+  topFrame: boolean,
+  availability: RuleAvailabilityStates,
+): void {
   // document.body may be missing in some about:blank / about:srcdoc iframes
   // at document_idle if the parent injects the frame without children. Skip
   // rule application entirely in that case — there's nothing to scan, and
@@ -137,7 +146,7 @@ function applyEnabled(states: RuleStates, topFrame: boolean): void {
     return;
   }
   const enabled = RULES.filter(
-    (rule) => isApplicableHere(rule, topFrame) && states[rule.id],
+    (rule) => isApplicableHere(rule, topFrame, availability) && states[rule.id],
   ).map((r) => r.id);
   log("initial rule application", {
     enabled,
@@ -145,7 +154,7 @@ function applyEnabled(states: RuleStates, topFrame: boolean): void {
     topFrame,
   });
   for (const rule of RULES) {
-    if (!isApplicableHere(rule, topFrame)) continue;
+    if (!isApplicableHere(rule, topFrame, availability)) continue;
     if (states[rule.id]) {
       log("applying rule", { ruleId: rule.id });
       rule.apply(document.body);
@@ -153,18 +162,44 @@ function applyEnabled(states: RuleStates, topFrame: boolean): void {
   }
 }
 
-function reconcile(
-  next: RuleStates,
-  previous: RuleStates,
+// Effective application = enabled-by-user AND applicable-in-this-frame AND
+// currently-available. Reconciliation reads from this so a change in any input
+// (storage toggle, enforcement switch, availability flip) routes through the
+// same diff logic.
+function effectivelyApplied(
+  rule: Rule,
+  states: RuleStates,
   topFrame: boolean,
+  availability: RuleAvailabilityStates,
+): boolean {
+  return (
+    isApplicableHere(rule, topFrame, availability) && Boolean(states[rule.id])
+  );
+}
+
+function reconcile(
+  nextStates: RuleStates,
+  previousStates: RuleStates,
+  topFrame: boolean,
+  nextAvailability: RuleAvailabilityStates,
+  previousAvailability: RuleAvailabilityStates,
 ): void {
   if (!document.body) return;
   for (const rule of RULES) {
-    if (!isApplicableHere(rule, topFrame)) continue;
-    const wasEnabled = previous[rule.id];
-    const isEnabled = next[rule.id];
-    if (isEnabled === wasEnabled) continue;
-    if (isEnabled) {
+    const wasApplied = effectivelyApplied(
+      rule,
+      previousStates,
+      topFrame,
+      previousAvailability,
+    );
+    const isApplied = effectivelyApplied(
+      rule,
+      nextStates,
+      topFrame,
+      nextAvailability,
+    );
+    if (isApplied === wasApplied) continue;
+    if (isApplied) {
       log("rule enabled — applying", { ruleId: rule.id });
       rule.apply(document.body);
     } else {
@@ -197,29 +232,55 @@ export async function start(): Promise<void> {
   void getPlaceholderDisplayMode().then(applyDisplayMode);
   subscribePlaceholderDisplayMode(applyDisplayMode);
 
-  const [rawStates, enforcementInitial] = await Promise.all([
-    getRuleStates(),
-    getEnforcementEnabled(),
-  ]);
+  const [rawStates, enforcementInitial, availabilityInitial] =
+    await Promise.all([
+      getRuleStates(),
+      getEnforcementEnabled(),
+      getRuleAvailabilityStates(),
+    ]);
   let rawCurrent = rawStates;
   let enforcementCurrent = enforcementInitial;
-  applyEnabled(mask(rawCurrent, enforcementCurrent), topFrame);
+  let availabilityCurrent = availabilityInitial;
+  applyEnabled(
+    mask(rawCurrent, enforcementCurrent),
+    topFrame,
+    availabilityCurrent,
+  );
 
   let effectiveCurrent = mask(rawCurrent, enforcementCurrent);
 
-  function applyChange(nextRaw: RuleStates, nextEnforcement: boolean): void {
+  function applyChange(
+    nextRaw: RuleStates,
+    nextEnforcement: boolean,
+    nextAvailability: RuleAvailabilityStates,
+  ): void {
     const nextEffective = mask(nextRaw, nextEnforcement);
-    reconcile(nextEffective, effectiveCurrent, topFrame);
+    reconcile(
+      nextEffective,
+      effectiveCurrent,
+      topFrame,
+      nextAvailability,
+      availabilityCurrent,
+    );
     effectiveCurrent = nextEffective;
     rawCurrent = nextRaw;
     enforcementCurrent = nextEnforcement;
+    availabilityCurrent = nextAvailability;
   }
 
   subscribe((next) => {
-    applyChange(next, enforcementCurrent);
+    applyChange(next, enforcementCurrent, availabilityCurrent);
   });
   subscribeEnforcementEnabled((enabled) => {
     log("enforcement toggle changed", { enabled });
-    applyChange(rawCurrent, enabled);
+    applyChange(rawCurrent, enabled, availabilityCurrent);
+  });
+  subscribeRuleAvailability((next) => {
+    log("rule availability changed", {
+      snapshot: Object.fromEntries(
+        Object.entries(next).map(([id, snap]) => [id, snap.available]),
+      ),
+    });
+    applyChange(rawCurrent, enforcementCurrent, next);
   });
 }

--- a/extension/src/lib/storage.ts
+++ b/extension/src/lib/storage.ts
@@ -10,14 +10,15 @@ export type RuleStates = Record<RuleId, boolean>;
 const STORAGE_KEY = "agent-browser-shield.rules";
 
 // Defaults derived once at module load — each rule carries its own
-// `defaultEnabled` and `available` flags. No separate map to keep in sync.
+// `defaultEnabled` flag. Availability is resolved separately via
+// `lib/availability.ts` (which supports reactive accessors), and the rule
+// engine gates application on it at apply time. We deliberately don't mask
+// unavailable rules' stored state here: if availability is reactive (e.g.
+// gated on a user-supplied API key) we want the user's toggle preference
+// preserved so it takes effect the moment the rule becomes available.
 const DEFAULT_STATES: RuleStates = Object.fromEntries(
   RULES.map((rule) => [rule.id, rule.defaultEnabled]),
 ) as RuleStates;
-
-const UNAVAILABLE_RULE_IDS: ReadonlySet<RuleId> = new Set(
-  RULES.filter((rule) => rule.available === false).map((rule) => rule.id),
-);
 
 function normalize(raw: unknown): RuleStates {
   const result: RuleStates = { ...DEFAULT_STATES };
@@ -28,9 +29,6 @@ function normalize(raw: unknown): RuleStates {
         result[id] = value;
       }
     }
-  }
-  for (const id of UNAVAILABLE_RULE_IDS) {
-    result[id] = false;
   }
   return result;
 }

--- a/extension/src/options/Options.tsx
+++ b/extension/src/options/Options.tsx
@@ -2,7 +2,16 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { useEffect, useState } from "react";
-import { getUserApiKey, setUserApiKey } from "../lib/api-key-storage";
+import {
+  getUserApiKey,
+  HAS_BUILT_IN_OPENAI_KEY,
+  setUserApiKey,
+} from "../lib/api-key-storage";
+import {
+  getRuleAvailabilityStates,
+  type RuleAvailabilityStates,
+  subscribeRuleAvailability,
+} from "../lib/availability";
 import {
   getPlaceholderDisplayMode,
   type PlaceholderDisplayMode,
@@ -19,8 +28,6 @@ import {
   subscribe,
 } from "../lib/storage";
 import { RULES } from "../rules";
-
-const HAS_BUILT_IN_OPENAI_KEY = process.env.HAS_BUILT_IN_OPENAI_KEY === "true";
 
 const RULE_ID_SET = new Set<string>(RULE_IDS);
 
@@ -74,6 +81,8 @@ export function Options() {
   const [displayMode, setDisplayMode] = useState<PlaceholderDisplayMode | null>(
     null,
   );
+  const [availability, setAvailability] =
+    useState<RuleAvailabilityStates | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -86,20 +95,27 @@ export function Options() {
     getPlaceholderDisplayMode().then((mode) => {
       if (!cancelled) setDisplayMode(mode);
     });
+    getRuleAvailabilityStates().then((initial) => {
+      if (!cancelled) setAvailability(initial);
+    });
     const unsubscribe = subscribe((next) => {
       setStates(next);
     });
     const unsubscribeMode = subscribePlaceholderDisplayMode((mode) => {
       setDisplayMode(mode);
     });
+    const unsubscribeAvailability = subscribeRuleAvailability((next) => {
+      setAvailability(next);
+    });
     return () => {
       cancelled = true;
       unsubscribe();
       unsubscribeMode();
+      unsubscribeAvailability();
     };
   }, []);
 
-  if (!states) {
+  if (!states || !availability) {
     return <div className="loading">Loading…</div>;
   }
 
@@ -263,7 +279,7 @@ export function Options() {
         </fieldset>
       </section>
 
-      <section id="api-key" className="section section--unavailable">
+      <section id="api-key" className="section">
         <h2>
           <a
             href="#api-key"
@@ -272,22 +288,19 @@ export function Options() {
           >
             #
           </a>
-          OpenAI API key <span className="badge">Unavailable</span>
+          OpenAI API key
         </h2>
         <p className="hint">
-          Used by the <code>irrelevant-sections-hide</code> rule, which is
-          currently turned off in this build. Saving a key has no effect until
-          that rule is re-enabled.{" "}
+          Used by the <code>irrelevant-sections-hide</code> rule.{" "}
           {HAS_BUILT_IN_OPENAI_KEY
-            ? "A built-in key is bundled with this build."
-            : "No built-in key is bundled with this build."}
+            ? "A built-in key is bundled with this build; saving a key here overrides it."
+            : "No built-in key is bundled with this build — provide one here to enable the rule."}
         </p>
         <input
           type="password"
           className="api-key-input"
           autoComplete="off"
           spellCheck={false}
-          disabled
           placeholder={
             HAS_BUILT_IN_OPENAI_KEY ? "(blank — using built-in key)" : "sk-..."
           }
@@ -295,7 +308,7 @@ export function Options() {
           onChange={(event) => setApiKeyDraft(event.target.value)}
         />
         <div className="button-row">
-          <button type="button" onClick={handleSaveApiKey} disabled>
+          <button type="button" onClick={handleSaveApiKey}>
             Save key
           </button>
           {apiKeyStatus && (
@@ -315,7 +328,8 @@ export function Options() {
         </h2>
         <ul className="rules">
           {RULES.map((rule) => {
-            const unavailable = rule.available === false;
+            const snapshot = availability[rule.id];
+            const unavailable = !snapshot?.available;
             return (
               <li
                 key={rule.id}
@@ -341,10 +355,8 @@ export function Options() {
                         <span className="badge">Unavailable</span>
                       )}
                     </strong>
-                    {unavailable && rule.unavailableReason && (
-                      <p className="unavailable-reason">
-                        {rule.unavailableReason}
-                      </p>
+                    {unavailable && snapshot?.reason && (
+                      <p className="unavailable-reason">{snapshot.reason}</p>
                     )}
                     <p>{rule.description}</p>
                   </div>

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -3,6 +3,11 @@
 
 import { useEffect, useState } from "react";
 import {
+  getRuleAvailabilityStates,
+  type RuleAvailabilityStates,
+  subscribeRuleAvailability,
+} from "../lib/availability";
+import {
   getEnforcementEnabled,
   setEnforcementEnabled,
   subscribeEnforcementEnabled,
@@ -20,6 +25,8 @@ export function Popup() {
   const [enforcementEnabled, setEnforcementState] = useState<boolean | null>(
     null,
   );
+  const [availability, setAvailability] =
+    useState<RuleAvailabilityStates | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -29,20 +36,27 @@ export function Popup() {
     getEnforcementEnabled().then((value) => {
       if (!cancelled) setEnforcementState(value);
     });
+    getRuleAvailabilityStates().then((initial) => {
+      if (!cancelled) setAvailability(initial);
+    });
     const unsubscribe = subscribe((next) => {
       setStates(next);
     });
     const unsubscribeEnforcement = subscribeEnforcementEnabled((value) => {
       setEnforcementState(value);
     });
+    const unsubscribeAvailability = subscribeRuleAvailability((next) => {
+      setAvailability(next);
+    });
     return () => {
       cancelled = true;
       unsubscribe();
       unsubscribeEnforcement();
+      unsubscribeAvailability();
     };
   }, []);
 
-  if (!states || enforcementEnabled === null) {
+  if (!states || enforcementEnabled === null || !availability) {
     return <div className="loading">Loading…</div>;
   }
 
@@ -97,7 +111,8 @@ export function Popup() {
         }
       >
         {RULES.map((rule) => {
-          const unavailable = rule.available === false;
+          const snapshot = availability[rule.id];
+          const unavailable = !snapshot?.available;
           const disabled = unavailable || !enforcementEnabled;
           return (
             <li
@@ -122,10 +137,8 @@ export function Popup() {
                     {rule.label}
                     {unavailable && <span className="badge">Unavailable</span>}
                   </strong>
-                  {unavailable && rule.unavailableReason && (
-                    <p className="unavailable-reason">
-                      {rule.unavailableReason}
-                    </p>
+                  {unavailable && snapshot?.reason && (
+                    <p className="unavailable-reason">{snapshot.reason}</p>
                   )}
                   <p>{rule.description}</p>
                 </div>

--- a/extension/src/rules/irrelevant-sections-hide.ts
+++ b/extension/src/rules/irrelevant-sections-hide.ts
@@ -17,6 +17,7 @@ import {
   pruneReferences,
   resolveReference,
 } from "../lib/automation-element-reference";
+import { createApiKeyAvailability } from "../lib/availability";
 import { isInsidePlaceholder } from "../lib/dom-utils";
 import { classifyIrrelevantSections } from "../lib/llm-client";
 import { log } from "../lib/log";
@@ -310,10 +311,11 @@ export const irrelevantSectionsHideRule = {
   id: RULE_ID,
   label: "Hide Irrelevant Sections (AI)",
   description:
-    "Use a small LLM to identify engagement/exploration rails (related products, 'you might also like', recommended articles, trending now, etc.) and replace them with click-to-reveal placeholders. Sends a compressed page tree with stable refs so the LLM can choose the right granularity; interactive elements (search, cart, checkout, login) are labeled as protected. Re-scans on scroll to catch lazy-loaded content. Requires OPENAI_API_KEY at build time.",
+    "Use a small LLM to identify engagement/exploration rails (related products, 'you might also like', recommended articles, trending now, etc.) and replace them with click-to-reveal placeholders. Sends a compressed page tree with stable refs so the LLM can choose the right granularity; interactive elements (search, cart, checkout, login) are labeled as protected. Re-scans on scroll to catch lazy-loaded content. Requires an OpenAI API key (bundled at build time or provided on the options page).",
   defaultEnabled: false,
-  available: false,
-  unavailableReason: "LLM-based detection is turned off in this build.",
+  available: createApiKeyAvailability(
+    "Set an OpenAI API key on the options page to enable this rule.",
+  ),
   // Page-level recommendation rails live on the top frame; classifying the
   // contents of every iframe would multiply LLM cost without benefit.
   topFrameOnly: true,

--- a/extension/src/rules/types.ts
+++ b/extension/src/rules/types.ts
@@ -1,6 +1,23 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
+export interface AvailabilitySnapshot {
+  available: boolean;
+  // Optional human-readable explanation rendered alongside the disabled toggle
+  // in the popup/options when `available` is false.
+  reason?: string;
+}
+
+// Reactive availability accessor. Use when a rule's availability depends on
+// runtime state that can change after install (e.g. user-supplied credentials
+// in storage). The popup, options page, and rule engine call `get()` to read
+// the current snapshot and `subscribe()` to refresh when the underlying state
+// changes.
+export interface RuleAvailability {
+  get(): Promise<AvailabilitySnapshot>;
+  subscribe(listener: () => void): () => void;
+}
+
 export interface Rule {
   id: string;
   label: string;
@@ -8,13 +25,12 @@ export interface Rule {
   // Initial state on a fresh install. Overridden by anything the user has
   // toggled in the popup/options page.
   defaultEnabled: boolean;
-  // When false, the rule is shown in the UI as unavailable: the toggle is
-  // disabled and the engine never applies it, regardless of stored state.
-  // Use for rules temporarily turned off at the build level (e.g. while the
-  // backing capability is offline).
-  available?: boolean;
-  // Optional note rendered alongside the disabled toggle when `available` is
-  // false, explaining why the rule is unavailable.
+  // - omitted / `true` — always available
+  // - `false` — statically unavailable (e.g. backing capability turned off at
+  //   build time); pair with `unavailableReason` for the UI
+  // - `RuleAvailability` — reactive accessor for runtime-dependent rules. The
+  //   snapshot's own `reason` takes precedence over `unavailableReason`.
+  available?: boolean | RuleAvailability;
   unavailableReason?: string;
   // When true, the rule is only applied in the top-level browsing context.
   // Set this for rules whose targets are inherently page-wide (site footer,

--- a/skills/agent-browser-shield-config/SKILL.md
+++ b/skills/agent-browser-shield-config/SKILL.md
@@ -69,10 +69,10 @@ keys and non-boolean values are rejected with an error.
   IKEA, Home Depot, REI, GitHub, Wikipedia, Hacker News, hn.algolia.com, MDN,
   npm, weather.gov, arXiv, Python docs, BBC) so agents can navigate by URL
   instead of typing into search boxes
-- `irrelevant-sections-hide` — **currently unavailable** (LLM-based detection is
-  turned off in this build). The toggle shows in the popup and options page as
-  disabled. AI-classified hide of engagement / exploration rails (related
-  products, "you might also like", recommended articles, trending now,
-  sponsored, site-wide navigation rails). Calls a small LLM in the background
-  worker; requires `OPENAI_API_KEY` injected at build time. Hidden sections
-  become click-to-reveal placeholders.
+- `irrelevant-sections-hide` — AI-classified hide of engagement / exploration
+  rails (related products, "you might also like", recommended articles, trending
+  now, sponsored, site-wide navigation rails). Calls a small LLM in the
+  background worker; requires an OpenAI API key — either bundled at build time
+  via `OPENAI_API_KEY` or saved on the options page. Until a key is configured
+  the toggle shows as Unavailable. Hidden sections become click-to-reveal
+  placeholders.


### PR DESCRIPTION
## Summary

- The `irrelevant-sections-hide` rule was hardcoded `available: false` with reason "LLM-based detection is turned off in this build", and the options page's API-key section was hardcoded as unavailable with disabled input + Save button — even though the background classifier already does `userKey || BUILT_IN_API_KEY`. This PR makes the rule reactively available whenever a key exists (bundled or user-saved) and un-gates the API-key UI.
- `Rule.available` now accepts a `RuleAvailability` accessor (`get()` + `subscribe()`) alongside the existing static boolean. A new `lib/availability.ts` module resolves snapshots and fans out change notifications. Popup, options, and the rule engine all subscribe — toggle flips from Unavailable the moment a key is saved, no reload needed.
- Storage no longer force-disables "unavailable" rules in normalize: when availability is gated on a runtime signal (e.g. user key), the user's toggle preference needs to survive availability changes so it takes effect immediately on flip. The engine already gates at apply time, so this is safe.

## Test plan

- [x] `bun run test` — 385 passing
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run build` — clean
- [x] `bun run check` — no new biome findings (one pre-existing warning unrelated)
- [ ] Load the unpacked dist in Chrome with **no** `.env`, open Options → API key section is enabled; popup shows the LLM rule as Unavailable with the new reason
- [ ] Save a key on the Options page → both popup and Options flip the rule from Unavailable without reload; toggling it on triggers classification on the next page load
- [ ] Clear the saved key → rule returns to Unavailable; previously enabled toggle reverts to disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)