### PR TITLE
chore(extension): shorten rule descriptions in popup and options

### DIFF
--- a/extension/src/rules/ads-hide.ts
+++ b/extension/src/rules/ads-hide.ts
@@ -68,7 +68,7 @@ const { rule: baseRule, selectorsFor } = createSelectorHideRule({
   id: "ads-hide",
   label: "Hide Ads & Sponsored Results",
   description:
-    "Remove display ads and paid/sponsored search results. Well-known surfaces (AdSense, GAM, Outbrain, Taboola, Google/Bing/Amazon sponsored results) are stripped from the DOM so the agent never sees them. ~13k additional ad selectors from EasyList are injected as a display:none stylesheet for broader coverage of third-party ad networks.",
+    "Remove display ads and paid/sponsored search results. Uses EasyList for broad coverage.",
   defaultEnabled: true,
   removeEntirely: true,
   alwaysOnSelectors: [

--- a/extension/src/rules/cart-addon-flag.ts
+++ b/extension/src/rules/cart-addon-flag.ts
@@ -186,7 +186,7 @@ export const cartAddonFlagRule = {
   id: RULE_ID,
   label: "Flag Cart Add-Ons (Sneak-Into-Basket)",
   description:
-    'On checkout-like URLs (/cart, /checkout, /basket, /bag, /payment, /order), prepend a visible "[abs: likely cart add-on]" annotation onto line items matching common sneak-into-basket patterns (protection plans, extended warranties, AppleCare/SquareTrade/Asurion, insurance, donation/round-up, gift wrap, carbon offset, shipping/package protection, Route, Seel, Navidium, driver tips). The line item is NOT removed — the agent reads the annotation and decides whether to click the line\'s remove control.',
+    "On checkout pages, flag likely sneak-into-basket line items (protection plans, warranties, insurance, donations, gift wrap, etc.) with a visible annotation. Items are not removed.",
   defaultEnabled: true,
   apply,
   teardown: () => watcher.stop(),

--- a/extension/src/rules/chat-widget-hide.ts
+++ b/extension/src/rules/chat-widget-hide.ts
@@ -16,8 +16,7 @@ import { createSelectorHideRule } from "../lib/selector-hide-rule";
 const { rule, selectorsFor } = createSelectorHideRule({
   id: "chat-widget-hide",
   label: "Remove Chat Widgets",
-  description:
-    "Remove live-chat widgets (Intercom, Drift, Zendesk, etc.).",
+  description: "Remove live-chat widgets (Intercom, Drift, Zendesk, etc.).",
   defaultEnabled: true,
   removeEntirely: true,
   alwaysOnSelectors: [

--- a/extension/src/rules/chat-widget-hide.ts
+++ b/extension/src/rules/chat-widget-hide.ts
@@ -17,7 +17,7 @@ const { rule, selectorsFor } = createSelectorHideRule({
   id: "chat-widget-hide",
   label: "Remove Chat Widgets",
   description:
-    "Remove live-chat widgets (Intercom, Drift, Zendesk, Crisp, Tawk.to, HubSpot, Olark, LiveChat, Freshchat, Zopim). These bubbles float above the page, so they're removed entirely rather than replaced with an in-flow placeholder.",
+    "Remove live-chat widgets (Intercom, Drift, Zendesk, etc.).",
   defaultEnabled: true,
   removeEntirely: true,
   alwaysOnSelectors: [

--- a/extension/src/rules/checkout-checkbox-clear.ts
+++ b/extension/src/rules/checkout-checkbox-clear.ts
@@ -80,7 +80,7 @@ export const checkoutCheckboxClearRule = {
   id: RULE_ID,
   label: "Clear Checkout Checkboxes",
   description:
-    'On checkout-like URLs (/cart, /checkout, /basket, /bag, /payment, /order), uncheck every pre-checked checkbox so the agent inherits no silently selected add-ons (insurance, warranty, gift wrap, donations, marketing opt-ins). The agent is then expected to re-check anything it actually wants to opt into, including required agreements. ARIA role="checkbox" widgets and radio groups are out of scope.',
+    "On checkout pages, uncheck pre-checked checkboxes so the agent doesn't silently inherit add-ons or marketing opt-ins.",
   defaultEnabled: true,
   apply,
   teardown: () => watcher.stop(),

--- a/extension/src/rules/comments-hide.ts
+++ b/extension/src/rules/comments-hide.ts
@@ -15,7 +15,7 @@ const { rule, selectorsFor } = createSelectorHideRule({
   id: "comments-hide",
   label: "Hide Comments",
   description:
-    "Hide user-generated comment threads so agents aren't exposed to potential prompt injection from commenters. Covers common platforms (Disqus, Facebook) plus Reddit, YouTube, and Hacker News.",
+    "Hide user-generated comment threads (Disqus, Facebook, Reddit, YouTube, Hacker News).",
   defaultEnabled: true,
   hideLabel: "[comment section hidden — click to reveal]",
   // Selectors that ship on many sites (Disqus, Livefyre, Facebook comment

--- a/extension/src/rules/cookie-banner-hide.ts
+++ b/extension/src/rules/cookie-banner-hide.ts
@@ -27,7 +27,7 @@ const { rule, selectorsFor } = createSelectorHideRule({
   id: "cookie-banner-hide",
   label: "Remove Cookie Banners",
   description:
-    "Remove GDPR/CCPA cookie consent banners (OneTrust, Cookiebot, TrustArc, Sourcepoint, Quantcast, Osano, Didomi, and generic patterns). These overlays float above the page, so they're removed entirely rather than replaced with an in-flow placeholder.",
+    "Remove GDPR/CCPA cookie consent banners.",
   defaultEnabled: true,
   removeEntirely: true,
   alwaysOnSelectors: [

--- a/extension/src/rules/cookie-banner-hide.ts
+++ b/extension/src/rules/cookie-banner-hide.ts
@@ -26,8 +26,7 @@ function isOverlay(element: HTMLElement): boolean {
 const { rule, selectorsFor } = createSelectorHideRule({
   id: "cookie-banner-hide",
   label: "Remove Cookie Banners",
-  description:
-    "Remove GDPR/CCPA cookie consent banners.",
+  description: "Remove GDPR/CCPA cookie consent banners.",
   defaultEnabled: true,
   removeEntirely: true,
   alwaysOnSelectors: [

--- a/extension/src/rules/countdown-timer-hide.ts
+++ b/extension/src/rules/countdown-timer-hide.ts
@@ -167,7 +167,7 @@ export const countdownTimerHideRule = {
   id: RULE_ID,
   label: "Hide Countdown Timers",
   description:
-    "Hide running countdown timers so agents aren't pressured by the artificial time-sensitivity dark pattern. Snapshots timer-shaped text and confirms the value decreased after 1.5s; re-scans on subtree mutations to catch lazy-loaded sections.",
+    "Hide running countdown timers (artificial-urgency dark pattern).",
   defaultEnabled: true,
   apply,
   teardown,

--- a/extension/src/rules/footer-hide.ts
+++ b/extension/src/rules/footer-hide.ts
@@ -29,7 +29,7 @@ const { rule, selectorsFor } = createSelectorHideRule({
   id: "footer-hide",
   label: "Hide Page Footer",
   description:
-    "Hide the page footer (legal links, sitemap, social icons, marketing copy) to save tokens. Per-section footers inside articles or asides are left visible.",
+    "Hide the page footer (legal links, sitemap, social) to save tokens.",
   defaultEnabled: true,
   hideLabel: "[footer hidden — click to reveal]",
   alwaysOnSelectors: [

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -257,7 +257,7 @@ export const hiddenTextStripRule = {
   id: RULE_ID,
   label: "Strip Hidden Text",
   description:
-    'Remove text that is invisible to humans (foreground matching background, visibility:hidden, opacity:0, font-size:0, off-screen positioning, zero-area clipping) but still readable by agents. Defends against "unseeable" prompt injection. Screen-reader-only text is preserved via class (.sr-only, .visually-hidden, .a-offscreen, .aok-offscreen, MUI visuallyHidden) and via the 1×1 + overflow:hidden + position:absolute envelope, so a11y-tree affordances like Amazon SERP prices stay intact regardless of which specific clip/positioning trick the framework uses. display:none is left alone so collapsed menus and tab panels keep working.',
+    'Remove text invisible to humans but readable by agents. Defends against "unseeable" prompt injection; screen-reader-only text is preserved.',
   defaultEnabled: true,
   apply,
   teardown: () => watcher.stop(),

--- a/extension/src/rules/html-comment-strip.ts
+++ b/extension/src/rules/html-comment-strip.ts
@@ -58,7 +58,7 @@ export const htmlCommentStripRule = {
   id: RULE_ID,
   label: "Strip HTML Comments",
   description:
-    "Remove HTML comments from the page. Comments are invisible to humans but readable by agents and can carry prompt-injection payloads. Comments inside <script>/<style>/<noscript> are preserved. Removal is not reversible within the current page load.",
+    "Remove HTML comments. Invisible to humans but readable by agents and can carry prompt-injection payloads.",
   defaultEnabled: true,
   apply,
   teardown: () => watcher.stop(),

--- a/extension/src/rules/irrelevant-sections-hide.ts
+++ b/extension/src/rules/irrelevant-sections-hide.ts
@@ -311,7 +311,7 @@ export const irrelevantSectionsHideRule = {
   id: RULE_ID,
   label: "Hide Irrelevant Sections (AI)",
   description:
-    "Use a small LLM to identify engagement/exploration rails (related products, 'you might also like', recommended articles, trending now, etc.) and replace them with click-to-reveal placeholders. Sends a compressed page tree with stable refs so the LLM can choose the right granularity; interactive elements (search, cart, checkout, login) are labeled as protected. Re-scans on scroll to catch lazy-loaded content. Requires an OpenAI API key (bundled at build time or provided on the options page).",
+    "Use a small LLM to identify engagement rails (related products, recommended articles, trending now) and replace them with click-to-reveal placeholders.",
   defaultEnabled: false,
   available: createApiKeyAvailability(
     "Set an OpenAI API key on the options page to enable this rule.",

--- a/extension/src/rules/newsletter-modal-hide.ts
+++ b/extension/src/rules/newsletter-modal-hide.ts
@@ -57,7 +57,7 @@ const { rule, selectorsFor } = createSelectorHideRule({
   id: "newsletter-modal-hide",
   label: "Remove Newsletter Modals",
   description:
-    "Remove interstitial newsletter signup modals that cover the page. Detects fixed-position dialogs containing signup language and an email input. These modals float above the page, so they're removed entirely rather than replaced with an in-flow placeholder. Standard login modals, paywalls, and small toasts are kept visible.",
+    "Remove interstitial newsletter signup modals. Login modals and paywalls stay visible.",
   defaultEnabled: true,
   removeEntirely: true,
   alwaysOnSelectors: [

--- a/extension/src/rules/prompt-injection-hide.ts
+++ b/extension/src/rules/prompt-injection-hide.ts
@@ -69,7 +69,7 @@ export const promptInjectionHideRule = {
   id: RULE_ID,
   label: "Hide Prompt Injection",
   description:
-    "Hide page sections containing phrases commonly used in prompt-injection attacks — instruction overrides, jailbreak personas, and chat-template tokens. Regex-based heuristic; an ML classifier is planned.",
+    "Hide page sections containing phrases common in prompt-injection attacks.",
   defaultEnabled: true,
   apply,
 } satisfies Rule;

--- a/extension/src/rules/reviews-hide.ts
+++ b/extension/src/rules/reviews-hide.ts
@@ -15,7 +15,7 @@ const { rule, selectorsFor } = createSelectorHideRule({
   id: "reviews-hide",
   label: "Hide Reviews",
   description:
-    "Hide user-generated review text so agents aren't exposed to potential prompt injection from reviewers. Covers schema.org microdata and supported sites (Amazon, Walmart); aggregate star ratings are kept visible.",
+    "Hide user-generated review text. Aggregate star ratings stay visible.",
   defaultEnabled: true,
   hideLabel: "[review section hidden — click to reveal]",
   // schema.org/Review marks UGC. schema.org/AggregateRating is the summary

--- a/extension/src/rules/scarcity-hide.ts
+++ b/extension/src/rules/scarcity-hide.ts
@@ -101,7 +101,7 @@ export const scarcityHideRule = {
   id: RULE_ID,
   label: "Hide Scarcity Warnings",
   description:
-    'Hide scarcity- and activity-based urgency messages ("Only 3 left", "Selling fast", "12 viewing now") so agents aren\'t pressured by manufactured scarcity. Out-of-stock indicators and bestseller badges are kept visible because they convey real purchaseability or preference information.',
+    'Hide scarcity messages like "Only 3 left" or "12 viewing now". Out-of-stock indicators and bestseller badges stay visible.',
   defaultEnabled: true,
   apply,
   teardown: () => watcher.stop(),

--- a/extension/src/rules/search-url-helper.ts
+++ b/extension/src/rules/search-url-helper.ts
@@ -73,7 +73,7 @@ export const searchUrlHelperRule = {
   id: RULE_ID,
   label: "Embed Search URL Recipes",
   description:
-    "On covered hosts (Amazon, Best Buy, Etsy, IKEA, Home Depot, REI, GitHub, Wikipedia, Hacker News, MDN, npm, weather.gov, arXiv, Python docs, BBC), embed a screen-reader-only landmark at the top of the page describing how to run searches, filters, sorts, and direct lookups via URL. Lets agents navigate by URL instead of typing into search boxes and clicking facets. No visible affordance — landmark is preserved by `hidden-text-strip` via the `sr-only` class allowlist and the 1×1 + overflow:hidden + position:absolute envelope.",
+    "On covered hosts, embed a screen-reader-only landmark describing how to run searches and filters by URL, so agents can navigate by URL instead of clicking through search UI.",
   defaultEnabled: true,
   // Recipes are URL navigation hints for the page the agent is viewing —
   // the top-level URL — not for whatever third-party content happens to be

--- a/extension/src/rules/social-embed-hide.ts
+++ b/extension/src/rules/social-embed-hide.ts
@@ -23,7 +23,7 @@ const { rule, selectorsFor } = createSelectorHideRule({
   id: "social-embed-hide",
   label: "Hide Social Embeds",
   description:
-    "Hide embedded social-media widgets (Twitter/X, YouTube, Facebook, Instagram, TikTok, LinkedIn, Reddit, Spotify, SoundCloud). Replaced with a placeholder so the agent knows an embed lived there. Skipped on the embed providers' own domains where embeds are the page content.",
+    "Hide embedded social-media widgets (Twitter/X, YouTube, Facebook, Instagram, TikTok, etc.). Replaced with a placeholder.",
   defaultEnabled: true,
   hideLabel: "[social embed hidden — click to reveal]",
   alwaysOnSelectors: [

--- a/extension/src/rules/svg-sprite-suppress.ts
+++ b/extension/src/rules/svg-sprite-suppress.ts
@@ -93,7 +93,7 @@ export const svgSpriteSuppressRule = {
   id: RULE_ID,
   label: "Remove Unused SVG Sprites",
   description:
-    "Remove hidden SVG sprite containers (those holding only <symbol>/<defs> definitions) when none of their symbols are referenced by any <use> element on the page. Referenced sprites are preserved so icons keep working.",
+    "Remove hidden SVG sprite containers whose symbols aren't referenced on the page.",
   defaultEnabled: true,
   apply,
   teardown: () => watcher.stop(),


### PR DESCRIPTION
## Summary
- Trim each rule's `description` so the popup and options UI carry only the minimal text needed to understand what the rule does — verbose implementation detail (selector lists, vendor catalogs, internal mechanism) moved out of the user-facing string.
- Drop the sub-category enumeration and the "ML classifier is planned" line from `prompt-injection-hide` (sub-categories and aspirational behavior shouldn't appear in user-facing surfaces).
- Drop the trailing "Requires an OpenAI API key" from `irrelevant-sections-hide` — the `unavailable-reason` italic already surfaces this, and only when actionable.

`pii-mask` and `secrets-mask` were already concise; left as-is. No tests assert on description text.

## Test plan
- [ ] `bun run build` succeeds
- [ ] Load the extension and visually scan the popup — each rule reads cleanly in one short paragraph
- [ ] Options page renders the same descriptions
- [ ] With no OpenAI key set, the "Hide Irrelevant Sections (AI)" row shows the italic "Set an OpenAI API key on the options page to enable this rule" reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)