### PR TITLE
Add ESLint with unicorn plugin and custom rule infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 24
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Biome check (lint + format)
+      - name: Lint (Biome + ESLint)
         run: bun run check
       - name: Typecheck
         run: bunx tsc --noEmit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.14'
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.x
+      - name: Install extension dependencies
+        run: bun install --frozen-lockfile
+        working-directory: extension
       - uses: pre-commit/action@v3.0.1
 
   python:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,16 @@ repos:
         files: ^extension/.*\.(ts|tsx|js|jsx|mjs|cjs|json|jsonc)$
         exclude: ^extension/dist/|\.generated\.(ts|tsx|js|jsx)$
 
+  - repo: local
+    hooks:
+      - id: eslint
+        name: ESLint (unicorn + custom)
+        language: system
+        entry: bash -c 'cd extension && bun run lint:eslint'
+        files: ^extension/.*\.(ts|tsx|js|mjs|cjs)$
+        exclude: ^extension/dist/|\.generated\.(ts|tsx|js|jsx)$
+        pass_filenames: false
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.14
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,24 @@ Ideas explored in this repository:
   for modern JS features
 - Python: use `uv` for all package management
 
+## Linting
+
+Two linters run on `extension/`: Biome owns formatting plus its recommended
+rule set; ESLint runs only rules Biome doesn't have. The split is mechanical —
+do not duplicate a rule between them.
+
+- Biome config: `extension/biome.json`.
+- ESLint config: `extension/eslint.config.js` (flat config) — pulls in
+  `@eslint/js`, `typescript-eslint`, and `eslint-plugin-unicorn`, then disables
+  unicorn rules that overlap with Biome or are too opinionated for this repo.
+- Custom rules: `extension/eslint-rules/*.js`. Each rule is one file, exported
+  via `extension/eslint-rules/index.js` under the
+  `agent-browser-shield/<rule-name>` namespace. Add a rule by dropping a file
+  in `eslint-rules/`, exporting it from `index.js`, and enabling it in
+  `eslint.config.js`.
+- `bun run check` runs Biome then ESLint; `bun run check:fix` runs both with
+  `--fix`/`--write`.
+
 ## Site-specific rule data
 
 Selectors and URL recipes for individual sites live in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,9 @@ Ideas explored in this repository:
 
 ## Linting
 
-Two linters run on `extension/`: Biome owns formatting plus its recommended
-rule set; ESLint runs only rules Biome doesn't have. The split is mechanical —
-do not duplicate a rule between them.
+Two linters run on `extension/`: Biome owns formatting plus its recommended rule
+set; ESLint runs only rules Biome doesn't have. The split is mechanical — do not
+duplicate a rule between them.
 
 - Biome config: `extension/biome.json`.
 - ESLint config: `extension/eslint.config.js` (flat config) — pulls in
@@ -49,8 +49,8 @@ do not duplicate a rule between them.
   unicorn rules that overlap with Biome or are too opinionated for this repo.
 - Custom rules: `extension/eslint-rules/*.js`. Each rule is one file, exported
   via `extension/eslint-rules/index.js` under the
-  `agent-browser-shield/<rule-name>` namespace. Add a rule by dropping a file
-  in `eslint-rules/`, exporting it from `index.js`, and enabling it in
+  `agent-browser-shield/<rule-name>` namespace. Add a rule by dropping a file in
+  `eslint-rules/`, exporting it from `index.js`, and enabling it in
   `eslint.config.js`.
 - `bun run check` runs Biome then ESLint; `bun run check:fix` runs both with
   `--fix`/`--write`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ bun install
 bun run build       # writes extension/dist/
 bun run watch       # rebuilds on change
 bun run test        # Jest unit tests
-bun run check       # Biome lint + format
+bun run check       # Biome (lint + format) + ESLint (unicorn + custom rules)
 ```
 
 Load `extension/dist/` as unpacked at `chrome://extensions`.
@@ -76,8 +76,8 @@ See [`benchmark/README.md`](./benchmark/README.md) for the full workflow.
   `skills/agent-browser-shield-diagnose/SKILL.md`.
 - **Commit messages.** Imperative mood, brief subject, body explains motivation
   when it's not obvious.
-- **Don't bypass hooks.** Pre-commit hooks run gitleaks, Biome, Ruff, and
-  markdownlint. Fix the issue rather than passing `--no-verify`.
+- **Don't bypass hooks.** Pre-commit hooks run gitleaks, Biome, ESLint, Ruff,
+  and markdownlint. Fix the issue rather than passing `--no-verify`.
 
 ## Adding a new rule
 

--- a/extension/build.ts
+++ b/extension/build.ts
@@ -20,7 +20,7 @@ function readEnvValue(name: string): string {
   for (const candidate of [join(ROOT, ".env"), join(ROOT, "..", ".env")]) {
     let content: string;
     try {
-      content = readFileSync(candidate, "utf-8");
+      content = readFileSync(candidate, "utf8");
     } catch {
       continue;
     }

--- a/extension/bun.lock
+++ b/extension/bun.lock
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
+        "@eslint/js": "10.0.1",
         "@types/bun": "^1.3.14",
         "@types/chrome": "^0.1.42",
         "@types/jest": "^30.0.0",
@@ -21,12 +22,16 @@
         "@types/lodash": "^4.17.24",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
+        "eslint": "10.4.0",
+        "eslint-plugin-unicorn": "64.0.0",
+        "globals": "17.6.0",
         "jest": "^30",
         "jest-environment-jsdom": "^30",
         "js-yaml": "^4.1.0",
         "jsdom": "29.1.1",
         "ts-jest": "^29",
         "typescript": "^6.0.3",
+        "typescript-eslint": "8.59.4",
         "zod": "^4.4.3",
       },
     },
@@ -148,7 +153,33 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.6.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA=="],
+
+    "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
+
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
+
     "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -230,6 +261,10 @@
 
     "@types/chrome": ["@types/chrome@0.1.42", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-tdT2roFqGecZZDjA9fUEAINb2STxSPifHMDvY6EfRjNRCjdrs/0FwKt5RCIA9MKMd1arAYZZL3nwEkp6ZLZu2w=="],
 
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
     "@types/filesystem": ["@types/filesystem@0.0.36", "", { "dependencies": { "@types/filewriter": "*" } }, "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA=="],
 
     "@types/filewriter": ["@types/filewriter@0.0.33", "", {}, "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g=="],
@@ -250,6 +285,8 @@
 
     "@types/jsdom": ["@types/jsdom@28.0.3", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^8.0.0", "undici-types": "^7.21.0" } }, "sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ=="],
 
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
     "@types/lodash": ["@types/lodash@4.17.24", "", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
@@ -265,6 +302,26 @@
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.4", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.4", "@typescript-eslint/type-utils": "8.59.4", "@typescript-eslint/utils": "8.59.4", "@typescript-eslint/visitor-keys": "8.59.4", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.4", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.4", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.4", "@typescript-eslint/types": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4", "@typescript-eslint/visitor-keys": "8.59.4", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.4", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.4", "@typescript-eslint/types": "^8.59.4", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.4", "", { "dependencies": { "@typescript-eslint/types": "8.59.4", "@typescript-eslint/visitor-keys": "8.59.4" } }, "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.4", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.4", "", { "dependencies": { "@typescript-eslint/types": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4", "@typescript-eslint/utils": "8.59.4", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.4", "", {}, "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.4", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.4", "@typescript-eslint/tsconfig-utils": "8.59.4", "@typescript-eslint/types": "8.59.4", "@typescript-eslint/visitor-keys": "8.59.4", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.4", "@typescript-eslint/types": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.4", "", { "dependencies": { "@typescript-eslint/types": "8.59.4", "eslint-visitor-keys": "^5.0.0" } }, "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
@@ -312,7 +369,13 @@
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.12.2", "", { "os": "win32", "cpu": "x64" }, "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA=="],
 
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
@@ -334,13 +397,13 @@
 
     "babel-preset-jest": ["babel-preset-jest@29.6.3", "", { "dependencies": { "babel-plugin-jest-hoist": "^29.6.3", "babel-preset-current-node-syntax": "^1.0.0" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.32", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -352,6 +415,8 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "builtin-modules": ["builtin-modules@5.2.0", "", {}, "sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
@@ -362,11 +427,15 @@
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
+
     "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
+
+    "clean-regexp": ["clean-regexp@1.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -381,6 +450,8 @@
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "core-js-compat": ["core-js-compat@3.49.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -397,6 +468,8 @@
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
@@ -416,9 +489,27 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
-    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@10.4.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ=="],
+
+    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@64.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "@eslint-community/eslint-utils": "^4.9.1", "change-case": "^5.4.4", "ci-info": "^4.4.0", "clean-regexp": "^1.0.0", "core-js-compat": "^3.49.0", "find-up-simple": "^1.0.1", "globals": "^17.4.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regexp-tree": "^0.1.27", "regjsparser": "^0.13.0", "semver": "^7.7.4", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=9.38.0" } }, "sha512-rNZwalHh8i0UfPlhNwg5BTUO1CMdKNmjqe+TgzOTZnpKoi8VBgsW7u9qCHIdpxEzZ1uwrJrPF0uRb7l//K38gA=="],
+
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
@@ -426,13 +517,27 @@
 
     "expect": ["expect@30.4.1", "", { "dependencies": { "@jest/expect-utils": "30.4.1", "@jest/get-type": "30.1.0", "jest-matcher-utils": "30.4.1", "jest-message-util": "30.4.1", "jest-mock": "30.4.1", "jest-util": "30.4.1" } }, "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
     "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
 
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
@@ -449,6 +554,10 @@
     "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -468,9 +577,13 @@
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
     "import-local": ["import-local@3.2.0", "", { "dependencies": { "pkg-dir": "^4.2.0", "resolve-cwd": "^3.0.0" }, "bin": { "import-local-fixture": "fixtures/cli.js" } }, "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
@@ -478,9 +591,15 @@
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
+    "is-builtin-module": ["is-builtin-module@5.0.0", "", { "dependencies": { "builtin-modules": "^5.0.0" } }, "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-generator-fn": ["is-generator-fn@2.1.0", "", {}, "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -562,15 +681,25 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
@@ -592,7 +721,7 @@
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
-    "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -622,9 +751,11 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
-    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
@@ -650,6 +781,10 @@
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
+    "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
     "pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -663,6 +798,10 @@
     "react-is-18": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "react-is-19": ["react-is@19.2.6", "", {}, "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw=="],
+
+    "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
+
+    "regjsparser": ["regjsparser@0.13.1", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -714,6 +853,8 @@
 
     "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
+    "strip-indent": ["strip-indent@4.1.1", "", {}, "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA=="],
+
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -723,6 +864,8 @@
     "synckit": ["synckit@0.11.13", "", { "dependencies": { "@pkgr/core": "^0.3.6" } }, "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg=="],
 
     "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "tldts": ["tldts@7.0.32", "", { "dependencies": { "tldts-core": "^7.0.32" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-5eDV0tK2NhLAAqBeXDAQ36+EwuStd1HbsSOnGsp+JbExITnExcALLL5M1kTH8gjDYN5QvwmUWimE3GoMZ2A7xQ=="],
 
@@ -736,15 +879,21 @@
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
     "ts-jest": ["ts-jest@29.4.11", "", { "dependencies": { "bs-logger": "^0.2.6", "fast-json-stable-stringify": "^2.1.0", "handlebars": "^4.7.9", "json5": "^2.2.3", "lodash.memoize": "^4.1.2", "make-error": "^1.3.6", "semver": "^7.8.0", "type-fest": "^4.41.0", "yargs-parser": "^21.1.1" }, "peerDependencies": { "@babel/core": ">=7.0.0-beta.0 <8", "@jest/transform": "^29.0.0 || ^30.0.0", "@jest/types": "^29.0.0 || ^30.0.0", "babel-jest": "^29.0.0 || ^30.0.0", "esbuild": "*", "jest": "^29.0.0 || ^30.0.0", "jest-util": "^29.0.0 || ^30.0.0", "typescript": ">=4.3 <7" }, "optionalPeers": ["@babel/core", "@jest/transform", "@jest/types", "babel-jest", "esbuild", "jest-util"], "bin": { "ts-jest": "cli.js" } }, "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.59.4", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.4", "@typescript-eslint/parser": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4", "@typescript-eslint/utils": "8.59.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
@@ -755,6 +904,8 @@
     "unrs-resolver": ["unrs-resolver@1.12.2", "", { "dependencies": { "napi-postinstall": "^0.3.4" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.12.2", "@unrs/resolver-binding-android-arm64": "1.12.2", "@unrs/resolver-binding-darwin-arm64": "1.12.2", "@unrs/resolver-binding-darwin-x64": "1.12.2", "@unrs/resolver-binding-freebsd-x64": "1.12.2", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2", "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2", "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2", "@unrs/resolver-binding-linux-arm64-musl": "1.12.2", "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2", "@unrs/resolver-binding-linux-loong64-musl": "1.12.2", "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2", "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2", "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2", "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2", "@unrs/resolver-binding-linux-x64-gnu": "1.12.2", "@unrs/resolver-binding-linux-x64-musl": "1.12.2", "@unrs/resolver-binding-openharmony-arm64": "1.12.2", "@unrs/resolver-binding-wasm32-wasi": "1.12.2", "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2", "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2", "@unrs/resolver-binding-win32-x64-msvc": "1.12.2" } }, "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
 
@@ -773,6 +924,8 @@
     "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
@@ -808,6 +961,8 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -815,6 +970,8 @@
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@istanbuljs/load-nyc-config/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "@istanbuljs/load-nyc-config/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
@@ -840,17 +997,23 @@
 
     "@jest/transform/jest-regex-util": ["jest-regex-util@29.6.3", "", {}, "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg=="],
 
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
     "cssstyle/@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
     "expect/jest-util": ["jest-util@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "jest-changed-files/jest-util": ["jest-util@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw=="],
 
@@ -902,13 +1065,17 @@
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
-
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "test-exclude/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -919,6 +1086,8 @@
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@istanbuljs/load-nyc-config/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
@@ -959,6 +1128,8 @@
     "cssstyle/@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "expect/jest-util/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
 
     "jest-changed-files/jest-util/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
@@ -1020,7 +1191,11 @@
 
     "jest-worker/jest-util/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "@jest/core/@jest/transform/write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -1033,6 +1208,8 @@
     "@jest/transform/jest-haste-map/jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "cssstyle/@asamuzakjp/css-color/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "jest-config/babel-jest/@jest/transform/write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
 
@@ -1052,8 +1229,16 @@
 
     "jest-util/@jest/types/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
+    "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
     "jest-config/babel-jest/@jest/transform/write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "jest-environment-jsdom/jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
+    "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }
 }

--- a/extension/eslint-rules/index.js
+++ b/extension/eslint-rules/index.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Local ESLint plugin for project-specific rules. New rules go in this
+// directory as one file each, then are exported below.
+
+import ruleIdMatchesFilename from "./rule-id-matches-filename.js";
+
+/** @type {import("eslint").ESLint.Plugin} */
+const plugin = {
+  meta: { name: "agent-browser-shield" },
+  rules: {
+    "rule-id-matches-filename": ruleIdMatchesFilename,
+  },
+};
+
+export default plugin;

--- a/extension/eslint-rules/rule-id-matches-filename.js
+++ b/extension/eslint-rules/rule-id-matches-filename.js
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import path from "node:path";
+
+const RULE_FILE_REGEX = /[/\\]src[/\\]rules[/\\][^/\\]+\.tsx?$/;
+
+function isRuleFile(filename) {
+  if (!RULE_FILE_REGEX.test(filename)) return false;
+  const base = path.basename(filename);
+  if (base === "index.ts" || base === "types.ts") return false;
+  if (base.endsWith(".generated.ts") || base.endsWith(".generated.tsx")) {
+    return false;
+  }
+  return true;
+}
+
+function expectedId(filename) {
+  const base = path.basename(filename);
+  return base.replace(/\.tsx?$/, "");
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Rule files in src/rules/ must declare an id matching their filename.",
+    },
+    schema: [],
+    messages: {
+      mismatch: 'Rule id "{{actual}}" does not match filename "{{expected}}".',
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename();
+    if (!isRuleFile(filename)) return {};
+    const expected = expectedId(filename);
+
+    function check(node, value) {
+      if (typeof value !== "string") return;
+      if (value !== expected) {
+        context.report({
+          node,
+          messageId: "mismatch",
+          data: { actual: value, expected },
+        });
+      }
+    }
+
+    return {
+      // const RULE_ID = "...";
+      'VariableDeclarator[id.name="RULE_ID"]'(node) {
+        if (node.init && node.init.type === "Literal") {
+          check(node.init, node.init.value);
+        } else if (
+          node.init &&
+          node.init.type === "TSAsExpression" &&
+          node.init.expression.type === "Literal"
+        ) {
+          check(node.init.expression, node.init.expression.value);
+        }
+      },
+      // { id: "...", ... } — object property in a rule factory call or
+      // exported rule object literal.
+      'Property[key.name="id"][value.type="Literal"]'(node) {
+        check(node.value, node.value.value);
+      },
+    };
+  },
+};
+
+export default rule;

--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// ESLint complements Biome here: Biome owns formatting and the common-error
+// recommended set; ESLint runs only the rules Biome does not have (unicorn's
+// modern-API hints) plus this project's custom rules in `eslint-rules/`.
+
+import js from "@eslint/js";
+import unicorn from "eslint-plugin-unicorn";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+import localPlugin from "./eslint-rules/index.js";
+
+export default tseslint.config(
+  {
+    ignores: [
+      "dist/**",
+      "node_modules/**",
+      "src/**/*.generated.*",
+      "eslint-rules/**",
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  unicorn.configs["flat/recommended"],
+  {
+    languageOptions: {
+      ecmaVersion: 2024,
+      sourceType: "module",
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.webextensions,
+      },
+    },
+    plugins: {
+      "agent-browser-shield": localPlugin,
+    },
+    rules: {
+      "agent-browser-shield/rule-id-matches-filename": "error",
+
+      // Disabled — overlaps with Biome's recommended set or its formatter.
+      "unicorn/no-useless-undefined": "off",
+      "unicorn/no-array-callback-reference": "off",
+      "unicorn/no-nested-ternary": "off",
+
+      // Disabled — too opinionated for this codebase.
+      "unicorn/prevent-abbreviations": "off",
+      "unicorn/no-null": "off",
+      "unicorn/no-array-reduce": "off",
+      "unicorn/no-array-for-each": "off",
+      "unicorn/prefer-module": "off",
+      "unicorn/import-style": "off",
+      "unicorn/no-keyword-prefix": "off",
+      "unicorn/switch-case-braces": "off",
+
+      // Keep but downgrade: useful guidance, but the codebase has many
+      // existing `for…of` loops we don't want to mass-rewrite right now.
+      "unicorn/no-for-loop": "warn",
+
+      // Filenames are kebab-case across the project, except React component
+      // files which follow PascalCase by ecosystem convention.
+      "unicorn/filename-case": [
+        "error",
+        { cases: { kebabCase: true, pascalCase: true } },
+      ],
+
+      // Allow underscore-prefixed unused parameters (e.g. `_root` for the
+      // Rule#apply signature when a rule ignores the argument).
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+  {
+    files: ["src/**/__tests__/**/*.{ts,tsx}"],
+    rules: {
+      // Tests legitimately use literal nulls and many small `for` loops.
+      "unicorn/no-useless-undefined": "off",
+      "unicorn/consistent-function-scoping": "off",
+    },
+  },
+  {
+    files: ["build.ts", "scripts/**/*.{ts,js,mjs,cjs}"],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+    rules: {
+      "unicorn/no-process-exit": "off",
+    },
+  },
+);

--- a/extension/package.json
+++ b/extension/package.json
@@ -27,10 +27,12 @@
     "build-injection-patterns": "bun run scripts/build-injection-patterns.ts",
     "clean": "rm -rf dist",
     "test": "jest",
-    "check": "biome check .",
-    "check:fix": "biome check --write .",
+    "check": "biome check . && eslint .",
+    "check:fix": "biome check --write . && eslint . --fix",
     "format": "biome format --write .",
-    "lint": "biome lint ."
+    "lint": "biome lint . && eslint .",
+    "lint:eslint": "eslint .",
+    "lint:eslint:fix": "eslint . --fix"
   },
   "dependencies": {
     "lodash": "^4.18.1",
@@ -41,20 +43,25 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
+    "@eslint/js": "10.0.1",
     "@types/bun": "^1.3.14",
     "@types/chrome": "^0.1.42",
     "@types/jest": "^30.0.0",
-    "@types/jsdom": "^28.0.3",
     "@types/js-yaml": "^4.0.9",
+    "@types/jsdom": "^28.0.3",
     "@types/lodash": "^4.17.24",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "eslint": "10.4.0",
+    "eslint-plugin-unicorn": "64.0.0",
+    "globals": "17.6.0",
     "jest": "^30",
     "jest-environment-jsdom": "^30",
     "js-yaml": "^4.1.0",
     "jsdom": "29.1.1",
     "ts-jest": "^29",
     "typescript": "^6.0.3",
+    "typescript-eslint": "8.59.4",
     "zod": "^4.4.3"
   }
 }

--- a/extension/scripts/build-injection-patterns.ts
+++ b/extension/scripts/build-injection-patterns.ts
@@ -41,7 +41,7 @@ const PatternFile = z
   .strict();
 
 function decode(b64: string): string {
-  return Buffer.from(b64, "base64").toString("utf-8");
+  return Buffer.from(b64, "base64").toString("utf8");
 }
 
 function buildOutput(
@@ -55,8 +55,8 @@ function buildOutput(
     "export const INJECTION_PATTERNS: readonly RegExp[] = [",
   ];
   for (const { name, source, flags } of entries) {
-    lines.push(`  // ${name}`);
     lines.push(
+      `  // ${name}`,
       `  new RegExp(${JSON.stringify(source)}, ${JSON.stringify(flags)}),`,
     );
   }
@@ -65,13 +65,14 @@ function buildOutput(
 }
 
 export function generateInjectionPatterns(): void {
-  const raw = readFileSync(INPUT, "utf-8");
+  const raw = readFileSync(INPUT, "utf8");
   let doc: unknown;
   try {
     doc = load(raw);
   } catch (error) {
     throw new Error(
       `${relative(ROOT, INPUT)}: YAML parse error — ${(error as Error).message}`,
+      { cause: error },
     );
   }
   const result = PatternFile.safeParse(doc);
@@ -93,6 +94,7 @@ export function generateInjectionPatterns(): void {
     } catch (error) {
       throw new Error(
         `${relative(ROOT, INPUT)}: pattern "${entry.name}" is not a valid RegExp — ${(error as Error).message}`,
+        { cause: error },
       );
     }
     return { name: entry.name, source, flags: entry.flags };

--- a/extension/scripts/build-site-data.ts
+++ b/extension/scripts/build-site-data.ts
@@ -47,13 +47,13 @@ interface RecipeBlock {
 function loadSites(): ParsedSiteFile[] {
   const entries = readdirSync(SITES_DIR)
     .filter((name) => name.endsWith(".yaml") || name.endsWith(".yml"))
-    .sort();
+    .toSorted();
   const errors: string[] = [];
   const parsed: ParsedSiteFile[] = [];
 
   for (const fileName of entries) {
     const path = join(SITES_DIR, fileName);
-    const raw = readFileSync(path, "utf-8");
+    const raw = readFileSync(path, "utf8");
     let doc: unknown;
     try {
       doc = load(raw);
@@ -155,9 +155,9 @@ function emitRecipeLiteral(recipe: string): string {
   // Recipes are multi-line by design. Use a template literal so the
   // generated file stays diff-friendly. Escape backticks and `${`.
   const escaped = recipe
-    .replace(/\\/g, "\\\\")
-    .replace(/`/g, "\\`")
-    .replace(/\$\{/g, "\\${");
+    .replaceAll("\\", "\\\\")
+    .replaceAll("`", "\\`")
+    .replaceAll("${", "\\${");
   return `\`${escaped}\``;
 }
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -73,7 +73,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
 // looking stale for the duration of those mutation observer cycles.
 subscribeEnforcementEnabled((enabled) => {
   if (enabled) return;
-  for (const tabId of Array.from(tabCounts.keys())) {
+  for (const tabId of tabCounts.keys()) {
     clearTab(tabId);
   }
 });

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -9,6 +9,9 @@ import { start } from "./lib/rule-engine";
 // Content script runs in every frame (`all_frames: true`). The rule engine
 // applies frame-appropriate rules in each; the badge is a single UI affordance
 // that belongs only on the top frame so the user doesn't get one per iframe.
+// Top-level await is unavailable — the bundler emits a classic script for the
+// content-script entry, so a promise chain is required.
+// eslint-disable-next-line unicorn/prefer-top-level-await
 start().catch((error) => {
   console.error("[abs] failed to start rule engine", error);
 });

--- a/extension/src/lib/dom-utils.ts
+++ b/extension/src/lib/dom-utils.ts
@@ -101,7 +101,7 @@ export function findInnermostMatches<T>(
 ): Array<{ element: HTMLElement; match: T }> {
   const { isSkipped, maxTextLength, maxDescendants, match } = options;
   const out: Array<{ element: HTMLElement; match: T }> = [];
-  for (const element of Array.from(root.querySelectorAll<HTMLElement>("*"))) {
+  for (const element of root.querySelectorAll<HTMLElement>("*")) {
     if (isNonContentTag(element.tagName)) continue;
     if (isSkipped?.(element)) continue;
     if (element.children.length > maxDescendants) continue;

--- a/extension/src/lib/frame.ts
+++ b/extension/src/lib/frame.ts
@@ -18,6 +18,10 @@
 // correctly (returns false for any nested frame).
 export function isTopFrame(): boolean {
   try {
+    // Comparison must use `window`, not `globalThis` — TypeScript types the
+    // latter as `typeof globalThis`, which doesn't overlap with the `Window`
+    // returned by `window.top`.
+    // eslint-disable-next-line unicorn/prefer-global-this
     return window === window.top;
   } catch {
     // Defensive fallback — if even the equality check throws, we are

--- a/extension/src/lib/options-badge.ts
+++ b/extension/src/lib/options-badge.ts
@@ -51,5 +51,5 @@ export function injectOptionsBadge(): void {
     });
   });
 
-  host.appendChild(badge);
+  host.append(badge);
 }

--- a/extension/src/lib/page-tree.ts
+++ b/extension/src/lib/page-tree.ts
@@ -77,7 +77,7 @@ const MAX_TEXT_NODE_CHARS = 160;
 // the edges, and cap the length. Returns null for content that's entirely
 // whitespace so callers can skip emitting an empty text node.
 function normalizeTextContent(raw: string): string | null {
-  const collapsed = raw.replace(/\s+/g, " ").trim();
+  const collapsed = raw.replaceAll(/\s+/g, " ").trim();
   if (collapsed.length === 0) return null;
   if (collapsed.length <= MAX_TEXT_NODE_CHARS) return collapsed;
   return `${collapsed.slice(0, MAX_TEXT_NODE_CHARS).trimEnd()}…`;

--- a/extension/src/lib/placeholder.ts
+++ b/extension/src/lib/placeholder.ts
@@ -102,7 +102,7 @@ function createIcon(ruleId: RuleId): SVGSVGElement {
   svg.setAttribute("focusable", "false");
   const path = document.createElementNS(SVG_NS, "path");
   path.setAttribute("d", RULE_ICON_PATHS[ruleId] ?? SHIELD_PATH);
-  svg.appendChild(path);
+  svg.append(path);
   return svg;
 }
 
@@ -118,11 +118,11 @@ function createRevealButton(ruleId: RuleId, label: string): HTMLButtonElement {
   // double-announcement.
   button.setAttribute("aria-label", label);
   button.title = label;
-  button.appendChild(createIcon(ruleId));
+  button.append(createIcon(ruleId));
   const text = document.createElement("span");
   text.className = LABEL_TEXT_CLASS;
   text.textContent = label;
-  button.appendChild(text);
+  button.append(text);
   return button;
 }
 
@@ -132,7 +132,7 @@ export function replaceWithBlockPlaceholder(
   label: string,
 ): HTMLDivElement {
   const rect = element.getBoundingClientRect();
-  const computed = window.getComputedStyle(element);
+  const computed = globalThis.getComputedStyle(element);
 
   // Outer container is a non-interactive <div> so the inner reveal button can
   // use position: sticky (which doesn't work as a child of <button>). Click
@@ -142,7 +142,7 @@ export function replaceWithBlockPlaceholder(
   placeholder.className = `${PLACEHOLDER_CLASS} ${PLACEHOLDER_CLASS}--block`;
   placeholder.setAttribute(RULE_ATTR, ruleId);
 
-  placeholder.appendChild(createRevealButton(ruleId, label));
+  placeholder.append(createRevealButton(ruleId, label));
 
   placeholder.style.width = `${rect.width}px`;
   placeholder.style.minHeight = `${rect.height}px`;
@@ -176,9 +176,7 @@ export function replaceMatchesInTextNode(
   for (const match of matches) {
     if (match.start < cursor) continue;
     if (match.start > cursor) {
-      fragment.appendChild(
-        document.createTextNode(text.slice(cursor, match.start)),
-      );
+      fragment.append(document.createTextNode(text.slice(cursor, match.start)));
     }
     // Inline placeholders are short and have no scrollable area, so the
     // <button> serves as both the visual chip and the a11y-tree exposure.
@@ -191,7 +189,7 @@ export function replaceMatchesInTextNode(
       text.slice(match.start, match.end),
     );
     attachReveal(placeholder, restored);
-    fragment.appendChild(placeholder);
+    fragment.append(placeholder);
     log("inline placeholder created", {
       ruleId,
       label: match.label,
@@ -201,7 +199,7 @@ export function replaceMatchesInTextNode(
   }
 
   if (cursor < text.length) {
-    fragment.appendChild(document.createTextNode(text.slice(cursor)));
+    fragment.append(document.createTextNode(text.slice(cursor)));
   }
 
   textNode.parentNode?.replaceChild(fragment, textNode);

--- a/extension/src/lib/rule-engine.ts
+++ b/extension/src/lib/rule-engine.ts
@@ -111,9 +111,9 @@ function injectStyles(): void {
   if (stylesInjected) return;
   stylesInjected = true;
   const style = document.createElement("style");
-  style.setAttribute("data-abs-styles", "");
+  style.dataset.absStyles = "";
   style.textContent = PLACEHOLDER_STYLES;
-  document.documentElement.appendChild(style);
+  document.documentElement.append(style);
 }
 
 function isApplicableHere(
@@ -141,7 +141,7 @@ function applyEnabled(
   // attempting to pass a null body would TypeError every rule.
   if (!document.body) {
     log("rule engine skipping — no document.body", {
-      url: window.location.href,
+      url: globalThis.location.href,
     });
     return;
   }
@@ -150,7 +150,7 @@ function applyEnabled(
   ).map((r) => r.id);
   log("initial rule application", {
     enabled,
-    url: window.location.href,
+    url: globalThis.location.href,
     topFrame,
   });
   for (const rule of RULES) {
@@ -224,7 +224,7 @@ function mask(states: RuleStates, enforcementEnabled: boolean): RuleStates {
 
 export async function start(): Promise<void> {
   const topFrame = isTopFrame();
-  log("rule engine starting", { url: window.location.href, topFrame });
+  log("rule engine starting", { url: globalThis.location.href, topFrame });
   injectStyles();
   // Set the default synchronously so any placeholder created before storage
   // resolves gets the right CSS scoping.

--- a/extension/src/lib/selector-hide-rule.ts
+++ b/extension/src/lib/selector-hide-rule.ts
@@ -97,12 +97,12 @@ export function createSelectorHideRule(
   }
 
   function scan(root: ParentNode): void {
-    const selectors = selectorsFor(window.location.href);
+    const selectors = selectorsFor(globalThis.location.href);
     if (selectors.length === 0) return;
 
-    let candidates = Array.from(
-      root.querySelectorAll<HTMLElement>(selectors.join(",")),
-    );
+    let candidates = [
+      ...root.querySelectorAll<HTMLElement>(selectors.join(",")),
+    ];
     if (candidateFilter) candidates = candidates.filter(candidateFilter);
 
     for (const element of candidates) {

--- a/extension/src/lib/storage.ts
+++ b/extension/src/lib/storage.ts
@@ -3,8 +3,6 @@
 
 import { RULE_IDS, RULES, type RuleId } from "../rules";
 
-export { RULE_IDS, type RuleId };
-
 export type RuleStates = Record<RuleId, boolean>;
 
 const STORAGE_KEY = "agent-browser-shield.rules";
@@ -72,3 +70,5 @@ export function subscribe(listener: RuleStatesListener): () => void {
   chrome.storage.onChanged.addListener(handler);
   return () => chrome.storage.onChanged.removeListener(handler);
 }
+
+export { RULE_IDS, type RuleId } from "../rules";

--- a/extension/src/lib/subtree-watcher.ts
+++ b/extension/src/lib/subtree-watcher.ts
@@ -44,14 +44,14 @@ export function createSubtreeWatcher(
 
   function drain(): void {
     if (pending.size === 0) return;
-    const roots = Array.from(pending).filter((root) => root.isConnected);
+    const roots = [...pending].filter((root) => root.isConnected);
     pending.clear();
     if (roots.length > 0) onSubtrees(roots);
   }
 
   function enqueue(mutations: MutationRecord[]): void {
     for (const mutation of mutations) {
-      for (const added of Array.from(mutation.addedNodes)) {
+      for (const added of mutation.addedNodes) {
         if (added.nodeType !== Node.ELEMENT_NODE) continue;
         const element = added as Element;
         if (skipPlaceholderSubtrees) {

--- a/extension/src/options.tsx
+++ b/extension/src/options.tsx
@@ -4,7 +4,7 @@
 import { createRoot } from "react-dom/client";
 import { Options } from "./options/Options";
 
-const root = document.getElementById("root");
+const root = document.querySelector("#root");
 if (root) {
   createRoot(root).render(<Options />);
 }

--- a/extension/src/options/Options.tsx
+++ b/extension/src/options/Options.tsx
@@ -127,7 +127,7 @@ export function Options() {
     const link = document.createElement("a");
     link.href = url;
     link.download = "agent-browser-shield-config.json";
-    document.body.appendChild(link);
+    document.body.append(link);
     link.click();
     link.remove();
     URL.revokeObjectURL(url);
@@ -202,6 +202,11 @@ export function Options() {
           <button type="button" onClick={handleApply}>
             Apply
           </button>
+          {status && (
+            <span className="status" role="status">
+              {status}
+            </span>
+          )}
         </div>
       </section>
 

--- a/extension/src/popup.tsx
+++ b/extension/src/popup.tsx
@@ -4,7 +4,7 @@
 import { createRoot } from "react-dom/client";
 import { Popup } from "./popup/Popup";
 
-const root = document.getElementById("root");
+const root = document.querySelector("#root");
 if (root) {
   createRoot(root).render(<Popup />);
 }

--- a/extension/src/rules/__tests__/ads-hide.test.ts
+++ b/extension/src/rules/__tests__/ads-hide.test.ts
@@ -66,7 +66,7 @@ describe("adsHideRule.apply", () => {
 
     // #tads is the outer container being hidden — the data-text-ad descendants
     // become invisible by inheritance, but aren't individually marked.
-    expectHidden(document.getElementById("tads"));
+    expectHidden(document.querySelector("#tads"));
     expect(document.querySelector("#rso .g")?.textContent).toBe(
       "Organic result",
     );
@@ -122,9 +122,9 @@ describe("adsHideRule.apply", () => {
 
 describe("adsHideRule EasyList stylesheet", () => {
   it("injects the EasyList stylesheet on apply()", () => {
-    expect(document.getElementById(EASYLIST_STYLE_ID)).toBeNull();
+    expect(document.querySelector(`#${EASYLIST_STYLE_ID}`)).toBeNull();
     adsHideRule.apply(document.body);
-    const style = document.getElementById(EASYLIST_STYLE_ID);
+    const style = document.querySelector(`#${EASYLIST_STYLE_ID}`);
     expect(style).not.toBeNull();
     expect(style?.tagName).toBe("STYLE");
     // Sanity-check that the stylesheet contains real selector rules,
@@ -136,9 +136,9 @@ describe("adsHideRule EasyList stylesheet", () => {
 
   it("removes the EasyList stylesheet on teardown()", () => {
     adsHideRule.apply(document.body);
-    expect(document.getElementById(EASYLIST_STYLE_ID)).not.toBeNull();
+    expect(document.querySelector(`#${EASYLIST_STYLE_ID}`)).not.toBeNull();
     adsHideRule.teardown?.();
-    expect(document.getElementById(EASYLIST_STYLE_ID)).toBeNull();
+    expect(document.querySelector(`#${EASYLIST_STYLE_ID}`)).toBeNull();
   });
 
   it("does not duplicate the stylesheet when apply() runs twice", () => {
@@ -155,12 +155,12 @@ describe("adsHideRule lazy-loaded slots", () => {
     const lateSlot = document.createElement("div");
     lateSlot.id = "div-gpt-ad-late";
     lateSlot.innerHTML = "<iframe></iframe>";
-    document.body.appendChild(lateSlot);
+    document.body.append(lateSlot);
 
     await flushMutations();
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-    expectHidden(document.getElementById("div-gpt-ad-late"));
+    expectHidden(document.querySelector("#div-gpt-ad-late"));
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 });

--- a/extension/src/rules/__tests__/cart-addon-flag.test.ts
+++ b/extension/src/rules/__tests__/cart-addon-flag.test.ts
@@ -111,7 +111,7 @@ describe("cartAddonFlagRule on checkout URLs", () => {
     cartAddonFlagRule.apply(document.body);
 
     // Trigger another scan via an unrelated mutation.
-    document.body.appendChild(document.createElement("div"));
+    document.body.append(document.createElement("div"));
     await flushMutations();
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
@@ -123,7 +123,7 @@ describe("cartAddonFlagRule on checkout URLs", () => {
 
     const late = document.createElement("div");
     late.innerHTML = `<span>Route Package Protection</span><span>$0.98</span>`;
-    document.body.appendChild(late);
+    document.body.append(late);
 
     await flushMutations();
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
@@ -156,9 +156,9 @@ describe("cartAddonFlagRule on checkout URLs", () => {
     for (let i = 0; i < 60; i++) {
       const row = document.createElement("div");
       row.textContent = i === 30 ? "Add SquareTrade Protection Plan" : "row";
-      big.appendChild(row);
+      big.append(row);
     }
-    document.body.appendChild(big);
+    document.body.append(big);
 
     cartAddonFlagRule.apply(document.body);
 
@@ -172,10 +172,10 @@ describe("cartAddonFlagRule on checkout URLs", () => {
 
 describe("cartAddonFlagRule URL gating", () => {
   it("does not annotate on a non-checkout URL", () => {
-    const originalHref = window.location.href;
+    const originalHref = globalThis.location.href;
     // jsdom doesn't allow direct href assignment in all paths; use the
     // history API to navigate within the same origin.
-    window.history.replaceState({}, "", "/product/widget");
+    globalThis.history.replaceState({}, "", "/product/widget");
 
     try {
       document.body.innerHTML = `
@@ -189,7 +189,7 @@ describe("cartAddonFlagRule URL gating", () => {
       expect(document.querySelectorAll(`[${FLAGGED_ATTR}]`).length).toBe(0);
       expect(document.querySelector(`.${FLAG_CLASS}`)).toBeNull();
     } finally {
-      window.history.replaceState({}, "", originalHref);
+      globalThis.history.replaceState({}, "", originalHref);
     }
   });
 });

--- a/extension/src/rules/__tests__/chat-widget-hide.test.ts
+++ b/extension/src/rules/__tests__/chat-widget-hide.test.ts
@@ -34,7 +34,7 @@ describe("chatWidgetHideRule", () => {
 
     // Node stays in the DOM (so we don't break React's fiber) but is marked
     // hidden in-place via display:none.
-    expectHidden(document.getElementById("intercom-container"));
+    expectHidden(document.querySelector("#intercom-container"));
     // Overlays don't get an in-flow placeholder.
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
     expect(document.querySelector("main")).not.toBeNull();
@@ -75,7 +75,7 @@ describe("chatWidgetHideRule", () => {
     `;
     chatWidgetHideRule.apply(document.body);
 
-    expectHidden(document.getElementById("hubspot-messages-iframe-container"));
+    expectHidden(document.querySelector("#hubspot-messages-iframe-container"));
   });
 
   it("removes Drift widget frame by id prefix", () => {
@@ -111,13 +111,13 @@ describe("chatWidgetHideRule", () => {
       container.innerHTML = `
         <iframe id="hubspot-conversations-iframe" title="Chat Widget" src="https://app.hubspot.com/conversations-visitor/..."></iframe>
       `;
-      document.body.appendChild(container);
+      document.body.append(container);
 
       await flushMutations();
       jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
       expectHidden(
-        document.getElementById("hubspot-messages-iframe-container"),
+        document.querySelector("#hubspot-messages-iframe-container"),
       );
       expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
     });
@@ -127,7 +127,7 @@ describe("chatWidgetHideRule", () => {
 
       const iframe = document.createElement("iframe");
       iframe.name = "intercom-frame-1234";
-      document.body.appendChild(iframe);
+      document.body.append(iframe);
 
       await flushMutations();
       jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
@@ -141,12 +141,12 @@ describe("chatWidgetHideRule", () => {
 
       const container = document.createElement("div");
       container.id = "intercom-container";
-      document.body.appendChild(container);
+      document.body.append(container);
 
       await flushMutations();
       jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-      const stillThere = document.getElementById("intercom-container");
+      const stillThere = document.querySelector("#intercom-container");
       expect(stillThere).not.toBeNull();
       // And it should not have been touched by the rule.
       expect(stillThere?.getAttribute(HIDDEN_ATTR)).toBeNull();

--- a/extension/src/rules/__tests__/checkout-checkbox-clear.test.ts
+++ b/extension/src/rules/__tests__/checkout-checkbox-clear.test.ts
@@ -54,7 +54,7 @@ describe("checkoutCheckboxClearRule.apply", () => {
     document.body.innerHTML = `
       <input id="warranty" type="checkbox" checked />
     `;
-    const checkbox = document.getElementById("warranty") as HTMLInputElement;
+    const checkbox = document.querySelector("#warranty") as HTMLInputElement;
     const changeSpy = jest.fn();
     checkbox.addEventListener("change", changeSpy);
 
@@ -69,7 +69,7 @@ describe("checkoutCheckboxClearRule.apply", () => {
     document.body.innerHTML = `
       <input id="locked" type="checkbox" checked disabled />
     `;
-    const checkbox = document.getElementById("locked") as HTMLInputElement;
+    const checkbox = document.querySelector("#locked") as HTMLInputElement;
 
     checkoutCheckboxClearRule.apply(document.body);
 
@@ -81,7 +81,7 @@ describe("checkoutCheckboxClearRule.apply", () => {
     document.body.innerHTML = `
       <input id="optional" type="checkbox" />
     `;
-    const checkbox = document.getElementById("optional") as HTMLInputElement;
+    const checkbox = document.querySelector("#optional") as HTMLInputElement;
     const changeSpy = jest.fn();
     checkbox.addEventListener("change", changeSpy);
 
@@ -97,8 +97,8 @@ describe("checkoutCheckboxClearRule.apply", () => {
       <input id="r" type="radio" checked />
       <input id="t" type="text" value="hello" />
     `;
-    const radio = document.getElementById("r") as HTMLInputElement;
-    const text = document.getElementById("t") as HTMLInputElement;
+    const radio = document.querySelector("#r") as HTMLInputElement;
+    const text = document.querySelector("#t") as HTMLInputElement;
 
     checkoutCheckboxClearRule.apply(document.body);
 
@@ -113,12 +113,12 @@ describe("checkoutCheckboxClearRule lazy-loaded sections", () => {
 
     const lazy = document.createElement("div");
     lazy.innerHTML = `<input id="late" type="checkbox" checked />`;
-    document.body.appendChild(lazy);
+    document.body.append(lazy);
 
     await flushMutations();
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-    const checkbox = document.getElementById("late") as HTMLInputElement;
+    const checkbox = document.querySelector("#late") as HTMLInputElement;
     expect(checkbox.checked).toBe(false);
     expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
   });
@@ -127,14 +127,14 @@ describe("checkoutCheckboxClearRule lazy-loaded sections", () => {
     document.body.innerHTML = `<input id="terms" type="checkbox" checked />`;
     checkoutCheckboxClearRule.apply(document.body);
 
-    const checkbox = document.getElementById("terms") as HTMLInputElement;
+    const checkbox = document.querySelector("#terms") as HTMLInputElement;
     expect(checkbox.checked).toBe(false);
 
     // Agent re-checks the box (e.g., after deciding to accept T&C).
     checkbox.checked = true;
 
     // Trigger a scan: append an unrelated element so the mutation observer fires.
-    document.body.appendChild(document.createElement("span"));
+    document.body.append(document.createElement("span"));
     await flushMutations();
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
@@ -147,12 +147,12 @@ describe("checkoutCheckboxClearRule lazy-loaded sections", () => {
 
     const lazy = document.createElement("div");
     lazy.innerHTML = `<input id="late" type="checkbox" checked />`;
-    document.body.appendChild(lazy);
+    document.body.append(lazy);
 
     await flushMutations();
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-    const checkbox = document.getElementById("late") as HTMLInputElement;
+    const checkbox = document.querySelector("#late") as HTMLInputElement;
     expect(checkbox.checked).toBe(true);
     expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(false);
   });

--- a/extension/src/rules/__tests__/comments-hide.test.ts
+++ b/extension/src/rules/__tests__/comments-hide.test.ts
@@ -98,7 +98,7 @@ describe("commentsHideRule.apply", () => {
     // re-scans document.body. Wait long enough for the 250ms throttle to fire.
     await new Promise((resolve) => setTimeout(resolve, 350));
 
-    expect(document.getElementById("comments")).not.toBeNull();
+    expect(document.querySelector("#comments")).not.toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
 
     commentsHideRule.teardown?.();

--- a/extension/src/rules/__tests__/cookie-banner-hide.test.ts
+++ b/extension/src/rules/__tests__/cookie-banner-hide.test.ts
@@ -19,7 +19,7 @@ describe("cookieBannerHideRule", () => {
     `;
     cookieBannerHideRule.apply(document.body);
 
-    const banner = document.getElementById("onetrust-banner-sdk");
+    const banner = document.querySelector("#onetrust-banner-sdk");
     // Node stays in the DOM (so we don't break React's fiber) but is marked
     // hidden in-place via display:none.
     expect(banner?.getAttribute(HIDDEN_ATTR)).toBe(RULE_ID);
@@ -35,7 +35,7 @@ describe("cookieBannerHideRule", () => {
     `;
     cookieBannerHideRule.apply(document.body);
 
-    const dialog = document.getElementById("CybotCookiebotDialog");
+    const dialog = document.querySelector("#CybotCookiebotDialog");
     expect(dialog?.getAttribute(HIDDEN_ATTR)).toBe(RULE_ID);
     expect(dialog?.style.display).toBe("none");
   });
@@ -86,6 +86,6 @@ describe("cookieBannerHideRule", () => {
     `;
     cookieBannerHideRule.apply(document.body);
 
-    expect(document.getElementById("onetrust-banner-sdk")).not.toBeNull();
+    expect(document.querySelector("#onetrust-banner-sdk")).not.toBeNull();
   });
 });

--- a/extension/src/rules/__tests__/countdown-timer-hide.test.ts
+++ b/extension/src/rules/__tests__/countdown-timer-hide.test.ts
@@ -78,7 +78,7 @@ describe("parseTotalSeconds", () => {
   });
 
   it("parses days alongside other units", () => {
-    expect(parseTotalSeconds("2 days 3 hours")).toBe(2 * 86400 + 3 * 3600);
+    expect(parseTotalSeconds("2 days 3 hours")).toBe(2 * 86_400 + 3 * 3600);
   });
 
   it("returns null when no time value is present", () => {
@@ -95,12 +95,12 @@ describe("countdownTimerHideRule", () => {
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
 
     // Simulate the timer ticking down before the snapshot fires.
-    const timer = document.getElementById("t");
+    const timer = document.querySelector("#t");
     if (timer) timer.textContent = "12:34:55";
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
-    expect(document.getElementById("t")).toBeNull();
+    expect(document.querySelector("#t")).toBeNull();
     const placeholder = document.querySelector(`.${PLACEHOLDER_CLASS}`);
     expect(placeholder).not.toBeNull();
     expect(placeholder?.getAttribute(RULE_ATTR)).toBe("countdown-timer-hide");
@@ -111,12 +111,12 @@ describe("countdownTimerHideRule", () => {
     document.body.innerHTML = `<div id="t">5m 30s</div>`;
     countdownTimerHideRule.apply(document.body);
 
-    const timer = document.getElementById("t");
+    const timer = document.querySelector("#t");
     if (timer) timer.textContent = "5m 29s";
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
-    expect(document.getElementById("t")).toBeNull();
+    expect(document.querySelector("#t")).toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
   });
 
@@ -135,13 +135,13 @@ describe("countdownTimerHideRule", () => {
     countdownTimerHideRule.apply(document.body);
 
     // Stopwatch-style increment — should not be hidden.
-    const timer = document.getElementById("t");
+    const timer = document.querySelector("#t");
     if (timer) timer.textContent = "05:31";
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
-    expect(document.getElementById("t")).not.toBeNull();
+    expect(document.querySelector("#t")).not.toBeNull();
   });
 
   it("skips elements whose value did not change during the window", () => {
@@ -163,13 +163,13 @@ describe("countdownTimerHideRule", () => {
     `;
     countdownTimerHideRule.apply(document.body);
 
-    const inner = document.getElementById("inner");
+    const inner = document.querySelector("#inner");
     if (inner) inner.textContent = "09:59";
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
-    expect(document.getElementById("outer")).not.toBeNull();
-    expect(document.getElementById("inner")).toBeNull();
+    expect(document.querySelector("#outer")).not.toBeNull();
+    expect(document.querySelector("#inner")).toBeNull();
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 
@@ -177,7 +177,7 @@ describe("countdownTimerHideRule", () => {
     document.body.innerHTML = `<p id="t">Lorem ipsum dolor sit amet, consectetur adipiscing elit — countdown 10:00 here for context.</p>`;
     countdownTimerHideRule.apply(document.body);
 
-    const node = document.getElementById("t");
+    const node = document.querySelector("#t");
     if (node) {
       node.textContent =
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit — countdown 09:59 here for context.";
@@ -186,7 +186,7 @@ describe("countdownTimerHideRule", () => {
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
-    expect(document.getElementById("t")).not.toBeNull();
+    expect(document.querySelector("#t")).not.toBeNull();
   });
 
   it("does not process text inside SCRIPT or STYLE", () => {
@@ -205,7 +205,7 @@ describe("countdownTimerHideRule", () => {
     document.body.innerHTML = `<span id="t">10:00</span>`;
     countdownTimerHideRule.apply(document.body);
 
-    const timer = document.getElementById("t");
+    const timer = document.querySelector("#t");
     if (timer) timer.textContent = "09:59";
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
@@ -217,7 +217,7 @@ describe("countdownTimerHideRule", () => {
     placeholder?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
-    expect(document.getElementById("t")).not.toBeNull();
+    expect(document.querySelector("#t")).not.toBeNull();
   });
 
   it("does not re-process content inside an existing placeholder", () => {
@@ -228,13 +228,13 @@ describe("countdownTimerHideRule", () => {
     `;
     countdownTimerHideRule.apply(document.body);
 
-    const timer = document.getElementById("t");
+    const timer = document.querySelector("#t");
     if (timer) timer.textContent = "09:59";
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
-    expect(document.getElementById("t")).not.toBeNull();
+    expect(document.querySelector("#t")).not.toBeNull();
   });
 });
 
@@ -245,17 +245,17 @@ describe("countdownTimerHideRule lazy-loaded sections", () => {
     // Simulate a lazy-loaded section appearing after first paint.
     const lazy = document.createElement("div");
     lazy.innerHTML = `<span id="t">10:00</span>`;
-    document.body.appendChild(lazy);
+    document.body.append(lazy);
 
     await flushMutations();
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-    const timer = document.getElementById("t");
+    const timer = document.querySelector("#t");
     if (timer) timer.textContent = "09:59";
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
-    expect(document.getElementById("t")).toBeNull();
+    expect(document.querySelector("#t")).toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
   });
 
@@ -267,13 +267,13 @@ describe("countdownTimerHideRule lazy-loaded sections", () => {
     for (let i = 0; i < 5; i++) {
       const wrapper = document.createElement("div");
       wrapper.innerHTML = `<span class="t" data-i="${i}">10:00</span>`;
-      document.body.appendChild(wrapper);
+      document.body.append(wrapper);
     }
 
     await flushMutations();
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-    for (const span of Array.from(document.querySelectorAll(".t"))) {
+    for (const span of document.querySelectorAll(".t")) {
       span.textContent = "09:59";
     }
 
@@ -289,17 +289,17 @@ describe("countdownTimerHideRule lazy-loaded sections", () => {
 
     const lazy = document.createElement("div");
     lazy.innerHTML = `<span id="t">10:00</span>`;
-    document.body.appendChild(lazy);
+    document.body.append(lazy);
 
     await flushMutations();
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-    const timer = document.getElementById("t");
+    const timer = document.querySelector("#t");
     if (timer) timer.textContent = "09:59";
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
-    expect(document.getElementById("t")).not.toBeNull();
+    expect(document.querySelector("#t")).not.toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 
@@ -307,13 +307,13 @@ describe("countdownTimerHideRule lazy-loaded sections", () => {
     document.body.innerHTML = `<span id="t">10:00</span>`;
     countdownTimerHideRule.apply(document.body);
 
-    const timer = document.getElementById("t");
+    const timer = document.querySelector("#t");
     if (timer) timer.textContent = "09:59";
 
     countdownTimerHideRule.teardown?.();
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
-    expect(document.getElementById("t")).not.toBeNull();
+    expect(document.querySelector("#t")).not.toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 
@@ -321,7 +321,7 @@ describe("countdownTimerHideRule lazy-loaded sections", () => {
     document.body.innerHTML = `<span id="t">10:00</span>`;
     countdownTimerHideRule.apply(document.body);
 
-    const timer = document.getElementById("t");
+    const timer = document.querySelector("#t");
     if (timer) timer.textContent = "09:59";
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);

--- a/extension/src/rules/__tests__/footer-hide.test.ts
+++ b/extension/src/rules/__tests__/footer-hide.test.ts
@@ -54,7 +54,7 @@ describe("footerHideRule", () => {
     `;
     footerHideRule.apply(document.body);
 
-    expect(document.getElementById("f")).toBeNull();
+    expect(document.querySelector("#f")).toBeNull();
     const placeholder = document.querySelector(`.${PLACEHOLDER_CLASS}`);
     expect(placeholder).not.toBeNull();
     expect(placeholder?.getAttribute(RULE_ATTR)).toBe("footer-hide");
@@ -65,7 +65,7 @@ describe("footerHideRule", () => {
     document.body.innerHTML = `<div role="contentinfo" id="f">links</div>`;
     footerHideRule.apply(document.body);
 
-    expect(document.getElementById("f")).toBeNull();
+    expect(document.querySelector("#f")).toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
   });
 
@@ -99,9 +99,9 @@ describe("footerHideRule", () => {
     `;
     footerHideRule.apply(document.body);
 
-    expect(document.getElementById("footer")).toBeNull();
+    expect(document.querySelector("#footer")).toBeNull();
     expect(document.querySelector(".site-footer")).toBeNull();
-    expect(document.getElementById("page-footer")).toBeNull();
+    expect(document.querySelector("#page-footer")).toBeNull();
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(3);
   });
 
@@ -115,7 +115,7 @@ describe("footerHideRule", () => {
     `;
     footerHideRule.apply(document.body);
 
-    expect(document.getElementById("navFooter")).toBeNull();
+    expect(document.querySelector("#navFooter")).toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
   });
 
@@ -128,7 +128,7 @@ describe("footerHideRule", () => {
     `;
     footerHideRule.apply(document.body);
 
-    expect(document.getElementById("byline")).not.toBeNull();
+    expect(document.querySelector("#byline")).not.toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 
@@ -140,9 +140,9 @@ describe("footerHideRule", () => {
     `;
     footerHideRule.apply(document.body);
 
-    expect(document.getElementById("s")).not.toBeNull();
-    expect(document.getElementById("a")).not.toBeNull();
-    expect(document.getElementById("n")).not.toBeNull();
+    expect(document.querySelector("#s")).not.toBeNull();
+    expect(document.querySelector("#a")).not.toBeNull();
+    expect(document.querySelector("#n")).not.toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 
@@ -153,8 +153,8 @@ describe("footerHideRule", () => {
     `;
     footerHideRule.apply(document.body);
 
-    expect(document.getElementById("byline")).not.toBeNull();
-    expect(document.getElementById("page")).toBeNull();
+    expect(document.querySelector("#byline")).not.toBeNull();
+    expect(document.querySelector("#page")).toBeNull();
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 
@@ -166,8 +166,8 @@ describe("footerHideRule", () => {
     `;
     footerHideRule.apply(document.body);
 
-    expect(document.getElementById("outer")).toBeNull();
-    expect(document.getElementById("inner")).toBeNull();
+    expect(document.querySelector("#outer")).toBeNull();
+    expect(document.querySelector("#inner")).toBeNull();
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 
@@ -181,7 +181,7 @@ describe("footerHideRule", () => {
     placeholder?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
-    expect(document.getElementById("f")?.textContent).toBe("© 2026");
+    expect(document.querySelector("#f")?.textContent).toBe("© 2026");
   });
 
   it("does not re-process content inside an existing placeholder", () => {
@@ -193,7 +193,7 @@ describe("footerHideRule", () => {
     footerHideRule.apply(document.body);
 
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
-    expect(document.getElementById("f")).not.toBeNull();
+    expect(document.querySelector("#f")).not.toBeNull();
   });
 
   // Costco's Next.js footer lives inside a Suspense boundary that bails to
@@ -216,12 +216,12 @@ describe("footerHideRule", () => {
       const footer = document.createElement("footer");
       footer.id = "late-footer";
       footer.textContent = "© 2026";
-      document.body.appendChild(footer);
+      document.body.append(footer);
 
       await flushMutations();
       jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-      expect(document.getElementById("late-footer")).toBeNull();
+      expect(document.querySelector("#late-footer")).toBeNull();
       expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
     });
 
@@ -232,19 +232,19 @@ describe("footerHideRule", () => {
         <footer id="ssr-footer">© 2026</footer>
       `;
       footerHideRule.apply(document.body);
-      expect(document.getElementById("ssr-footer")).toBeNull();
+      expect(document.querySelector("#ssr-footer")).toBeNull();
 
       // React tears down the placeholder subtree and mounts a fresh footer.
       document.body.querySelector(`.${PLACEHOLDER_CLASS}`)?.remove();
       const replacement = document.createElement("footer");
       replacement.id = "csr-footer";
       replacement.textContent = "© 2026";
-      document.body.appendChild(replacement);
+      document.body.append(replacement);
 
       await flushMutations();
       jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-      expect(document.getElementById("csr-footer")).toBeNull();
+      expect(document.querySelector("#csr-footer")).toBeNull();
       expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(
         1,
       );
@@ -256,12 +256,12 @@ describe("footerHideRule", () => {
 
       const footer = document.createElement("footer");
       footer.id = "after-teardown";
-      document.body.appendChild(footer);
+      document.body.append(footer);
 
       await flushMutations();
       jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-      expect(document.getElementById("after-teardown")).not.toBeNull();
+      expect(document.querySelector("#after-teardown")).not.toBeNull();
     });
   });
 });

--- a/extension/src/rules/__tests__/hidden-text-strip.test.ts
+++ b/extension/src/rules/__tests__/hidden-text-strip.test.ts
@@ -18,8 +18,8 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("hidden")).toBeNull();
-    expect(document.getElementById("visible")).not.toBeNull();
+    expect(document.querySelector("#hidden")).toBeNull();
+    expect(document.querySelector("#visible")).not.toBeNull();
     // Hidden-text removal does not insert a placeholder — the element is
     // gone from the DOM so DOM-scraping agents can't read it.
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
@@ -31,7 +31,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).toBeNull();
+    expect(document.querySelector("#x")).toBeNull();
   });
 
   it("removes text positioned off-screen", () => {
@@ -40,7 +40,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).toBeNull();
+    expect(document.querySelector("#x")).toBeNull();
   });
 
   it("removes text clipped to zero area via clip-path", () => {
@@ -49,7 +49,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).toBeNull();
+    expect(document.querySelector("#x")).toBeNull();
   });
 
   it("removes text with font-size:0", () => {
@@ -58,7 +58,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).toBeNull();
+    expect(document.querySelector("#x")).toBeNull();
   });
 
   it("preserves .sr-only text", () => {
@@ -67,7 +67,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).not.toBeNull();
+    expect(document.querySelector("#x")).not.toBeNull();
   });
 
   it("preserves .visually-hidden text", () => {
@@ -76,7 +76,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).not.toBeNull();
+    expect(document.querySelector("#x")).not.toBeNull();
   });
 
   // MUI's `visuallyHidden` utility (and Tailwind's `sr-only` when compiled
@@ -99,7 +99,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("mui-style")).not.toBeNull();
+    expect(document.querySelector("#mui-style")).not.toBeNull();
   });
 
   it("preserves the structural SR-only pattern when expressed via clip-path", () => {
@@ -114,7 +114,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).not.toBeNull();
+    expect(document.querySelector("#x")).not.toBeNull();
   });
 
   // Amazon's `a-offscreen`, eBay's accessible price labels, and many older
@@ -133,7 +133,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).not.toBeNull();
+    expect(document.querySelector("#x")).not.toBeNull();
   });
 
   // Amazon's current `a-offscreen` ships a Bootstrap-5 style envelope:
@@ -159,7 +159,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).not.toBeNull();
+    expect(document.querySelector("#x")).not.toBeNull();
   });
 
   // Bootstrap-5's `.visually-hidden` and many hand-rolled SR-only utilities
@@ -177,7 +177,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).not.toBeNull();
+    expect(document.querySelector("#x")).not.toBeNull();
   });
 
   // An offscreen element that's large enough to carry prose is not an
@@ -194,7 +194,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).toBeNull();
+    expect(document.querySelector("#x")).toBeNull();
   });
 
   it("removes text whose foreground color matches the page background", () => {
@@ -204,7 +204,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).toBeNull();
+    expect(document.querySelector("#x")).toBeNull();
   });
 
   // Effective background comes from an ancestor, not the element itself.
@@ -218,7 +218,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).toBeNull();
+    expect(document.querySelector("#x")).toBeNull();
   });
 
   it("preserves text with normal contrast against its background", () => {
@@ -228,7 +228,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).not.toBeNull();
+    expect(document.querySelector("#x")).not.toBeNull();
   });
 
   it("preserves text inside aria-hidden=true ancestors", () => {
@@ -239,7 +239,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).not.toBeNull();
+    expect(document.querySelector("#x")).not.toBeNull();
   });
 
   it("leaves display:none text alone (collapsed menu / tab panel pattern)", () => {
@@ -248,14 +248,14 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("panel")).not.toBeNull();
+    expect(document.querySelector("#panel")).not.toBeNull();
   });
 
   it("leaves visible text alone", () => {
     document.body.innerHTML = `<p id="x">normal visible paragraph</p>`;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("x")).not.toBeNull();
+    expect(document.querySelector("#x")).not.toBeNull();
   });
 
   // Other rules drop their own placeholders that may legitimately contain
@@ -268,7 +268,7 @@ describe("hiddenTextStripRule", () => {
     `;
     hiddenTextStripRule.apply(document.body);
 
-    expect(document.getElementById("ph")).not.toBeNull();
-    expect(document.getElementById("inner")).not.toBeNull();
+    expect(document.querySelector("#ph")).not.toBeNull();
+    expect(document.querySelector("#inner")).not.toBeNull();
   });
 });

--- a/extension/src/rules/__tests__/html-comment-strip.test.ts
+++ b/extension/src/rules/__tests__/html-comment-strip.test.ts
@@ -53,7 +53,7 @@ describe("htmlCommentStripRule", () => {
     document.body.innerHTML = `<${tagName}></${tagName}>`;
     const element = document.querySelector(tagName);
     expect(element).not.toBeNull();
-    element?.appendChild(document.createComment(" preserved "));
+    element?.append(document.createComment(" preserved "));
 
     htmlCommentStripRule.apply(document.body);
 

--- a/extension/src/rules/__tests__/newsletter-modal-hide.test.ts
+++ b/extension/src/rules/__tests__/newsletter-modal-hide.test.ts
@@ -41,7 +41,7 @@ describe("newsletterModalHideRule", () => {
     `;
     newsletterModalHideRule.apply(document.body);
 
-    const container = document.getElementById("privy-container");
+    const container = document.querySelector("#privy-container");
     expect(container?.getAttribute(HIDDEN_ATTR)).toBe(RULE_ID);
     expect(container?.style.display).toBe("none");
   });

--- a/extension/src/rules/__tests__/reviews-hide.amazon.test.ts
+++ b/extension/src/rules/__tests__/reviews-hide.amazon.test.ts
@@ -18,7 +18,7 @@ describe("reviews-hide on amazon.com", () => {
     `;
     reviewsHideRule.apply(document.body);
 
-    expect(document.getElementById("reviewsMedley")).toBeNull();
+    expect(document.querySelector("#reviewsMedley")).toBeNull();
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 
@@ -34,8 +34,8 @@ describe("reviews-hide on amazon.com", () => {
     `;
     reviewsHideRule.apply(document.body);
 
-    expect(document.getElementById("averageCustomerReviews")).not.toBeNull();
-    expect(document.getElementById("productTitle")).not.toBeNull();
+    expect(document.querySelector("#averageCustomerReviews")).not.toBeNull();
+    expect(document.querySelector("#productTitle")).not.toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 
@@ -61,7 +61,7 @@ describe("reviews-hide on amazon.com", () => {
     `;
     reviewsHideRule.apply(document.body);
 
-    expect(document.getElementById("reviewsMedley")).toBeNull();
+    expect(document.querySelector("#reviewsMedley")).toBeNull();
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 });

--- a/extension/src/rules/__tests__/reviews-hide.rei.test.ts
+++ b/extension/src/rules/__tests__/reviews-hide.rei.test.ts
@@ -22,7 +22,7 @@ describe("reviews-hide on rei.com", () => {
     `;
     reviewsHideRule.apply(document.body);
 
-    expect(document.getElementById("product-reviews-accordion")).toBeNull();
+    expect(document.querySelector("#product-reviews-accordion")).toBeNull();
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 
@@ -47,7 +47,7 @@ describe("reviews-hide on rei.com", () => {
     reviewsHideRule.apply(document.body);
 
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
-    expect(document.getElementById("item-review-section")).not.toBeNull();
-    expect(document.getElementById("reviewsMedley")).not.toBeNull();
+    expect(document.querySelector("#item-review-section")).not.toBeNull();
+    expect(document.querySelector("#reviewsMedley")).not.toBeNull();
   });
 });

--- a/extension/src/rules/__tests__/reviews-hide.target.test.ts
+++ b/extension/src/rules/__tests__/reviews-hide.target.test.ts
@@ -19,7 +19,7 @@ describe("reviews-hide on target.com", () => {
     `;
     reviewsHideRule.apply(document.body);
 
-    expect(document.getElementById("Reviews")).toBeNull();
+    expect(document.querySelector("#Reviews")).toBeNull();
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 
@@ -46,7 +46,7 @@ describe("reviews-hide on target.com", () => {
     reviewsHideRule.apply(document.body);
 
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
-    expect(document.getElementById("item-review-section")).not.toBeNull();
-    expect(document.getElementById("reviewsMedley")).not.toBeNull();
+    expect(document.querySelector("#item-review-section")).not.toBeNull();
+    expect(document.querySelector("#reviewsMedley")).not.toBeNull();
   });
 });

--- a/extension/src/rules/__tests__/reviews-hide.test.ts
+++ b/extension/src/rules/__tests__/reviews-hide.test.ts
@@ -139,7 +139,7 @@ describe("reviews-hide", () => {
     );
     placeholder?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
-    const restored = document.getElementById("r1");
+    const restored = document.querySelector("#r1");
     expect(restored).not.toBeNull();
     expect(restored?.textContent).toContain("Original review");
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();

--- a/extension/src/rules/__tests__/reviews-hide.walmart.test.ts
+++ b/extension/src/rules/__tests__/reviews-hide.walmart.test.ts
@@ -18,7 +18,7 @@ describe("reviews-hide on walmart.com", () => {
     `;
     reviewsHideRule.apply(document.body);
 
-    expect(document.getElementById("item-review-section")).toBeNull();
+    expect(document.querySelector("#item-review-section")).toBeNull();
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 
@@ -61,6 +61,6 @@ describe("reviews-hide on walmart.com", () => {
     reviewsHideRule.apply(document.body);
 
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
-    expect(document.getElementById("reviewsMedley")).not.toBeNull();
+    expect(document.querySelector("#reviewsMedley")).not.toBeNull();
   });
 });

--- a/extension/src/rules/__tests__/scarcity-hide.test.ts
+++ b/extension/src/rules/__tests__/scarcity-hide.test.ts
@@ -76,7 +76,7 @@ describe("scarcityHideRule", () => {
     document.body.innerHTML = `<span id="t">Only 3 left in stock</span>`;
     scarcityHideRule.apply(document.body);
 
-    expect(document.getElementById("t")).toBeNull();
+    expect(document.querySelector("#t")).toBeNull();
     const placeholder = document.querySelector(`.${PLACEHOLDER_CLASS}`);
     expect(placeholder).not.toBeNull();
     expect(placeholder?.getAttribute(RULE_ATTR)).toBe("scarcity-hide");
@@ -91,9 +91,9 @@ describe("scarcityHideRule", () => {
     `;
     scarcityHideRule.apply(document.body);
 
-    expect(document.getElementById("oos")).not.toBeNull();
-    expect(document.getElementById("so")).not.toBeNull();
-    expect(document.getElementById("un")).not.toBeNull();
+    expect(document.querySelector("#oos")).not.toBeNull();
+    expect(document.querySelector("#so")).not.toBeNull();
+    expect(document.querySelector("#un")).not.toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 
@@ -104,8 +104,8 @@ describe("scarcityHideRule", () => {
     `;
     scarcityHideRule.apply(document.body);
 
-    expect(document.getElementById("bs")).not.toBeNull();
-    expect(document.getElementById("ts")).not.toBeNull();
+    expect(document.querySelector("#bs")).not.toBeNull();
+    expect(document.querySelector("#ts")).not.toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 
@@ -116,8 +116,8 @@ describe("scarcityHideRule", () => {
     `;
     scarcityHideRule.apply(document.body);
 
-    expect(document.getElementById("urgency")).toBeNull();
-    expect(document.getElementById("oos")).not.toBeNull();
+    expect(document.querySelector("#urgency")).toBeNull();
+    expect(document.querySelector("#oos")).not.toBeNull();
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 
@@ -125,7 +125,7 @@ describe("scarcityHideRule", () => {
     document.body.innerHTML = `<span id="t">5 in stock</span>`;
     scarcityHideRule.apply(document.body);
 
-    expect(document.getElementById("t")).toBeNull();
+    expect(document.querySelector("#t")).toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
   });
 
@@ -133,7 +133,7 @@ describe("scarcityHideRule", () => {
     document.body.innerHTML = `<span id="t">23 people are viewing this</span>`;
     scarcityHideRule.apply(document.body);
 
-    expect(document.getElementById("t")).toBeNull();
+    expect(document.querySelector("#t")).toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
   });
 
@@ -146,8 +146,8 @@ describe("scarcityHideRule", () => {
     `;
     scarcityHideRule.apply(document.body);
 
-    expect(document.getElementById("outer")).not.toBeNull();
-    expect(document.getElementById("inner")).toBeNull();
+    expect(document.querySelector("#outer")).not.toBeNull();
+    expect(document.querySelector("#inner")).toBeNull();
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 
@@ -170,14 +170,14 @@ describe("scarcityHideRule", () => {
     scarcityHideRule.apply(document.body);
 
     expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
-    expect(document.getElementById("t")).not.toBeNull();
+    expect(document.querySelector("#t")).not.toBeNull();
   });
 
   it("skips elements whose text content is too long to be a badge", () => {
     document.body.innerHTML = `<p id="t">Lorem ipsum dolor sit amet, consectetur adipiscing elit — there are only 3 left in stock here for context too.</p>`;
     scarcityHideRule.apply(document.body);
 
-    expect(document.getElementById("t")).not.toBeNull();
+    expect(document.querySelector("#t")).not.toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 
@@ -192,7 +192,7 @@ describe("scarcityHideRule", () => {
     placeholder?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
-    const restored = document.getElementById("t");
+    const restored = document.querySelector("#t");
     expect(restored).not.toBeNull();
     expect(restored?.textContent).toContain("Selling fast");
   });
@@ -204,12 +204,12 @@ describe("scarcityHideRule lazy-loaded sections", () => {
 
     const lazy = document.createElement("div");
     lazy.innerHTML = `<span id="t">Only 2 left in stock</span>`;
-    document.body.appendChild(lazy);
+    document.body.append(lazy);
 
     await flushMutations();
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-    expect(document.getElementById("t")).toBeNull();
+    expect(document.querySelector("#t")).toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
   });
 
@@ -219,7 +219,7 @@ describe("scarcityHideRule lazy-loaded sections", () => {
     for (let i = 0; i < 5; i++) {
       const wrapper = document.createElement("div");
       wrapper.innerHTML = `<span class="t" data-i="${i}">Only ${i + 1} left</span>`;
-      document.body.appendChild(wrapper);
+      document.body.append(wrapper);
     }
 
     await flushMutations();
@@ -235,12 +235,12 @@ describe("scarcityHideRule lazy-loaded sections", () => {
 
     const lazy = document.createElement("div");
     lazy.innerHTML = `<span id="t">Only 1 left</span>`;
-    document.body.appendChild(lazy);
+    document.body.append(lazy);
 
     await flushMutations();
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
-    expect(document.getElementById("t")).not.toBeNull();
+    expect(document.querySelector("#t")).not.toBeNull();
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 

--- a/extension/src/rules/__tests__/site-data.test.ts
+++ b/extension/src/rules/__tests__/site-data.test.ts
@@ -23,7 +23,7 @@ const SITES_DIR = join(__dirname, "..", "..", "..", "data", "sites");
 function listSiteFiles(): string[] {
   return readdirSync(SITES_DIR)
     .filter((name) => name.endsWith(".yaml") || name.endsWith(".yml"))
-    .sort();
+    .toSorted();
 }
 
 describe("site data YAML files", () => {
@@ -34,7 +34,7 @@ describe("site data YAML files", () => {
   });
 
   it.each(files)("%s parses + validates against the schema", (fileName) => {
-    const raw = readFileSync(join(SITES_DIR, fileName), "utf-8");
+    const raw = readFileSync(join(SITES_DIR, fileName), "utf8");
     const doc = load(raw);
     const result = SiteFileSchema.safeParse(doc);
     if (!result.success) {
@@ -49,7 +49,7 @@ describe("site data YAML files", () => {
   });
 
   it.each(files)("%s hostnames construct as URLPattern", (fileName) => {
-    const raw = readFileSync(join(SITES_DIR, fileName), "utf-8");
+    const raw = readFileSync(join(SITES_DIR, fileName), "utf8");
     const doc = load(raw);
     const parsed = SiteFileSchema.parse(doc);
 
@@ -70,7 +70,7 @@ describe("site data YAML files", () => {
   it("only references rule ids declared in SITE_DATA_RULE_IDS", () => {
     const allowedIds = new Set<string>(SITE_DATA_RULE_IDS);
     for (const fileName of files) {
-      const raw = readFileSync(join(SITES_DIR, fileName), "utf-8");
+      const raw = readFileSync(join(SITES_DIR, fileName), "utf8");
       const doc = load(raw) as { rules?: Record<string, unknown> };
       for (const key of Object.keys(doc?.rules ?? {})) {
         expect({

--- a/extension/src/rules/__tests__/svg-sprite-suppress.test.ts
+++ b/extension/src/rules/__tests__/svg-sprite-suppress.test.ts
@@ -19,7 +19,7 @@ describe("svgSpriteSuppressRule", () => {
     `;
     svgSpriteSuppressRule.apply(document.body);
 
-    expect(document.getElementById("sprite")).toBeNull();
+    expect(document.querySelector("#sprite")).toBeNull();
     expect(document.querySelector("main")).not.toBeNull();
   });
 
@@ -32,7 +32,7 @@ describe("svgSpriteSuppressRule", () => {
     `;
     svgSpriteSuppressRule.apply(document.body);
 
-    expect(document.getElementById("sprite")).not.toBeNull();
+    expect(document.querySelector("#sprite")).not.toBeNull();
   });
 
   it("preserves a sprite referenced via xlink:href", () => {
@@ -44,7 +44,7 @@ describe("svgSpriteSuppressRule", () => {
     `;
     svgSpriteSuppressRule.apply(document.body);
 
-    expect(document.getElementById("sprite")).not.toBeNull();
+    expect(document.querySelector("#sprite")).not.toBeNull();
   });
 
   it("preserves a sprite referenced via an external-file href (path#id)", () => {
@@ -56,7 +56,7 @@ describe("svgSpriteSuppressRule", () => {
     `;
     svgSpriteSuppressRule.apply(document.body);
 
-    expect(document.getElementById("sprite")).not.toBeNull();
+    expect(document.querySelector("#sprite")).not.toBeNull();
   });
 
   it("removes a sprite hidden via inline width:0 + height:0", () => {
@@ -89,7 +89,7 @@ describe("svgSpriteSuppressRule", () => {
     `;
     svgSpriteSuppressRule.apply(document.body);
 
-    expect(document.getElementById("vis")).not.toBeNull();
+    expect(document.querySelector("#vis")).not.toBeNull();
   });
 
   it("leaves a hidden SVG with rendered shapes alongside symbols alone", () => {

--- a/extension/src/rules/ads-hide.ts
+++ b/extension/src/rules/ads-hide.ts
@@ -50,7 +50,7 @@ function injectEasyListStylesheet(): void {
   style.textContent = EASYLIST_STYLESHEET_TEXT;
   // documentElement, not head — `head` doesn't exist yet on document_start
   // injection and may be missing on partial DOMs.
-  (document.head ?? document.documentElement).appendChild(style);
+  (document.head ?? document.documentElement).append(style);
   injectedStyle = style;
 }
 

--- a/extension/src/rules/cart-addon-flag.ts
+++ b/extension/src/rules/cart-addon-flag.ts
@@ -160,14 +160,14 @@ function flag(candidate: Candidate): void {
 }
 
 function scanAndFlag(root: ParentNode): void {
-  if (!isCheckoutUrl(window.location.href)) return;
+  if (!isCheckoutUrl(globalThis.location.href)) return;
   const candidates = findCandidates(root);
   if (candidates.length === 0) return;
   for (const candidate of candidates) flag(candidate);
   log("cart add-ons flagged", {
     count: candidates.length,
     labels: candidates.map((c) => c.label),
-    url: window.location.href,
+    url: globalThis.location.href,
   });
 }
 

--- a/extension/src/rules/checkout-checkbox-clear.ts
+++ b/extension/src/rules/checkout-checkbox-clear.ts
@@ -40,7 +40,7 @@ function uncheck(checkbox: HTMLInputElement): void {
 }
 
 function scanAndClear(root: ParentNode): void {
-  if (!isCheckoutUrl(window.location.href)) return;
+  if (!isCheckoutUrl(globalThis.location.href)) return;
 
   const checkboxes = root.querySelectorAll<HTMLInputElement>(
     `input[type="checkbox"]:checked:not(:disabled):not([${CLEARED_ATTR}])`,
@@ -56,7 +56,7 @@ function scanAndClear(root: ParentNode): void {
   if (cleared > 0) {
     log("checkout checkboxes cleared", {
       count: cleared,
-      url: window.location.href,
+      url: globalThis.location.href,
     });
   }
 }

--- a/extension/src/rules/cookie-banner-hide.ts
+++ b/extension/src/rules/cookie-banner-hide.ts
@@ -19,7 +19,7 @@ const OVERLAY_ROLES = new Set(["dialog", "alertdialog"]);
 function isOverlay(element: HTMLElement): boolean {
   const role = element.getAttribute("role");
   if (role && OVERLAY_ROLES.has(role)) return true;
-  const position = window.getComputedStyle(element).position;
+  const position = globalThis.getComputedStyle(element).position;
   return OVERLAY_POSITIONS.has(position);
 }
 

--- a/extension/src/rules/countdown-timer-hide.ts
+++ b/extension/src/rules/countdown-timer-hide.ts
@@ -47,7 +47,7 @@ export function matchesTimerPattern(text: string): boolean {
 }
 
 const UNIT_MULTIPLIERS: ReadonlyArray<readonly [RegExp, number]> = [
-  [/(\d+)\s*(?:days?|d)\b/i, 86400],
+  [/(\d+)\s*(?:days?|d)\b/i, 86_400],
   [/(\d+)\s*(?:hours?|hrs?|h)\b/i, 3600],
   [/(\d+)\s*(?:minutes?|mins?|m)\b/i, 60],
   [/(\d+)\s*(?:seconds?|secs?|s)\b/i, 1],

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -66,7 +66,7 @@ const RULE_ID = "hidden-text-strip" as const;
 const OFFSCREEN_THRESHOLD_PX = -9999;
 
 function hasSrOnlyClass(element: Element): boolean {
-  for (const cls of Array.from(element.classList)) {
+  for (const cls of element.classList) {
     if (SR_ONLY_CLASS_NAMES.has(cls)) return true;
     if (/visuallyhidden/i.test(cls)) return true;
   }
@@ -165,7 +165,7 @@ function parseColor(value: string): RGBA | null {
   const r = Number.parseFloat(match[1]);
   const g = Number.parseFloat(match[2]);
   const b = Number.parseFloat(match[3]);
-  const a = match[4] !== undefined ? Number.parseFloat(match[4]) : 1;
+  const a = match[4] === undefined ? 1 : Number.parseFloat(match[4]);
   if ([r, g, b, a].some((n) => Number.isNaN(n))) return null;
   return [r, g, b, a];
 }
@@ -177,7 +177,7 @@ function parseColor(value: string): RGBA | null {
 function effectiveBackgroundColor(element: Element): RGB {
   let current: Element | null = element;
   while (current) {
-    const style = window.getComputedStyle(current);
+    const style = globalThis.getComputedStyle(current);
     const bg = parseColor(style.backgroundColor);
     if (bg && bg[3] >= 0.999) {
       return [bg[0], bg[1], bg[2]];
@@ -191,7 +191,7 @@ function colorDistance(a: RGB, b: RGB): number {
   const dr = a[0] - b[0];
   const dg = a[1] - b[1];
   const db = a[2] - b[2];
-  return Math.sqrt(dr * dr + dg * dg + db * db);
+  return Math.hypot(dr, dg, db);
 }
 
 // Foreground is the same color as the effective background, modulo a
@@ -211,14 +211,14 @@ function hasMatchingForeground(
 
 function findCandidates(root: ParentNode): HTMLElement[] {
   const matches: HTMLElement[] = [];
-  for (const element of Array.from(root.querySelectorAll<HTMLElement>("*"))) {
+  for (const element of root.querySelectorAll<HTMLElement>("*")) {
     if (isNonContentTag(element.tagName)) continue;
     if (isInsidePlaceholder(element)) continue;
     if (element.closest('[aria-hidden="true"]')) continue;
     if (hasSrOnlyClass(element)) continue;
     if (isExcludedAncestor(element)) continue;
     if (!hasNonemptyText(element)) continue;
-    const style = window.getComputedStyle(element);
+    const style = globalThis.getComputedStyle(element);
     if (hasStructuralSrOnlyPattern(style)) continue;
     if (!isHiddenByCss(style) && !hasMatchingForeground(element, style))
       continue;

--- a/extension/src/rules/irrelevant-sections-hide.ts
+++ b/extension/src/rules/irrelevant-sections-hide.ts
@@ -56,7 +56,7 @@ function placeholderLabel(summary: string): string {
 
 function describeElement(element: Element): Record<string, unknown> {
   const rect = element.getBoundingClientRect();
-  const text = (element.textContent ?? "").replace(/\s+/g, " ").trim();
+  const text = (element.textContent ?? "").replaceAll(/\s+/g, " ").trim();
   return {
     tag: element.tagName,
     id: element.id || undefined,
@@ -84,7 +84,7 @@ function checkHideable(element: Element): string | null {
   if (element.closest('[role="banner"]')) return "inside-banner";
 
   // Sticky / fixed elements leave a layout hole behind if replaced.
-  const position = window.getComputedStyle(element).position;
+  const position = globalThis.getComputedStyle(element).position;
   if (position === "fixed" || position === "sticky") {
     return `position-${position}`;
   }

--- a/extension/src/rules/newsletter-modal-hide.ts
+++ b/extension/src/rules/newsletter-modal-hide.ts
@@ -24,7 +24,7 @@ const NEWSLETTER_TEXT =
 const MIN_VIEWPORT_AREA_RATIO = 0.25;
 
 function looksLikeNewsletterModal(element: HTMLElement): boolean {
-  const style = window.getComputedStyle(element);
+  const style = globalThis.getComputedStyle(element);
   if (style.position !== "fixed" && style.position !== "sticky") return false;
 
   // In real browsers, getBoundingClientRect returns layout dimensions; in

--- a/extension/src/rules/pii-mask.ts
+++ b/extension/src/rules/pii-mask.ts
@@ -14,7 +14,7 @@ const PHONE_PATTERN =
   /(?<![\d.])(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}(?!\d)/g;
 
 function passesLuhn(raw: string): boolean {
-  const digits = raw.replace(/\D/g, "");
+  const digits = raw.replaceAll(/\D/g, "");
   if (digits.length < 13 || digits.length > 19) return false;
   let sum = 0;
   let alt = false;
@@ -62,7 +62,7 @@ function collectMatches(text: string): InlineMatch[] {
   matches.sort((a, b) => a.start - b.start);
   const merged: InlineMatch[] = [];
   for (const match of matches) {
-    const last = merged[merged.length - 1];
+    const last = merged.at(-1);
     if (last && match.start < last.end) continue;
     merged.push(match);
   }

--- a/extension/src/rules/prompt-injection-hide.ts
+++ b/extension/src/rules/prompt-injection-hide.ts
@@ -54,7 +54,7 @@ function apply(root: ParentNode): void {
     if (container) containers.add(container);
   }
 
-  for (const element of filterToOutermost(Array.from(containers))) {
+  for (const element of filterToOutermost([...containers])) {
     if (!element.isConnected) continue;
     if (isInsidePlaceholder(element)) continue;
     replaceWithBlockPlaceholder(

--- a/extension/src/rules/search-url-helper.ts
+++ b/extension/src/rules/search-url-helper.ts
@@ -47,7 +47,7 @@ function buildLandmark(recipe: string): HTMLElement {
 }
 
 function apply(_root: ParentNode): void {
-  const recipe = findRecipe(window.location.href);
+  const recipe = findRecipe(globalThis.location.href);
   if (recipe === null) return;
   // Idempotent: a previous apply (initial pass, re-enable from the
   // options page, or rule-engine re-fire on history navigation) may
@@ -58,7 +58,7 @@ function apply(_root: ParentNode): void {
   // the first element of <body> at the top of the a11y tree.
   document.body.prepend(buildLandmark(recipe));
   log("search-url-helper applied", {
-    host: window.location.hostname,
+    host: globalThis.location.hostname,
     recipeLength: recipe.length,
   });
 }

--- a/extension/src/rules/secrets-mask.ts
+++ b/extension/src/rules/secrets-mask.ts
@@ -65,7 +65,7 @@ const ENTROPY_CANDIDATE = /[A-Za-z0-9+/=_-]{32,}/g;
 const HEX_CANDIDATE = /\b[0-9a-fA-F]{32,}\b/g;
 
 const BASE64_ENTROPY_THRESHOLD = 4.5;
-const HEX_ENTROPY_THRESHOLD = 3.0;
+const HEX_ENTROPY_THRESHOLD = 3;
 
 function shannonEntropy(value: string): number {
   const counts = new Map<string, number>();
@@ -135,7 +135,7 @@ function collectMatches(text: string): InlineMatch[] {
   matches.sort((a, b) => a.start - b.start || b.end - a.end);
   const merged: InlineMatch[] = [];
   for (const match of matches) {
-    const last = merged[merged.length - 1];
+    const last = merged.at(-1);
     if (last && match.start < last.end) continue;
     merged.push(match);
   }

--- a/extension/src/rules/social-embed-hide.ts
+++ b/extension/src/rules/social-embed-hide.ts
@@ -16,7 +16,7 @@ const EMBED_OWNER_HOSTS =
   /(?:^|\.)(?:twitter|x|youtube|facebook|instagram|tiktok|reddit|linkedin|spotify|soundcloud)\.com$/i;
 
 function notOnEmbedOwnerSite(_element: HTMLElement): boolean {
-  return !EMBED_OWNER_HOSTS.test(window.location.hostname);
+  return !EMBED_OWNER_HOSTS.test(globalThis.location.hostname);
 }
 
 const { rule, selectorsFor } = createSelectorHideRule({

--- a/extension/src/rules/svg-sprite-suppress.ts
+++ b/extension/src/rules/svg-sprite-suppress.ts
@@ -25,11 +25,11 @@ const STRUCTURAL_TAGS = new Set([
 
 function collectReferencedSymbolIds(): Set<string> {
   const refs = new Set<string>();
-  for (const use of Array.from(document.querySelectorAll("use"))) {
+  for (const use of document.querySelectorAll("use")) {
     const href = use.getAttribute("href") ?? use.getAttribute("xlink:href");
     if (!href) continue;
     const hashIdx = href.lastIndexOf("#");
-    if (hashIdx < 0) continue;
+    if (hashIdx === -1) continue;
     const id = href.slice(hashIdx + 1);
     if (id) refs.add(id);
   }
@@ -37,7 +37,7 @@ function collectReferencedSymbolIds(): Set<string> {
 }
 
 function isSpriteShaped(svg: SVGSVGElement): boolean {
-  const children = Array.from(svg.children);
+  const children = [...svg.children];
   if (children.length === 0) return false;
   let hasSymbolOrDefs = false;
   for (const child of children) {
@@ -50,7 +50,7 @@ function isSpriteShaped(svg: SVGSVGElement): boolean {
 
 function isHidden(svg: SVGSVGElement): boolean {
   if (svg.getAttribute("aria-hidden") === "true") return true;
-  const style = window.getComputedStyle(svg);
+  const style = globalThis.getComputedStyle(svg);
   if (style.display === "none") return true;
   if (style.visibility === "hidden") return true;
   if (svg.getAttribute("width") === "0" || svg.getAttribute("height") === "0") {
@@ -68,13 +68,11 @@ function isHidden(svg: SVGSVGElement): boolean {
 
 function scan(root: ParentNode): void {
   const referenced = collectReferencedSymbolIds();
-  for (const svg of Array.from(root.querySelectorAll<SVGSVGElement>("svg"))) {
+  for (const svg of root.querySelectorAll<SVGSVGElement>("svg")) {
     if (!svg.isConnected) continue;
     if (!isSpriteShaped(svg)) continue;
     if (!isHidden(svg)) continue;
-    const symbols = Array.from(
-      svg.querySelectorAll<SVGSymbolElement>("symbol[id]"),
-    );
+    const symbols = [...svg.querySelectorAll<SVGSymbolElement>("symbol[id]")];
     if (symbols.some((s) => referenced.has(s.id))) continue;
     svg.remove();
   }

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "types": ["chrome", "bun"],
     "jsx": "react-jsx",
     "strict": true,


### PR DESCRIPTION
## Summary

- Adds ESLint alongside Biome on the `extension/` package. Biome continues to own formatting and its recommended lint set; ESLint runs `eslint-plugin-unicorn` (modern-API hints Biome doesn't cover) plus a local `agent-browser-shield/*` plugin for project-specific rules.
- Custom-rule scaffold lives in `extension/eslint-rules/` — one file per rule, registered via `eslint-rules/index.js`. First rule shipped: `rule-id-matches-filename` (catches drift between `src/rules/<file>.ts` and the `id` it declares).
- Versions respect the dependabot 7-day cooldown (eslint@10.4.0, @eslint/js@10.0.1, typescript-eslint@8.59.4, eslint-plugin-unicorn@64.0.0, globals@17.6.0).
- `bun run check` now runs Biome then ESLint; CI step + a local pre-commit hook were updated to match. Docs in `CLAUDE.md` and `CONTRIBUTING.md` mention the new split.
- Autofix handled 203 of 226 violations. Remaining were fixed by hand, including one drive-by: an `Applied` status in the options page that was set but never rendered.
- Bumped `tsconfig.json` `target`/`lib` from ES2022 → ES2023 so `Array#toSorted` is in the typelib (Chrome 148+ already supports it per the existing project floor).

## Test plan

- [x] `bun run check` (Biome + ESLint) — clean
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test` — 26 suites / 385 tests pass
- [x] `bun run build` — extension builds
- [x] Custom rule sanity-checked by temporarily mismatching `RULE_ID` in `scarcity-hide.ts` and confirming it errors
- [ ] Load `extension/dist/` unpacked and smoke-test the options page (the `Applied` status is the only behavior change beyond lint fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)