### PR TITLE
ci: add bandit security scan for Python scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   python:
-    name: Python (ruff)
+    name: Python (ruff + bandit)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -112,3 +112,5 @@ jobs:
         run: uvx ruff check scripts/
       - name: Ruff format check
         run: uvx ruff format --check scripts/
+      - name: Bandit security scan
+        run: uvx --from "bandit[toml]" bandit -c pyproject.toml -r scripts/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,3 +98,12 @@ repos:
         args: [--fix]
       - id: ruff-format
         name: Ruff format
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        name: Bandit (Python security)
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]
+        files: ^scripts/.*\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,10 @@ ignore = [
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.bandit]
+exclude_dirs = [".venv", "output", "benchmark", "node_modules"]
+# B404/B603/B607: subprocess import + fixed-argv calls + partial paths
+# (e.g. `sips`, `git`). These scripts are dev tooling, not user-facing
+# services; the argv lists are static and `shell=True` is never used.
+skips = ["B404", "B603", "B607"]

--- a/scripts/_stagehand.py
+++ b/scripts/_stagehand.py
@@ -74,7 +74,8 @@ def event_to_dict(event: Any) -> Any:
     if callable(dump):
         try:
             return event_to_dict(dump())
-        except Exception:
+        # Fall through to other serialization strategies if model_dump() raises.
+        except Exception:  # nosec B110
             pass
     if hasattr(event, "__dict__") and not isinstance(event, type):
         return {k: event_to_dict(v) for k, v in vars(event).items() if not k.startswith("_")}

--- a/scripts/fetch_bu_bench.py
+++ b/scripts/fetch_bu_bench.py
@@ -48,7 +48,8 @@ def main() -> int:
     TARGET.parent.mkdir(parents=True, exist_ok=True)
     print(f"Fetching {args.url} → {TARGET.relative_to(Path.cwd())}")
     try:
-        with urllib.request.urlopen(args.url) as response:
+        # URL comes from a CLI arg in a dev fetch script; default points to a trusted upstream.
+        with urllib.request.urlopen(args.url) as response:  # nosec B310
             data = response.read()
     except OSError as exc:
         print(f"error: download failed: {exc}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Runs [Bandit](https://github.com/PyCQA/bandit) over `scripts/` via pre-commit and a new step in the CI `python` job.
- Config lives in `pyproject.toml` under `[tool.bandit]`. `B404`/`B603`/`B607` are skipped — subprocess noise that's not actionable for dev-tooling scripts that only use fixed argv lists and never `shell=True`.
- Two real findings annotated inline with `# nosec`: `scripts/_stagehand.py` (B110 — intentional fall-through in `event_to_dict`) and `scripts/fetch_bu_bench.py` (B310 — `urlopen` of a CLI URL arg, default points at a trusted upstream).

## Test plan
- [ ] CI passes (new `Bandit security scan` step in the `Python (ruff + bandit)` job is green).
- [ ] `pre-commit run bandit --all-files` passes locally.
- [ ] `uvx --from "bandit[toml]" bandit -c pyproject.toml -r scripts/` reports no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)