### PR TITLE
ci: add manual ClawHub publish workflow

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -1,0 +1,39 @@
+name: Publish ClawHub skill
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump level
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: Preview without publishing
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: clawhub-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish agent-browser-shield to ClawHub
+    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@v1
+    with:
+      skill_path: clawhub/agent-browser-shield
+      owner: pixiebrix
+      bump: ${{ inputs.bump }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   publish:
     name: Publish agent-browser-shield to ClawHub
-    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@v1
+    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@6fc5bb7cd80f8efc020bfc787b0b2ad2de017147 # PR #2450
     with:
       skill_path: clawhub/agent-browser-shield
       owner: pixiebrix

--- a/clawhub/README.md
+++ b/clawhub/README.md
@@ -20,10 +20,8 @@ yet, create it once (the authenticated user becomes the owner):
 clawhub publisher create pixiebrix --display-name "PixieBrix"
 ```
 
-See the
-[ClawHub CLI docs](https://github.com/openclaw/clawhub/blob/main/docs/cli.md)
-for details on publisher management. Newly created org publishers are not marked
-trusted/official by default.
+See the [ClawHub CLI docs][clawhub-cli] for details on publisher management.
+Newly created org publishers are not marked trusted/official by default.
 
 ## Publish
 
@@ -69,3 +67,5 @@ If the skill was previously published under a personal handle, add
 Independent semver, **not** tied to the extension's `v2026.x.x` release tag.
 Bump only when the agent-facing contract changes (new DOM marker, new behavior
 rule). Extension bugfixes don't require a republish.
+
+[clawhub-cli]: https://github.com/openclaw/clawhub/blob/main/docs/cli.md

--- a/clawhub/README.md
+++ b/clawhub/README.md
@@ -20,9 +20,10 @@ yet, create it once (the authenticated user becomes the owner):
 clawhub publisher create pixiebrix --display-name "PixieBrix"
 ```
 
-See the [ClawHub CLI docs](https://github.com/openclaw/clawhub/blob/main/docs/cli.md)
-for details on publisher management. Newly created org publishers are not
-marked trusted/official by default.
+See the
+[ClawHub CLI docs](https://github.com/openclaw/clawhub/blob/main/docs/cli.md)
+for details on publisher management. Newly created org publishers are not marked
+trusted/official by default.
 
 ## Publish
 

--- a/clawhub/README.md
+++ b/clawhub/README.md
@@ -20,9 +20,9 @@ yet, create it once (the authenticated user becomes the owner):
 clawhub publisher create pixiebrix --display-name "PixieBrix"
 ```
 
-See https://github.com/openclaw/clawhub/blob/main/docs/cli.md for details on
-publisher management. Newly created org publishers are not marked
-trusted/official by default.
+See the [ClawHub CLI docs](https://github.com/openclaw/clawhub/blob/main/docs/cli.md)
+for details on publisher management. Newly created org publishers are not
+marked trusted/official by default.
 
 ## Publish
 

--- a/clawhub/README.md
+++ b/clawhub/README.md
@@ -13,6 +13,17 @@ clawhub login        # GitHub OAuth
 clawhub whoami       # confirm
 ```
 
+Skills are published under the `pixiebrix` org publisher. If it doesn't exist
+yet, create it once (the authenticated user becomes the owner):
+
+```sh
+clawhub publisher create pixiebrix --display-name "PixieBrix"
+```
+
+See https://github.com/openclaw/clawhub/blob/main/docs/cli.md for details on
+publisher management. Newly created org publishers are not marked
+trusted/official by default.
+
 ## Publish
 
 1. Edit `agent-browser-shield/SKILL.md`. Keep it short — every line is loaded
@@ -27,6 +38,7 @@ clawhub whoami       # confirm
    clawhub skill publish ./agent-browser-shield \
      --slug agent-browser-shield \
      --name "Agent Browser Shield" \
+     --owner pixiebrix \
      --version <semver> \
      --changelog "<one-line summary>" \
      --dry-run
@@ -36,7 +48,7 @@ clawhub whoami       # confirm
    we don't author or bundle one):
 
    ```sh
-   clawhub skill publish ./agent-browser-shield --dry-run --card
+   clawhub skill publish ./agent-browser-shield --owner pixiebrix --dry-run --card
    ```
 
 5. Eyeball the SKILL.md in a fresh agent session — dry-run validates
@@ -47,6 +59,9 @@ clawhub whoami       # confirm
    ```sh
    clawhub inspect agent-browser-shield
    ```
+
+If the skill was previously published under a personal handle, add
+`--migrate-owner` on the next publish to move it under `pixiebrix`.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- Adds a manual `workflow_dispatch` workflow that calls openclaw/clawhub's reusable `skill-publish.yml` to publish `clawhub/agent-browser-shield` to ClawHub, with `bump` and `dry_run` inputs.
- Pins the reusable workflow to commit `6fc5bb7c` (openclaw/clawhub PR #2450), since `@v1` and existing tags up through `v0.18.0` don't contain this file yet and `@v1` fails to parse on dispatch.
- Minor `clawhub/README.md` markdown fixups (mdformat wrapping, MD034 bare-URL fix, reference-style link).

## Test plan
- [ ] Trigger the workflow from the Actions tab with `dry_run=true` and confirm the reusable workflow now resolves and runs.
- [ ] After a successful dry-run, run once with `dry_run=false, bump=patch` and confirm the skill is published to ClawHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)