### PR TITLE
Add site rules for 10 agent-relevant hosts

### DIFF
--- a/extension/data/sites/booking.yaml
+++ b/extension/data/sites/booking.yaml
@@ -1,0 +1,32 @@
+# Booking.com — reviews-hide, search-url-helper.
+#
+# Footer is a semantic <footer role="contentinfo"> caught by the generic
+# always-on selector. No footer-hide entry needed.
+
+hostnames:
+  - "{*.}?booking.com"
+
+rules:
+  reviews-hide:
+    # `[data-testid="PropertyReviewsRegionBlock"]` wraps the "Guest reviews"
+    # region on /hotel/ pages — heading, AI-generated review summary, and
+    # featured review cards. The aggregate score chip (`#reviewFloater`,
+    # "Scored 8.5 / Rated very good / N reviews") sits outside the region
+    # and stays visible, as does the small "Guest reviews (N)" tab anchor.
+    hostnames:
+      - "{*.}?booking.com"
+    pathnames:
+      - "/hotel/*"
+    selectors:
+      - '[data-testid="PropertyReviewsRegionBlock"]'
+
+  search-url-helper:
+    recipe: |
+      abs URL helper for booking.com — prefer URL navigation over typing.
+      Search: /searchresults.html?ss={location}&checkin={YYYY-MM-DD}&checkout={YYYY-MM-DD}&group_adults={n}&no_rooms={n}&group_children={n}
+      Guest mix: group_adults=2&no_rooms=1&group_children=0 (defaults); per-child age: age={n}&age={n}
+      Sort (order=): popularity (default), price, bayesian_review_score, review_score_and_price, distance_from_search, class (star rating), class_asc
+      Pagination: offset={n} (multiples of 25)
+      Currency / language: selected_currency=USD ; lang=en-us
+      Filters (nflt= ; semicolon-joined): pri=1,2,3 (price band), class=4,5 (stars), ht_id=204 (hotels), review_score=80, hotelfacility=2 (parking), popular_activities=24 (spa)
+      Direct property: /hotel/{cc}/{slug}.html (cc = 2-letter country code; e.g. /hotel/us/the-plaza.html)

--- a/extension/data/sites/costco.yaml
+++ b/extension/data/sites/costco.yaml
@@ -1,0 +1,32 @@
+# Costco — reviews-hide, search-url-helper.
+#
+# Footer is `<footer>` (semantic) — caught by the generic always-on
+# selector. The footer-hide rule's `watchSubtrees` flag already accounts
+# for Costco's Next.js Suspense re-mount, so no site entry is needed.
+
+hostnames:
+  - "{*.}?costco.com"
+
+rules:
+  reviews-hide:
+    # On PDPs (canonical path `/p/...`) the "Member Reviews" section sits
+    # inside a Material UI Accordion identified by
+    # `[data-testid="Accordion_member_reviews"]`. The accordion is
+    # collapsed by default but the review content lives inside its DOM
+    # subtree, so hiding the accordion covers the heading + cards.
+    # The aggregate rating chip near the product title (separate node)
+    # stays visible.
+    selectors:
+      - '[data-testid="Accordion_member_reviews"]'
+
+  search-url-helper:
+    recipe: |
+      abs URL helper for costco.com — prefer URL navigation over typing.
+      Search: /s?keyword={query} (legacy /CatalogSearch?keyword= redirects to /s)
+      Department-scoped search: /s?keyword={query}&dept={departmentSlug}
+      Pagination: /s?keyword={query}&from={offset} (offset is multiples of 24)
+      Sort (sortBy=): item_relevance (default), item_price_low_to_high, item_price_high_to_low, member_rating, item_newest
+      Common filter facets (refine= ; ampersand-joined): brand_name-{Dell}, customer_rating-{4-up}, price_range-{500-1000}, item_location-{InWarehouse}
+      Direct product (canonical): /p/-/{product-slug}/{itemId} (older `.product.{itemId}.html` URLs 301-redirect)
+      Category page: /{slug}.html (e.g. /laptops.html)
+      Warehouse locator: /warehouse-locations

--- a/extension/data/sites/duckduckgo.yaml
+++ b/extension/data/sites/duckduckgo.yaml
@@ -1,0 +1,20 @@
+# DuckDuckGo — search-url-helper only.
+#
+# DDG has no UGC sections — no reviews-hide or comments-hide. Footer is a
+# small marketing strip caught by the generic semantic <footer>.
+
+hostnames:
+  - "{*.}?duckduckgo.com"
+
+rules:
+  search-url-helper:
+    recipe: |
+      abs URL helper for duckduckgo.com — prefer URL navigation over typing.
+      Search: /?q={query}&ia={web|news|images|videos|maps|shopping}
+      Time filter (df=): d (past day), w (past week), m (past month), y (past year), {YYYY-MM-DD..YYYY-MM-DD} (custom range)
+      Region (kl=): wt-wt (worldwide, default), us-en, uk-en, ca-en, au-en, de-de, fr-fr, jp-jp, etc. (ISO {country}-{language})
+      SafeSearch (kp=): -2 (off), -1 (moderate), 1 (strict)
+      Lite/HTML-only (no JS): https://html.duckduckgo.com/html/?q={query}
+      Pagination (HTML mode): &s={offset} (multiples of ~30)
+      Bangs in q=: prefix `!` to redirect to a target site's search — `!w` (Wikipedia), `!gh` (GitHub), `!so` (Stack Overflow), `!yt` (YouTube), `!gi` (Google Images), `!a` (Amazon). Full list at duckduckgo.com/bangs.
+      AI-assist answer (web vertical): the result page surfaces an "AI Assist" box for natural-language queries — no separate URL.

--- a/extension/data/sites/ebay.yaml
+++ b/extension/data/sites/ebay.yaml
@@ -1,0 +1,31 @@
+# eBay — reviews-hide, search-url-helper.
+#
+# Footer is a semantic <footer class="gh-footer"> caught by the generic
+# always-on selector — no footer-hide entry needed.
+
+hostnames:
+  - "{*.}?ebay.com"
+
+rules:
+  reviews-hide:
+    # `#UserReviews` (`.x-reviews`) is the product reviews module on
+    # catalog-mapped /itm/ listings — it contains the aggregate, top
+    # favorable/critical summaries, and the most-relevant review list.
+    # `.x-feedback-detail-list` is the seller feedback panel with buyer
+    # comments. The seller's overall rating chip (`.x-sellercard-atf`,
+    # "99.6% positive") and the detailed seller rating breakdown
+    # (`.fdbk-seller-rating`, aggregated metrics) stay visible.
+    selectors:
+      - "#UserReviews"
+      - ".x-feedback-detail-list"
+
+  search-url-helper:
+    recipe: |
+      abs URL helper for ebay.com — prefer URL navigation over typing.
+      Search: /sch/i.html?_nkw={query}&_sacat={categoryId}&_sop={sort}&_pgn={page}
+      Sort (_sop=): 12 (Best Match, default), 1 (Ending soonest), 10 (Newly listed), 15 (Price+Shipping low→high), 16 (Price+Shipping high→low), 7 (Distance nearest)
+      Filters (append): LH_BIN=1 (Buy It Now only), LH_Auction=1 (Auctions only), LH_PrefLoc=1 (US only), LH_PrefLoc=2 (North America), LH_PrefLoc=98 (Worldwide), LH_FS=1 (Free shipping), LH_ItemCondition={3000=Used,1000=New}
+      Category: _sacat={categoryId} (0 = all)
+      Direct listing: /itm/{itemId}
+      Seller's store: /str/{sellerName}
+      Catalog product page: /p/{epid} (epid from the listing's URL query)

--- a/extension/data/sites/goodreads.yaml
+++ b/extension/data/sites/goodreads.yaml
@@ -1,0 +1,38 @@
+# Goodreads — reviews-hide, search-url-helper.
+#
+# Footer is a semantic <footer> — caught by the generic always-on
+# selector. comments-hide is not authored separately: Goodreads doesn't
+# have a distinct "comments" feature on book pages; reader reactions
+# live inside each review card and are covered by reviews-hide.
+
+hostnames:
+  - "{*.}?goodreads.com"
+
+rules:
+  reviews-hide:
+    # `article.ReviewCard` is the per-review container on `/book/show/*`
+    # pages — there are 150+ cards per book in the initial render.
+    # Hiding the cards keeps the "Community Reviews" heading, the
+    # aggregate rating chart, and the filter/sort/pagination controls
+    # visible (those sit outside any `ReviewCard`). `#SocialReviews` is
+    # the small "Friends & Following" recommendations strip — also UGC,
+    # also hidden.
+    hostnames:
+      - "{*.}?goodreads.com"
+    pathnames:
+      - "/book/show/*"
+    selectors:
+      - "article.ReviewCard"
+      - "#SocialReviews"
+
+  search-url-helper:
+    recipe: |
+      abs URL helper for goodreads.com — prefer URL navigation over typing.
+      Search: /search?q={query}&search_type=books (default) | people | groups | author
+      Field-restricted search (search%5Bfield%5D=): all (default), title, author, genre
+      Pagination: page={n} (1-indexed)
+      Direct book: /book/show/{bookId} or /book/show/{bookId}-{slug}
+      Author profile: /author/show/{authorId} or /author/show/{authorId}.{slug}
+      User profile: /user/show/{userId} or /user/show/{userId}-{slug}
+      Lists: /list/show/{listId} ; user shelves: /review/list/{userId}?shelf={shelfName}
+      Shelves with sort: /review/list/{userId}?shelf=read&sort=date_read&order=d

--- a/extension/data/sites/google-maps.yaml
+++ b/extension/data/sites/google-maps.yaml
@@ -1,0 +1,31 @@
+# Google Maps — search-url-helper only.
+#
+# `hostnames` is wide (`google.com`) but rules below pin pathnames to
+# `/maps/*` so the entries only apply inside Maps, not on Search/News/etc.
+#
+# reviews-hide is deliberately omitted: Maps' SPA paints the place-panel
+# (where the reviews live) only after a geo-aware client-side render and
+# returns a near-empty document to a headless probe, so the reviews
+# container selector could not be verified against a live render. The
+# class names in the place panel are also obfuscated and rotate per
+# session — any selector here needs verification from a real session.
+
+hostnames:
+  - "{*.}?google.com"
+
+rules:
+  search-url-helper:
+    hostnames:
+      - "{*.}?google.com"
+    pathnames:
+      - "/maps/*"
+    recipe: |
+      abs URL helper for google.com/maps — prefer URL navigation over typing.
+      Search: /maps/search/{queryEncoded} or /maps/search/?api=1&query={query}
+      Search near a point: /maps/search/{query}/@{lat},{lng},{zoom}z
+      Direct place by name: /maps/place/{nameEncoded} — Maps resolves to the canonical place panel
+      Direct place by Plus Code or CID: /maps/place/?q=place_id:{placeId}
+      Directions: /maps/dir/{origin}/{destination}/ ; with mode and waypoints: /maps/dir/?api=1&origin={a}&destination={b}&travelmode={driving|walking|bicycling|transit}&waypoints={c|d|e}
+      Reviews tab on a place: append /@{lat},{lng},{zoom}z/data=!4m... (data segment is opaque — use search/place URL instead)
+      Coordinate viewport: /maps/@{lat},{lng},{zoom}z
+      Spaces in queries should be URL-encoded as `+` or `%20`.

--- a/extension/data/sites/nytimes.yaml
+++ b/extension/data/sites/nytimes.yaml
@@ -1,0 +1,30 @@
+# NYTimes — comments-hide, search-url-helper.
+#
+# Footer is `<footer role="contentinfo">` — caught by the generic
+# always-on selector. No footer-hide entry needed.
+
+hostnames:
+  - "{*.}?nytimes.com"
+
+rules:
+  comments-hide:
+    # The "Read N comments" actionbar button stays visible — it conveys
+    # only the aggregate count and lets the agent reason about whether to
+    # expand. When the user/agent clicks it, NYT mounts the comments
+    # dialog into `#comments-panel` (referenced by the button's
+    # `aria-controls`). Hiding that container keeps the reader-comment
+    # UGC out of the rendered DOM while leaving the count visible.
+    selectors:
+      - "#comments-panel"
+
+  search-url-helper:
+    recipe: |
+      abs URL helper for nytimes.com — prefer URL navigation over typing.
+      Search: /search?query={query}&sort={newest|best|oldest}&startDate={YYYYMMDD}&endDate={YYYYMMDD}
+      Section filter (sections=): comma-joined section slugs (us, world, business, technology, opinion, science, health, sports, arts, books, movies, theater, food, travel, magazine, fashion)
+      Document type (types=): article (default), interactive, video, recipe, audio, multimedia
+      Pagination: page={n} (1-indexed)
+      Direct article URL: /{YYYY}/{MM}/{DD}/{section}/{slug}.html
+      Section landing: /section/{sectionSlug} ; topic landing: /topic/{topicSlug}
+      Wirecutter (reviews vertical): https://www.nytimes.com/wirecutter/search/?s={query}
+      Cooking (separate subdomain): https://cooking.nytimes.com/search?q={query}

--- a/extension/data/sites/stackoverflow.yaml
+++ b/extension/data/sites/stackoverflow.yaml
@@ -1,0 +1,29 @@
+# Stack Overflow — comments-hide, search-url-helper.
+#
+# Footer is `<footer class="site-footer" role="contentinfo">` — already
+# caught by the generic always-on selector. No footer-hide entry needed.
+
+hostnames:
+  - "{*.}?stackoverflow.com"
+
+rules:
+  comments-hide:
+    # `.js-comments-container` wraps every per-post comments thread on
+    # question and answer cards. The class is shared by both the question's
+    # and each answer's comment container. The aggregated "X more comment(s)"
+    # link (`#comments-link-{id}`) lives outside the container and is
+    # acceptable to leave visible — it carries no UGC text.
+    selectors:
+      - ".js-comments-container"
+
+  search-url-helper:
+    recipe: |
+      abs URL helper for stackoverflow.com — prefer URL navigation over typing.
+      Search: /search?q={query}&tab={Newest|Relevance|Votes|Active}
+      Search operators (in q=): [tag] (tag filter), is:question, is:answer, user:{id}, score:{n}, answers:{n}, isaccepted:{yes|no}, hasaccepted:{yes|no}, created:YYYY-MM-DD..YYYY-MM-DD, lastactive:YYYY-MM-DD, title:{phrase}, body:{phrase}, url:{phrase}
+      Question list: /questions?tab={Newest|Active|Bountied|Frequent|Votes|Hot|Week|Month}&pagesize={15|30|50}&page={n}
+      Tag-filtered list: /questions/tagged/{tag}?tab={tab}&pagesize={n}
+      Direct question: /questions/{questionId} or /questions/{questionId}/{slug}
+      Direct answer: /a/{answerId}
+      User profile: /users/{userId} or /users/{userId}/{slug}
+      Tag page: /tags/{tagName} ; tag wiki: /tags/{tagName}/info

--- a/extension/data/sites/tripadvisor.yaml
+++ b/extension/data/sites/tripadvisor.yaml
@@ -1,0 +1,31 @@
+# Tripadvisor — search-url-helper only.
+#
+# reviews-hide is deliberately omitted: Tripadvisor's hotel/restaurant
+# detail pages return a DataDome captcha interstitial when fetched
+# headlessly, so the review-list container selector could not be
+# verified against a live render. Add a reviews-hide entry here once
+# selectors are confirmed from a logged-in / unblocked browser session.
+#
+# Footer (when the real page does render) is a semantic <footer> and is
+# already caught by the generic always-on selector.
+
+hostnames:
+  - "{*.}?tripadvisor.com"
+
+rules:
+  search-url-helper:
+    recipe: |
+      abs URL helper for tripadvisor.com — prefer URL navigation over typing.
+      Search: /Search?q={query}&searchSessionId=&searchNearby=false
+      Free-form search (across hotels, restaurants, attractions, vacation rentals): /Search?q={query}
+      Geo-prefixed location/category pages follow a slug+id contract:
+        Hotels in a city:        /Hotels-g{geoId}-{slug}-Hotels.html
+        Restaurants in a city:   /Restaurants-g{geoId}-{slug}.html
+        Attractions in a city:   /Attractions-g{geoId}-{slug}-Activities.html
+        Vacation rentals:        /VacationRentals-g{geoId}-Reviews-{slug}.html
+      Direct property URLs (slug+two ids):
+        Hotel:        /Hotel_Review-g{geoId}-d{locationId}-Reviews-{slug}.html
+        Restaurant:   /Restaurant_Review-g{geoId}-d{locationId}-Reviews-{slug}.html
+        Attraction:   /Attraction_Review-g{geoId}-d{locationId}-Reviews-{slug}.html
+      Pagination (review list on a property page): -or{offset} segment inserted before "-Reviews", offset is 0-indexed by 10 (page 2 = `-or10-`).
+      Sort (hotel list, oa={offset}, ar=<rating>): /Hotels-g{geoId}-oa{offset}-{slug}-Hotels.html ; review-sort knob is `sortOrder=` with values RECENT, POPULAR, RATING_HIGH, RATING_LOW (appended as a query string).

--- a/extension/data/sites/yelp.yaml
+++ b/extension/data/sites/yelp.yaml
@@ -1,0 +1,37 @@
+# Yelp — reviews-hide, search-url-helper.
+#
+# Footer is a semantic <footer> caught by the generic always-on selector.
+# No footer-hide entry needed.
+#
+# Yelp business pages can be served behind a DataDome anti-bot challenge
+# that briefly stalls navigation; the selectors below apply to the real
+# page once it renders, not to the challenge interstitial.
+
+hostnames:
+  - "{*.}?yelp.com"
+
+rules:
+  reviews-hide:
+    # `#reviews` is the "Recommended Reviews" section on /biz/ pages — it
+    # contains the heading, review filter/sort controls, and the review
+    # cards (the entire UGC review feed). The aggregate rating and review
+    # count near the business name (in the page header) live outside
+    # `#reviews` and stay visible.
+    hostnames:
+      - "{*.}?yelp.com"
+    pathnames:
+      - "/biz/*"
+    selectors:
+      - "#reviews"
+
+  search-url-helper:
+    recipe: |
+      abs URL helper for yelp.com — prefer URL navigation over typing.
+      Search: /search?find_desc={query}&find_loc={cityOrZip}&start={offset}
+      Sort (sortby=): recommended (default), rating_asc, rating_desc, review_count_desc, date_desc, distance_asc
+      Pagination: start={offset} (0-indexed by 10; page 2 = start=10)
+      Attribute filters (attrs=): comma-joined keys — RestaurantsTakeOut, RestaurantsDelivery, OpenNow, RestaurantsReservations, GoodForKids, OutdoorSeating, WheelchairAccessible, BusinessAcceptsCreditCards, BikeParking, DogsAllowed
+      Price filter: attrs=RestaurantsPriceRange2.{1|2|3|4} ($/$$/$$$/$$$$)
+      Hours filter: open_now=1 ; specific time: open_time={HHMM}
+      Direct business: /biz/{slug} (slug includes city, e.g. /biz/the-french-laundry-yountville)
+      User profile: /user_details?userid={userId}

--- a/extension/src/rules/site-data.generated.ts
+++ b/extension/src/rules/site-data.generated.ts
@@ -22,6 +22,44 @@ export const REVIEWS_HIDE_SITE_RULES: readonly SiteRule[] = [
     ],
   },
   {
+    // from data/sites/booking.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?booking.com", pathname: "/hotel/*" }),
+    ],
+    selectors: [
+      "[data-testid=\"PropertyReviewsRegionBlock\"]",
+    ],
+  },
+  {
+    // from data/sites/costco.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?costco.com" }),
+    ],
+    selectors: [
+      "[data-testid=\"Accordion_member_reviews\"]",
+    ],
+  },
+  {
+    // from data/sites/ebay.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?ebay.com" }),
+    ],
+    selectors: [
+      "#UserReviews",
+      ".x-feedback-detail-list",
+    ],
+  },
+  {
+    // from data/sites/goodreads.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?goodreads.com", pathname: "/book/show/*" }),
+    ],
+    selectors: [
+      "article.ReviewCard",
+      "#SocialReviews",
+    ],
+  },
+  {
     // from data/sites/rei.yaml
     patterns: [
       new URLPattern({ hostname: "{*.}?rei.com" }),
@@ -50,6 +88,15 @@ export const REVIEWS_HIDE_SITE_RULES: readonly SiteRule[] = [
       "[data-testid=\"enhanced-review-section\"]",
     ],
   },
+  {
+    // from data/sites/yelp.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?yelp.com", pathname: "/biz/*" }),
+    ],
+    selectors: [
+      "#reviews",
+    ],
+  },
 ];
 
 export const COMMENTS_HIDE_SITE_RULES: readonly SiteRule[] = [
@@ -72,6 +119,15 @@ export const COMMENTS_HIDE_SITE_RULES: readonly SiteRule[] = [
     ],
   },
   {
+    // from data/sites/nytimes.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?nytimes.com" }),
+    ],
+    selectors: [
+      "#comments-panel",
+    ],
+  },
+  {
     // from data/sites/reddit.yaml
     patterns: [
       new URLPattern({ hostname: "{*.}?reddit.com" }),
@@ -79,6 +135,15 @@ export const COMMENTS_HIDE_SITE_RULES: readonly SiteRule[] = [
     selectors: [
       "shreddit-comment-tree",
       "shreddit-comments-list",
+    ],
+  },
+  {
+    // from data/sites/stackoverflow.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?stackoverflow.com" }),
+    ],
+    selectors: [
+      ".js-comments-container",
     ],
   },
   {
@@ -160,6 +225,68 @@ Direct product: /site/{slug}/{productId}.p?skuId={sku}
 `,
   },
   {
+    // from data/sites/booking.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?booking.com" }),
+    ],
+    recipe: `abs URL helper for booking.com — prefer URL navigation over typing.
+Search: /searchresults.html?ss={location}&checkin={YYYY-MM-DD}&checkout={YYYY-MM-DD}&group_adults={n}&no_rooms={n}&group_children={n}
+Guest mix: group_adults=2&no_rooms=1&group_children=0 (defaults); per-child age: age={n}&age={n}
+Sort (order=): popularity (default), price, bayesian_review_score, review_score_and_price, distance_from_search, class (star rating), class_asc
+Pagination: offset={n} (multiples of 25)
+Currency / language: selected_currency=USD ; lang=en-us
+Filters (nflt= ; semicolon-joined): pri=1,2,3 (price band), class=4,5 (stars), ht_id=204 (hotels), review_score=80, hotelfacility=2 (parking), popular_activities=24 (spa)
+Direct property: /hotel/{cc}/{slug}.html (cc = 2-letter country code; e.g. /hotel/us/the-plaza.html)
+`,
+  },
+  {
+    // from data/sites/costco.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?costco.com" }),
+    ],
+    recipe: `abs URL helper for costco.com — prefer URL navigation over typing.
+Search: /s?keyword={query} (legacy /CatalogSearch?keyword= redirects to /s)
+Department-scoped search: /s?keyword={query}&dept={departmentSlug}
+Pagination: /s?keyword={query}&from={offset} (offset is multiples of 24)
+Sort (sortBy=): item_relevance (default), item_price_low_to_high, item_price_high_to_low, member_rating, item_newest
+Common filter facets (refine= ; ampersand-joined): brand_name-{Dell}, customer_rating-{4-up}, price_range-{500-1000}, item_location-{InWarehouse}
+Direct product (canonical): /p/-/{product-slug}/{itemId} (older \`.product.{itemId}.html\` URLs 301-redirect)
+Category page: /{slug}.html (e.g. /laptops.html)
+Warehouse locator: /warehouse-locations
+`,
+  },
+  {
+    // from data/sites/duckduckgo.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?duckduckgo.com" }),
+    ],
+    recipe: `abs URL helper for duckduckgo.com — prefer URL navigation over typing.
+Search: /?q={query}&ia={web|news|images|videos|maps|shopping}
+Time filter (df=): d (past day), w (past week), m (past month), y (past year), {YYYY-MM-DD..YYYY-MM-DD} (custom range)
+Region (kl=): wt-wt (worldwide, default), us-en, uk-en, ca-en, au-en, de-de, fr-fr, jp-jp, etc. (ISO {country}-{language})
+SafeSearch (kp=): -2 (off), -1 (moderate), 1 (strict)
+Lite/HTML-only (no JS): https://html.duckduckgo.com/html/?q={query}
+Pagination (HTML mode): &s={offset} (multiples of ~30)
+Bangs in q=: prefix \`!\` to redirect to a target site's search — \`!w\` (Wikipedia), \`!gh\` (GitHub), \`!so\` (Stack Overflow), \`!yt\` (YouTube), \`!gi\` (Google Images), \`!a\` (Amazon). Full list at duckduckgo.com/bangs.
+AI-assist answer (web vertical): the result page surfaces an "AI Assist" box for natural-language queries — no separate URL.
+`,
+  },
+  {
+    // from data/sites/ebay.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?ebay.com" }),
+    ],
+    recipe: `abs URL helper for ebay.com — prefer URL navigation over typing.
+Search: /sch/i.html?_nkw={query}&_sacat={categoryId}&_sop={sort}&_pgn={page}
+Sort (_sop=): 12 (Best Match, default), 1 (Ending soonest), 10 (Newly listed), 15 (Price+Shipping low→high), 16 (Price+Shipping high→low), 7 (Distance nearest)
+Filters (append): LH_BIN=1 (Buy It Now only), LH_Auction=1 (Auctions only), LH_PrefLoc=1 (US only), LH_PrefLoc=2 (North America), LH_PrefLoc=98 (Worldwide), LH_FS=1 (Free shipping), LH_ItemCondition={3000=Used,1000=New}
+Category: _sacat={categoryId} (0 = all)
+Direct listing: /itm/{itemId}
+Seller's store: /str/{sellerName}
+Catalog product page: /p/{epid} (epid from the listing's URL query)
+`,
+  },
+  {
     // from data/sites/etsy.yaml
     patterns: [
       new URLPattern({ hostname: "{*.}?etsy.com" }),
@@ -184,6 +311,38 @@ Repo PR list: /{owner}/{repo}/pulls?q={query}&sort={created|updated|popularity|l
 Issue/PR query syntax (in q=): is:open, is:closed, is:issue, is:pr, is:draft, is:merged, label:{name}, author:{login}, assignee:{login}, milestone:{title}, no:label, sort:{field}-{asc|desc} — combine with + (URL-encoded space).
 Trending: /trending or /trending/{language}?since={daily|weekly|monthly} (e.g., /trending/python?since=weekly).
 Direct repo: /{owner}/{repo} ; file at ref: /{owner}/{repo}/blob/{branch}/{path}
+`,
+  },
+  {
+    // from data/sites/goodreads.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?goodreads.com" }),
+    ],
+    recipe: `abs URL helper for goodreads.com — prefer URL navigation over typing.
+Search: /search?q={query}&search_type=books (default) | people | groups | author
+Field-restricted search (search%5Bfield%5D=): all (default), title, author, genre
+Pagination: page={n} (1-indexed)
+Direct book: /book/show/{bookId} or /book/show/{bookId}-{slug}
+Author profile: /author/show/{authorId} or /author/show/{authorId}.{slug}
+User profile: /user/show/{userId} or /user/show/{userId}-{slug}
+Lists: /list/show/{listId} ; user shelves: /review/list/{userId}?shelf={shelfName}
+Shelves with sort: /review/list/{userId}?shelf=read&sort=date_read&order=d
+`,
+  },
+  {
+    // from data/sites/google-maps.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?google.com", pathname: "/maps/*" }),
+    ],
+    recipe: `abs URL helper for google.com/maps — prefer URL navigation over typing.
+Search: /maps/search/{queryEncoded} or /maps/search/?api=1&query={query}
+Search near a point: /maps/search/{query}/@{lat},{lng},{zoom}z
+Direct place by name: /maps/place/{nameEncoded} — Maps resolves to the canonical place panel
+Direct place by Plus Code or CID: /maps/place/?q=place_id:{placeId}
+Directions: /maps/dir/{origin}/{destination}/ ; with mode and waypoints: /maps/dir/?api=1&origin={a}&destination={b}&travelmode={driving|walking|bicycling|transit}&waypoints={c|d|e}
+Reviews tab on a place: append /@{lat},{lng},{zoom}z/data=!4m... (data segment is opaque — use search/place URL instead)
+Coordinate viewport: /maps/@{lat},{lng},{zoom}z
+Spaces in queries should be URL-encoded as \`+\` or \`%20\`.
 `,
   },
   {
@@ -263,6 +422,22 @@ Versions page exposes the full release history and is the canonical place to rea
 `,
   },
   {
+    // from data/sites/nytimes.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?nytimes.com" }),
+    ],
+    recipe: `abs URL helper for nytimes.com — prefer URL navigation over typing.
+Search: /search?query={query}&sort={newest|best|oldest}&startDate={YYYYMMDD}&endDate={YYYYMMDD}
+Section filter (sections=): comma-joined section slugs (us, world, business, technology, opinion, science, health, sports, arts, books, movies, theater, food, travel, magazine, fashion)
+Document type (types=): article (default), interactive, video, recipe, audio, multimedia
+Pagination: page={n} (1-indexed)
+Direct article URL: /{YYYY}/{MM}/{DD}/{section}/{slug}.html
+Section landing: /section/{sectionSlug} ; topic landing: /topic/{topicSlug}
+Wirecutter (reviews vertical): https://www.nytimes.com/wirecutter/search/?s={query}
+Cooking (separate subdomain): https://cooking.nytimes.com/search?q={query}
+`,
+  },
+  {
     // from data/sites/python-docs.yaml
     patterns: [
       new URLPattern({ hostname: "docs.python.org" }),
@@ -285,6 +460,43 @@ Sort: relevance (default), price-low-to-high, price-high-to-low, best-seller, to
 Category browse: /c/{slug} (e.g., /c/backpacking-tents)
 Faceted filters on /c/ and /search use r={facet}%3A{value} repeated for each, e.g., r=brand%3AREI+Co-op, r=minTrailWeight%3A0-4, r=capacity%3A2-person
 Direct product: /product/{productId}/{slug}
+`,
+  },
+  {
+    // from data/sites/stackoverflow.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?stackoverflow.com" }),
+    ],
+    recipe: `abs URL helper for stackoverflow.com — prefer URL navigation over typing.
+Search: /search?q={query}&tab={Newest|Relevance|Votes|Active}
+Search operators (in q=): [tag] (tag filter), is:question, is:answer, user:{id}, score:{n}, answers:{n}, isaccepted:{yes|no}, hasaccepted:{yes|no}, created:YYYY-MM-DD..YYYY-MM-DD, lastactive:YYYY-MM-DD, title:{phrase}, body:{phrase}, url:{phrase}
+Question list: /questions?tab={Newest|Active|Bountied|Frequent|Votes|Hot|Week|Month}&pagesize={15|30|50}&page={n}
+Tag-filtered list: /questions/tagged/{tag}?tab={tab}&pagesize={n}
+Direct question: /questions/{questionId} or /questions/{questionId}/{slug}
+Direct answer: /a/{answerId}
+User profile: /users/{userId} or /users/{userId}/{slug}
+Tag page: /tags/{tagName} ; tag wiki: /tags/{tagName}/info
+`,
+  },
+  {
+    // from data/sites/tripadvisor.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?tripadvisor.com" }),
+    ],
+    recipe: `abs URL helper for tripadvisor.com — prefer URL navigation over typing.
+Search: /Search?q={query}&searchSessionId=&searchNearby=false
+Free-form search (across hotels, restaurants, attractions, vacation rentals): /Search?q={query}
+Geo-prefixed location/category pages follow a slug+id contract:
+  Hotels in a city:        /Hotels-g{geoId}-{slug}-Hotels.html
+  Restaurants in a city:   /Restaurants-g{geoId}-{slug}.html
+  Attractions in a city:   /Attractions-g{geoId}-{slug}-Activities.html
+  Vacation rentals:        /VacationRentals-g{geoId}-Reviews-{slug}.html
+Direct property URLs (slug+two ids):
+  Hotel:        /Hotel_Review-g{geoId}-d{locationId}-Reviews-{slug}.html
+  Restaurant:   /Restaurant_Review-g{geoId}-d{locationId}-Reviews-{slug}.html
+  Attraction:   /Attraction_Review-g{geoId}-d{locationId}-Reviews-{slug}.html
+Pagination (review list on a property page): -or{offset} segment inserted before "-Reviews", offset is 0-indexed by 10 (page 2 = \`-or10-\`).
+Sort (hotel list, oa={offset}, ar=<rating>): /Hotels-g{geoId}-oa{offset}-{slug}-Hotels.html ; review-sort knob is \`sortOrder=\` with values RECENT, POPULAR, RATING_HIGH, RATING_LOW (appended as a query string).
 `,
   },
   {
@@ -313,6 +525,22 @@ Without fulltext=1, an exact title match auto-redirects to the article (the sear
 Specific revision: /wiki/{Title}?oldid={revId} ; diff: ?diff=prev&oldid={revId}
 Section anchors: /wiki/{Title}#{Section_heading_with_underscores}
 Language editions live on lang subdomains (en, de, ja, simple, …); the path contract is identical.
+`,
+  },
+  {
+    // from data/sites/yelp.yaml
+    patterns: [
+      new URLPattern({ hostname: "{*.}?yelp.com" }),
+    ],
+    recipe: `abs URL helper for yelp.com — prefer URL navigation over typing.
+Search: /search?find_desc={query}&find_loc={cityOrZip}&start={offset}
+Sort (sortby=): recommended (default), rating_asc, rating_desc, review_count_desc, date_desc, distance_asc
+Pagination: start={offset} (0-indexed by 10; page 2 = start=10)
+Attribute filters (attrs=): comma-joined keys — RestaurantsTakeOut, RestaurantsDelivery, OpenNow, RestaurantsReservations, GoodForKids, OutdoorSeating, WheelchairAccessible, BusinessAcceptsCreditCards, BikeParking, DogsAllowed
+Price filter: attrs=RestaurantsPriceRange2.{1|2|3|4} ($/$$/$$$/$$$$)
+Hours filter: open_now=1 ; specific time: open_time={HHMM}
+Direct business: /biz/{slug} (slug includes city, e.g. /biz/the-french-laundry-yountville)
+User profile: /user_details?userid={userId}
 `,
   },
 ];


### PR DESCRIPTION
## Summary

Extends `extension/data/sites/` with 10 new host YAMLs targeting agent-relevant categories (e-commerce, dev Q&A, travel, search, reviews-heavy). Selectors were extracted via the Playwright-MCP-driven crawl workflow staged in #companion-setup-PR (`scripts/crawl-targets.yaml` is the input manifest).

**reviews-hide + search-url-helper**

| Site | Reviews selector | Page scope |
|---|---|---|
| eBay | `#UserReviews`, `.x-feedback-detail-list` | all /itm/ |
| Yelp | `#reviews` | `/biz/*` |
| Booking | `[data-testid="PropertyReviewsRegionBlock"]` | `/hotel/*` |
| Costco | `[data-testid="Accordion_member_reviews"]` | all (PDPs only render the accordion) |
| Goodreads | `article.ReviewCard`, `#SocialReviews` | `/book/show/*` |

**comments-hide + search-url-helper**

| Site | Comments selector | Notes |
|---|---|---|
| Stack Overflow | `.js-comments-container` | covers question + per-answer threads |
| NYTimes | `#comments-panel` | the dialog panel mounted from the actionbar comments button |

**search-url-helper only**

| Site | Why no hide rule |
|---|---|
| Tripadvisor | Hotel/restaurant pages return a DataDome captcha to headless probes |
| Google Maps | SPA returned a near-empty doc to headless probe; place-panel class names are obfuscated + rotate per session |
| DuckDuckGo | No UGC sections |

**Footers**: every site in this batch ships a semantic `<footer>` already caught by the generic always-on selector in `footer-hide.ts` — zero site-specific footer entries needed.

`extension/src/rules/site-data.generated.ts` is regenerated by `bun run build-site-data` and committed as part of this PR (matching the existing convention).

## Test plan

- [ ] `bun run build-site-data` is a no-op (generated file is up-to-date).
- [ ] `bun run check` and `bun run check:fix` pass.
- [ ] Load the unpacked extension and visit a representative page per host:
  - eBay /itm/, Yelp /biz/, Booking /hotel/, Costco PDP, Goodreads /book/show/ → review block is hidden, aggregate rating chip near the title remains visible.
  - Stack Overflow question page, NYTimes article with comments enabled → comment thread / panel is hidden.
  - Tripadvisor /Search, Google Maps /maps/search, DuckDuckGo /?q= → URL helpers surface in the agent's view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)