### PR TITLE
ci: add Chrome Web Store publish target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,21 @@ jobs:
           archive: false
           if-no-files-found: error
 
+      # CWS rejects manifests containing a "key" field. Emit a sibling zip with
+      # "key" stripped so the initial CWS listing (and any manual re-uploads)
+      # can use a known-good CI build instead of a one-off local build.
+      - name: Package CWS-ready zip
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: bun run package:cws
+      - name: Upload CWS-ready zip
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: extension-cws-zip
+          path: output/extension-cws.zip
+          archive: false
+          if-no-files-found: error
+
   demo-site:
     name: Demo site (build)
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -2,6 +2,15 @@ name: Release extension
 
 on:
   workflow_dispatch:
+    inputs:
+      publish_s3:
+        description: "Upload to S3 (versioned + latest)"
+        type: boolean
+        default: true
+      publish_chrome_web_store:
+        description: "Submit to Chrome Web Store for publication"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -62,11 +71,13 @@ jobs:
         run: bun run package
 
       - uses: aws-actions/configure-aws-credentials@v4
+        if: ${{ inputs.publish_s3 }}
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Upload versioned ZIP
+        if: ${{ inputs.publish_s3 }}
         env:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
@@ -77,12 +88,42 @@ jobs:
             --cache-control 'public, max-age=31536000, immutable'
 
       - name: Upload latest pointer
+        if: ${{ inputs.publish_s3 }}
         run: |
           aws s3 cp output/extension.zip \
             s3://agent-browser-shield/latest/extension.zip \
             --content-type application/zip \
             --content-disposition 'attachment; filename="extension.zip"' \
             --cache-control 'public, max-age=300'
+
+      # CWS rejects manifests containing a "key" field; produce a sibling zip
+      # with it stripped. The S3 zip still includes "key" if/when one is added,
+      # so consumers wanting a stable extension ID (e.g., Browserbase) aren't
+      # affected.
+      - name: Package CWS-ready zip
+        if: ${{ inputs.publish_chrome_web_store }}
+        working-directory: extension
+        run: bun run package:cws
+
+      - name: Publish to Chrome Web Store
+        if: ${{ inputs.publish_chrome_web_store }}
+        env:
+          EXTENSION_ID: ${{ secrets.CWS_EXTENSION_ID }}
+          CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
+        run: |
+          npx --yes chrome-webstore-upload-cli@3 upload \
+            --source output/extension-cws.zip \
+            --extension-id "$EXTENSION_ID" \
+            --client-id "$CLIENT_ID" \
+            --client-secret "$CLIENT_SECRET" \
+            --refresh-token "$REFRESH_TOKEN"
+          npx --yes chrome-webstore-upload-cli@3 publish \
+            --extension-id "$EXTENSION_ID" \
+            --client-id "$CLIENT_ID" \
+            --client-secret "$CLIENT_SECRET" \
+            --refresh-token "$REFRESH_TOKEN"
 
       - name: Create GitHub Release
         env:

--- a/extension/package.json
+++ b/extension/package.json
@@ -22,6 +22,7 @@
     "build": "bun run build.ts",
     "watch": "bun run build.ts --watch",
     "package": "bun run ../scripts/package-extension.ts",
+    "package:cws": "bun run ../scripts/package-extension.ts --strip-key -o ../output/extension-cws.zip",
     "fetch-easylist": "uv run --directory .. scripts/fetch_easylist.py",
     "build-site-data": "bun run scripts/build-site-data.ts",
     "build-injection-patterns": "bun run scripts/build-injection-patterns.ts",

--- a/scripts/package-extension.ts
+++ b/scripts/package-extension.ts
@@ -2,7 +2,8 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-import { mkdir, rm, stat } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { parseArgs } from "node:util";
 
@@ -14,6 +15,7 @@ const { values, positionals } = parseArgs({
   args: process.argv.slice(2),
   options: {
     output: { type: "string", short: "o" },
+    "strip-key": { type: "boolean" },
     help: { type: "boolean", short: "h" },
   },
   allowPositionals: true,
@@ -22,12 +24,14 @@ const { values, positionals } = parseArgs({
 if (values.help) {
   console.log(
     `Usage: bun run scripts/package-extension.ts [output]\n\n` +
-      `Zips extension/dist/ for upload to Browserbase.\n\n` +
+      `Zips extension/dist/ for upload to Browserbase or the Chrome Web Store.\n\n` +
       `Arguments:\n` +
       `  output            Output path. If it's a directory, writes extension.zip inside.\n` +
       `                    Defaults to ${relative(REPO_ROOT, DEFAULT_OUTPUT)}.\n\n` +
       `Options:\n` +
       `  -o, --output      Same as the positional argument.\n` +
+      `      --strip-key   Remove the "key" field from manifest.json before zipping.\n` +
+      `                    Required for Chrome Web Store uploads.\n` +
       `  -h, --help        Show this help.`,
   );
   process.exit(0);
@@ -62,14 +66,39 @@ const outputPath = await resolveOutput();
 await mkdir(dirname(outputPath), { recursive: true });
 await rm(outputPath, { force: true });
 
-// `zip -r` from inside DIST so manifest.json sits at the archive root, which
-// Browserbase requires. -x excludes sourcemaps to keep the upload small.
+// When --strip-key is set, stage dist/ into a temp dir and rewrite manifest.json
+// there. Mutating dist/ in place would race with concurrent builds.
+let zipRoot = DIST;
+let stagedRoot: string | undefined;
+if (values["strip-key"]) {
+  stagedRoot = await mkdtemp(join(tmpdir(), "abs-package-"));
+  await cp(DIST, stagedRoot, { recursive: true });
+  const manifestPath = join(stagedRoot, "manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const hadKey = Object.hasOwn(manifest, "key");
+  delete manifest.key;
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(
+    hadKey
+      ? `Stripped manifest.key for Chrome Web Store compatibility`
+      : `manifest.key not present; --strip-key was a no-op`,
+  );
+  zipRoot = stagedRoot;
+}
+
+// `zip -r` from inside the source root so manifest.json sits at the archive
+// root, which Browserbase and CWS both require. -x excludes sourcemaps to keep
+// the upload small.
 const result = await Bun.spawn({
   cmd: ["zip", "-r", "-q", outputPath, ".", "-x", "*.map"],
-  cwd: DIST,
+  cwd: zipRoot,
   stdout: "inherit",
   stderr: "inherit",
 }).exited;
+
+if (stagedRoot) {
+  await rm(stagedRoot, { recursive: true, force: true });
+}
 
 if (result !== 0) {
   console.error(`zip exited with status ${result}`);


### PR DESCRIPTION
## Summary
- Extends `release-extension.yml` with `workflow_dispatch` inputs (`publish_s3`, `publish_chrome_web_store`) so one manual run can ship to any combination of S3 and the public Chrome Web Store. Build/version/package run once and feed every target. S3 default stays `true`; CWS default is `false` until the listing and OAuth secrets are configured.
- Adds `--strip-key` to `scripts/package-extension.ts` (stages `extension/dist/` to a tempdir, drops `manifest.key`, zips from the tempdir). Today a no-op since the source manifest has no `key`, but CWS rejects manifests containing one — having this wired now means adding a stable dev `key` later won't quietly break publishing.
- `ci.yml` emits a sibling `extension-cws.zip` workflow artifact (`extension-cws-zip`) on pushes to `main`, so the initial CWS listing can be created from a known-good CI build. PRs are unaffected.
- CWS upload + publish uses `chrome-webstore-upload-cli@3` via `npx` — avoids a third-party Action's trust boundary on a credential that can ship malware to users. Publish target is the public listing (CWS still performs human review). S3 step runs first; a CWS failure leaves S3 in a coherent state.

## Prerequisites before the CWS toggle becomes useful
1. CWS developer account; manually create the initial listing using the `extension-cws-zip` artifact from a green main build and record the extension ID.
2. Google Cloud OAuth Desktop-app client with the Chrome Web Store API enabled; generate a refresh token.
3. Add four GitHub Actions secrets: `CWS_EXTENSION_ID`, `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN`.

## Test plan
- [x] `bun run package` and `bun run package:cws` both produce valid zips locally.
- [x] With no `key` in the source manifest, `--strip-key` logs a no-op and the resulting zip's `manifest.json` has no `key`.
- [x] After injecting a fake `key` into `dist/manifest.json`, `--strip-key` logs "Stripped manifest.key…" and the resulting zip's `manifest.json` has no `key`. (Restored after.)
- [x] `bun run check`, `bunx tsc --noEmit`, `bun run test` (405 tests), `ruff check`, `ruff format --check` all green.
- [ ] Merge to `main` → CI run uploads both `extension.zip` and `extension-cws-zip` artifacts.
- [ ] Once secrets are configured: manual run of `Release extension` with `publish_chrome_web_store=true, publish_s3=false` lands a new pending-review version in the CWS dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)