### PR TITLE
Add experimental cross-origin-frame-hide rule

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -108,20 +108,18 @@ domains, where embeds are the page content.
 
 Replace every `<iframe>` whose `src` resolves to a different web origin with a
 click-to-reveal placeholder, so a browser-use agent reading the parent page
-doesn't ingest the embedded-origin content. Same-origin frames, `srcdoc`
-frames, and inert `about:`/`javascript:`/`data:`/`blob:` frames are left
-alone. Each frame in the page processes its own direct children, so a
-cross-origin frame nested inside a same-origin frame is also caught. Off by
-default because legitimate cross-origin embeds (payment widgets, OAuth
-pop-ins, video, third-party comments) are common and removing them will
-break those flows until the user reveals.
+doesn't ingest the embedded-origin content. Same-origin frames, `srcdoc` frames,
+and inert `about:`/`javascript:`/`data:`/`blob:` frames are left alone. Each
+frame in the page processes its own direct children, so a cross-origin frame
+nested inside a same-origin frame is also caught. Off by default because
+legitimate cross-origin embeds (payment widgets, OAuth pop-ins, video,
+third-party comments) are common and removing them will break those flows until
+the user reveals.
 
 Motivated by Roesner & Kohlbrenner,
-[*Agentic Browsers and the Same-Origin
-Policy*](https://www.franziroesner.com/pdf/roesner_kohlbrenner_2026_agentic_sop.pdf)
-(ICLR 2026 Workshop), which shows that agents willing to read cross-origin
-frame content turn the same-origin policy from a hard guarantee into a soft
-one.
+[*Agentic Browsers and the Same-Origin Policy*](https://www.franziroesner.com/pdf/roesner_kohlbrenner_2026_agentic_sop.pdf)
+(ICLR 2026 Workshop), which shows that agents willing to read cross-origin frame
+content turn the same-origin policy from a hard guarantee into a soft one.
 
 ## Dark-pattern blocking
 

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -3,7 +3,7 @@ title: Rules reference
 description: The defense rules shipped with agent-browser-shield, what each one does, and its default state.
 ---
 
-The extension ships 20 rules grouped into five rough categories. Each rule is
+The extension ships 21 rules grouped into five rough categories. Each rule is
 independently toggleable from the extension popup. Rules marked **default: on**
 are active on fresh install; **default: off** rules must be enabled manually.
 
@@ -100,6 +100,28 @@ Hide embedded social-media widgets (Twitter/X, YouTube, Facebook, Instagram,
 TikTok, LinkedIn, Reddit, Spotify, SoundCloud). Replaced with a placeholder so
 the agent knows an embed lived there. Skipped on the embed providers' own
 domains, where embeds are the page content.
+
+### Hide Cross-Origin Frames (Experimental)
+
+- **ID:** `cross-origin-frame-hide`
+- **Default:** off
+
+Replace every `<iframe>` whose `src` resolves to a different web origin with a
+click-to-reveal placeholder, so a browser-use agent reading the parent page
+doesn't ingest the embedded-origin content. Same-origin frames, `srcdoc`
+frames, and inert `about:`/`javascript:`/`data:`/`blob:` frames are left
+alone. Each frame in the page processes its own direct children, so a
+cross-origin frame nested inside a same-origin frame is also caught. Off by
+default because legitimate cross-origin embeds (payment widgets, OAuth
+pop-ins, video, third-party comments) are common and removing them will
+break those flows until the user reveals.
+
+Motivated by Roesner & Kohlbrenner,
+[*Agentic Browsers and the Same-Origin
+Policy*](https://www.franziroesner.com/pdf/roesner_kohlbrenner_2026_agentic_sop.pdf)
+(ICLR 2026 Workshop), which shows that agents willing to read cross-origin
+frame content turn the same-origin policy from a hard guarantee into a soft
+one.
 
 ## Dark-pattern blocking
 

--- a/extension/src/lib/placeholder.ts
+++ b/extension/src/lib/placeholder.ts
@@ -87,6 +87,9 @@ const RULE_ICON_PATHS: Partial<Record<RuleId, string>> = {
   "footer-hide": "M4 5h16v10H4zM4 19h16",
   "social-embed-hide": "M5 9h14M5 15h14M10 5l-2 14M16 5l-2 14",
   "irrelevant-sections-hide": "M3 4h18l-7 9v6l-4 2v-8L3 4z",
+  // Globe with one meridian + one parallel — signals "different web origin".
+  "cross-origin-frame-hide":
+    "M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18zM3 12h18M12 3c2.5 2.5 4 5.7 4 9s-1.5 6.5-4 9c-2.5-2.5-4-5.7-4-9s1.5-6.5 4-9z",
 };
 
 function createIcon(ruleId: RuleId): SVGSVGElement {

--- a/extension/src/rules/cross-origin-frame-hide.ts
+++ b/extension/src/rules/cross-origin-frame-hide.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Remove cross-origin <iframe> elements and replace them with a click-to-reveal
+// placeholder so a browser-use agent reading the parent page never ingests the
+// embedded-origin content unless the user explicitly opts in.
+//
+// Motivation: Roesner & Kohlbrenner ("Agentic Browsers and the Same-Origin
+// Policy", ICLR 2026 Workshop) show that an agent willing to read content from
+// an embedded cross-origin frame turns a successful prompt injection into a
+// same-origin-policy bypass — exfiltrating cross-origin data, forging
+// cross-origin actions, etc. Removing the iframe entirely is a stronger
+// defense than provenance markers: the agent can't be misled about content it
+// never sees. Ships off by default because legitimate cross-origin embeds
+// (payment widgets, OAuth pop-ins, video, embeds) are common.
+//
+// Per-frame: the extension's content script runs in every frame via
+// all_frames: true, so each frame independently hides its own direct
+// cross-origin iframe children. Nested cross-origin frames inside a
+// same-origin iframe are caught by the same-origin frame's own instance.
+
+import { REVEALED_ATTR, replaceWithBlockPlaceholder } from "../lib/placeholder";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import type { Rule } from "./types";
+
+const RULE_ID = "cross-origin-frame-hide" as const;
+
+function resolveOrigin(iframe: HTMLIFrameElement): string | null {
+  // srcdoc iframes inherit the embedding origin — not a cross-origin threat.
+  if (iframe.hasAttribute("srcdoc")) return null;
+  const raw = iframe.getAttribute("src");
+  if (!raw) return null;
+  let url: URL;
+  try {
+    url = new URL(raw, document.baseURI);
+  } catch {
+    return null;
+  }
+  // Only http(s) iframes carry a distinct web origin. about:, javascript:,
+  // data:, blob: all either inherit the parent origin or are inert for our
+  // purposes; skip them.
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  return url.origin;
+}
+
+function hideIfCrossOrigin(iframe: HTMLIFrameElement): void {
+  // Skip iframes the user has already revealed for this rule, so the subtree
+  // observer doesn't immediately re-hide the just-restored content.
+  if (iframe.getAttribute(REVEALED_ATTR) === RULE_ID) return;
+  const origin = resolveOrigin(iframe);
+  if (!origin || origin === globalThis.location.origin) return;
+  replaceWithBlockPlaceholder(
+    iframe,
+    RULE_ID,
+    `Cross-origin frame from ${origin}`,
+  );
+}
+
+function scan(root: ParentNode): void {
+  for (const iframe of root.querySelectorAll<HTMLIFrameElement>("iframe")) {
+    if (!iframe.isConnected) continue;
+    hideIfCrossOrigin(iframe);
+  }
+}
+
+const watcher = createSubtreeWatcher({
+  onSubtrees: (roots) => {
+    for (const root of roots) scan(root);
+  },
+  skipPlaceholderSubtrees: true,
+});
+
+function apply(root: ParentNode): void {
+  scan(root);
+  watcher.start(root);
+}
+
+function teardown(): void {
+  // The rule engine calls revealAll() before teardown(), so placeholders are
+  // already restored to their original iframes by the time we get here.
+  watcher.stop();
+}
+
+export const crossOriginFrameHideRule = {
+  id: RULE_ID,
+  label: "Hide Cross-Origin Frames (Experimental)",
+  description:
+    "Remove cross-origin iframes from the page and replace them with a click-to-reveal placeholder, so browser-use agents don't ingest embedded-origin content unless the user opts in.",
+  defaultEnabled: false,
+  apply,
+  teardown,
+} satisfies Rule;

--- a/extension/src/rules/index.ts
+++ b/extension/src/rules/index.ts
@@ -8,6 +8,7 @@ import { checkoutCheckboxClearRule } from "./checkout-checkbox-clear";
 import { commentsHideRule } from "./comments-hide";
 import { cookieBannerHideRule } from "./cookie-banner-hide";
 import { countdownTimerHideRule } from "./countdown-timer-hide";
+import { crossOriginFrameHideRule } from "./cross-origin-frame-hide";
 import { footerHideRule } from "./footer-hide";
 import { hiddenTextStripRule } from "./hidden-text-strip";
 import { htmlCommentStripRule } from "./html-comment-strip";
@@ -51,6 +52,7 @@ const RULES_TUPLE = [
   cartAddonFlagRule,
   searchUrlHelperRule,
   irrelevantSectionsHideRule,
+  crossOriginFrameHideRule,
 ] as const satisfies readonly Rule[];
 
 export type RuleId = (typeof RULES_TUPLE)[number]["id"];

--- a/skills/agent-browser-shield-config/SKILL.md
+++ b/skills/agent-browser-shield-config/SKILL.md
@@ -77,8 +77,8 @@ keys and non-boolean values are rejected with an error.
   the toggle shows as Unavailable. Hidden sections become click-to-reveal
   placeholders.
 - `cross-origin-frame-hide` — **experimental, off by default.** Replace
-  cross-origin `<iframe>` elements with click-to-reveal placeholders so an
-  agent reading the parent page doesn't ingest the embedded-origin content.
+  cross-origin `<iframe>` elements with click-to-reveal placeholders so an agent
+  reading the parent page doesn't ingest the embedded-origin content.
   Same-origin frames, `srcdoc` frames, and inert (`about:`/`javascript:`/
   `data:`/`blob:`) frames are left alone. Off by default because legitimate
   cross-origin embeds (payment widgets, OAuth pop-ins, video) are common and

--- a/skills/agent-browser-shield-config/SKILL.md
+++ b/skills/agent-browser-shield-config/SKILL.md
@@ -76,3 +76,10 @@ keys and non-boolean values are rejected with an error.
   via `OPENAI_API_KEY` or saved on the options page. Until a key is configured
   the toggle shows as Unavailable. Hidden sections become click-to-reveal
   placeholders.
+- `cross-origin-frame-hide` — **experimental, off by default.** Replace
+  cross-origin `<iframe>` elements with click-to-reveal placeholders so an
+  agent reading the parent page doesn't ingest the embedded-origin content.
+  Same-origin frames, `srcdoc` frames, and inert (`about:`/`javascript:`/
+  `data:`/`blob:`) frames are left alone. Off by default because legitimate
+  cross-origin embeds (payment widgets, OAuth pop-ins, video) are common and
+  removing them breaks those flows until revealed.


### PR DESCRIPTION
## Summary

- New defense rule `cross-origin-frame-hide` (experimental, **off by default**) that replaces every cross-origin `<iframe>` with a click-to-reveal placeholder, so a browser-use agent reading the parent page doesn't ingest the embedded-origin content unless the user opts in. Same-origin, `srcdoc`, and inert (`about:`/`javascript:`/`data:`/`blob:`) frames are left alone. Runs in every frame, so cross-origin frames nested inside same-origin frames are also caught.
- Adds a globe icon for the rule in `RULE_ICON_PATHS`.
- Documents the rule under *Prompt-injection defense* in `docs/src/content/docs/rules.md`, with a link to the motivating paper: Roesner & Kohlbrenner, [*Agentic Browsers and the Same-Origin Policy*](https://www.franziroesner.com/pdf/roesner_kohlbrenner_2026_agentic_sop.pdf) (ICLR 2026 Workshop). Updates the `agent-browser-shield-config` skill's rule list.

The paper shows current agentic browsers vary widely in how they honor the same-origin policy when reading page content. A successful prompt injection plus cross-origin read access lets an attacker page exfiltrate content from an embedded sensitive iframe — i.e., SOP becomes soft. Removing the iframe entirely is a stronger defense than provenance-only annotation; an annotation-only defense bets on the model behavior we can't verify.

## Test plan

- [x] `bun run check` (Biome + ESLint) — clean
- [x] `bun run build` — codegen + extension bundle succeed
- [x] `bun run test` — 445/445 pass
- [x] `astro build` in `docs/` — 8 pages built, rules page renders new entry
- [ ] Manual: load the unpacked extension, enable the new rule in the popup, open a page with a YouTube embed → iframe replaced by `Cross-origin frame from https://www.youtube.com` placeholder with globe icon; click the placeholder → iframe restored and loads normally
- [ ] Manual: confirm same-origin iframes are untouched
- [ ] Manual: confirm a nested case (top frame → same-origin iframe → cross-origin iframe) hides the inner iframe
- [ ] Manual: toggle off → all `[data-abs-rule="cross-origin-frame-hide"]` placeholders gone, originals restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)