### PR TITLE
docs: cite SusBench and DECEPTICON dark-pattern agent benchmarks

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -151,3 +151,17 @@ uv run scripts/benchmark_run.py ... --scenario 'haiku-*' --task 'hn-*'
   be backfilled with `benchmark_report.py --judge`. Re-grading every row (after
   changing model / prompt) is `--judge --rejudge` and doesn't burn Browserbase
   sessions.
+
+## Related work
+
+This harness measures the end-to-end task success delta from running the
+extension. For benchmarks focused specifically on agent susceptibility to
+manipulative UI:
+
+- [SusBench](https://arxiv.org/abs/2510.11035) (Guo et al., 2025) — 313 tasks
+  across 55 real websites measuring computer-use agent susceptibility to dark
+  patterns, with a human-participant baseline.
+- [DECEPTICON](https://arxiv.org/abs/2512.22894) (Cuvin et al., 2025) — 700
+  web-navigation tasks featuring dark patterns; finds agents fall for them at
+  roughly twice the rate of humans and that standard prompting/guardrail
+  defenses are insufficient.

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -104,7 +104,10 @@ domains, where embeds are the page content.
 ## Dark-pattern blocking
 
 Block manipulative UI patterns that work on humans and can mislead agents the
-same way.
+same way. For evidence that current computer-use agents are highly susceptible
+to these patterns — sometimes more so than humans — see
+[SusBench](https://arxiv.org/abs/2510.11035) (Guo et al., 2025) and
+[DECEPTICON](https://arxiv.org/abs/2512.22894) (Cuvin et al., 2025).
 
 ### Hide Countdown Timers
 


### PR DESCRIPTION
## Summary
- Adds short references to two arXiv papers on agent susceptibility to dark patterns: [SusBench](https://arxiv.org/abs/2510.11035) (Guo et al., 2025) and [DECEPTICON](https://arxiv.org/abs/2512.22894) (Cuvin et al., 2025).
- Citations land under the "Dark-pattern blocking" heading in `docs/src/content/docs/rules.md` and in a new "Related work" section in `benchmark/README.md`.

## Test plan
- [ ] `docs` site builds without broken-link warnings for the new arXiv URLs
- [ ] Spot-check rendered "Dark-pattern blocking" section and benchmark README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)