### PR TITLE
chore: gitignore Claude Code local runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,11 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Claude Code local runtime state — ignore everything except shared project config
+.claude/*
+!.claude/settings.json
+!.claude/commands/
+!.claude/agents/
+
 # Misc
 .playwright-mcp/


### PR DESCRIPTION
## Summary
- Ignore `.claude/*` (session locks, agent worktrees, other per-machine runtime state)
- Allow-list `settings.json`, `commands/`, and `agents/` so we can opt into sharing project-level Claude Code config later without further `.gitignore` changes

## Test plan
- [x] `git status` no longer shows `.claude/` as untracked
- [x] `git check-ignore -v .claude/scheduled_tasks.lock .claude/worktrees/` confirms both are matched by the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)