### PR TITLE
docs: fix OpenClaw tip aside not rendering

### DIFF
--- a/docs/src/content/docs/openclaw.md
+++ b/docs/src/content/docs/openclaw.md
@@ -16,10 +16,11 @@ to. Two paths work:
 
 The rest of this page covers both.
 
-:::tip[Skill-aware agents] If you're driving OpenClaw with a skill-aware agent,
-install the `agent-browser-shield` skill from ClawHub instead of pasting these
-steps into a prompt — it bundles the install paths below plus the runtime
-behavior rules:
+:::tip[Skill-aware agents]
+
+If you're driving OpenClaw with a skill-aware agent, install the
+`agent-browser-shield` skill from ClawHub instead of pasting these steps into a
+prompt — it bundles the install paths below plus the runtime behavior rules:
 
 ```sh
 clawhub install agent-browser-shield


### PR DESCRIPTION
## Summary

- The `:::tip[Skill-aware agents]` aside on the OpenClaw page was rendering as plain text because the body started on the same line as the opening fence — remark-directive parsed everything after `]` as part of the label rather than as content.
- Moved the body to its own line (with a blank line after the fence) so Starlight renders it as a proper tip aside.
- Verified `bun run build` produces `<aside class="starlight-aside starlight-aside--tip">…</aside>` and that both `mdformat` and `markdownlint-cli2` leave the directive intact.

## Test plan

- [ ] `cd docs && bun run build` succeeds
- [ ] `/openclaw/` page shows the green "Skill-aware agents" tip box (not plain text)
- [ ] `pre-commit run --files docs/src/content/docs/openclaw.md` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)