### PR TITLE
Add help links to popup and options surfaces

### DIFF
--- a/extension/src/lib/HelpLinks.tsx
+++ b/extension/src/lib/HelpLinks.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+const LINKS = [
+  { href: "https://pixiebrix.github.io/agent-browser-shield/", label: "Docs" },
+  {
+    href: "https://github.com/pixiebrix/agent-browser-shield",
+    label: "GitHub",
+  },
+  {
+    href: "https://github.com/pixiebrix/agent-browser-shield/issues",
+    label: "Report a bug",
+  },
+] as const;
+
+export function HelpLinks({ className }: { className?: string }) {
+  return (
+    <nav className={className} aria-label="Help and project links">
+      {LINKS.map((link, index) => (
+        <span key={link.href}>
+          {index > 0 && <span aria-hidden="true"> · </span>}
+          <a href={link.href} target="_blank" rel="noreferrer">
+            {link.label}
+          </a>
+        </span>
+      ))}
+    </nav>
+  );
+}

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -285,6 +285,19 @@
         font-size: 11px;
         color: #888;
       }
+      .footer__links {
+        margin-bottom: 6px;
+      }
+      .footer__links a {
+        color: #2563eb;
+        text-decoration: none;
+      }
+      .footer__links a:hover {
+        text-decoration: underline;
+      }
+      .footer__copyright {
+        color: #888;
+      }
     </style>
   </head>
   <body>

--- a/extension/src/options/Options.tsx
+++ b/extension/src/options/Options.tsx
@@ -12,6 +12,7 @@ import {
   type RuleAvailabilityStates,
   subscribeRuleAvailability,
 } from "../lib/availability";
+import { HelpLinks } from "../lib/HelpLinks";
 import {
   getPlaceholderDisplayMode,
   type PlaceholderDisplayMode,
@@ -372,7 +373,10 @@ export function Options() {
         </ul>
       </section>
 
-      <footer className="footer">© PixieBrix 2026</footer>
+      <footer className="footer">
+        <HelpLinks className="footer__links" />
+        <div className="footer__copyright">© PixieBrix 2026</div>
+      </footer>
     </div>
   );
 }

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -178,6 +178,21 @@
         padding: 14px;
         color: #888;
       }
+      .popup__footer {
+        margin-top: 12px;
+        padding-top: 10px;
+        border-top: 1px solid #e4e4e7;
+        text-align: center;
+        font-size: 11px;
+        color: #888;
+      }
+      .popup__footer a {
+        color: #2563eb;
+        text-decoration: none;
+      }
+      .popup__footer a:hover {
+        text-decoration: underline;
+      }
     </style>
   </head>
   <body>

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -12,6 +12,7 @@ import {
   setEnforcementEnabled,
   subscribeEnforcementEnabled,
 } from "../lib/enforcement";
+import { HelpLinks } from "../lib/HelpLinks";
 import {
   getRuleStates,
   type RuleStates,
@@ -147,6 +148,7 @@ export function Popup() {
           );
         })}
       </ul>
+      <HelpLinks className="popup__footer" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- New `HelpLinks` component (`extension/src/lib/HelpLinks.tsx`) rendering Docs · GitHub · Report a bug.
- Rendered at the bottom of the popup, and as a row above the existing copyright in the options page.
- Bug-report link points to `/issues` (search-and-file) rather than `/issues/new`, to surface duplicates.

## Test plan
- [ ] Load the unpacked `extension/dist/` build and confirm links render in the popup and options page.
- [ ] Click each link and confirm it opens the correct URL in a new tab.
- [ ] `bun run check` and `bun run test` are green (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)