### PR TITLE
ci: upload release extension zip as workflow artifact

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -70,6 +70,14 @@ jobs:
         working-directory: extension
         run: bun run package
 
+      - name: Upload extension zip as workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: extension-zip-${{ steps.version.outputs.tag }}
+          path: output/extension.zip
+          archive: false
+          if-no-files-found: error
+
       - uses: aws-actions/configure-aws-credentials@v4
         if: ${{ inputs.publish_s3 }}
         with:


### PR DESCRIPTION
## Summary
- Adds an `actions/upload-artifact@v7` step to `release-extension.yml` so the packaged `output/extension.zip` is available from the workflow run itself, alongside the existing S3 + GitHub Release uploads.
- Pinned to `@v7` to match `ci.yml`; latest release (v7.0.1, 2026-04-10) is well outside the 7-day Dependabot cooldown.

## Test plan
- [ ] Trigger the `Release extension` workflow via `workflow_dispatch` and confirm an `extension-zip-vYYYY.M.D.N` artifact appears on the run summary page.
- [ ] Confirm the artifact downloads as a single `extension.zip` (not a wrapping zip) — `archive: false` should preserve that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)