### PR TITLE
Collapse React surface duplication

### DIFF
--- a/extension/src/lib/RuleList.tsx
+++ b/extension/src/lib/RuleList.tsx
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import { RULES } from "../rules";
+import type { RuleAvailabilityStates } from "./availability";
+import { type RuleStates, setRuleEnabled } from "./storage";
+
+// Shared per-rule checkbox list rendered by both the popup and options page.
+// Pass `disabledByEnforcement` when the surface should grey out every rule
+// (popup, when global enforcement is off); the options page omits it because
+// the user can still edit preferences while enforcement is paused.
+export function RuleList({
+  states,
+  availability,
+  disabledByEnforcement = false,
+  className,
+}: {
+  states: RuleStates;
+  availability: RuleAvailabilityStates;
+  disabledByEnforcement?: boolean;
+  className?: string;
+}) {
+  const listClass = className ? `rules ${className}` : "rules";
+  return (
+    <ul
+      className={
+        disabledByEnforcement
+          ? `${listClass} rules--enforcement-off`
+          : listClass
+      }
+    >
+      {RULES.map((rule) => {
+        const snapshot = availability[rule.id];
+        const unavailable = !snapshot?.available;
+        const disabled = unavailable || disabledByEnforcement;
+        return (
+          <li
+            key={rule.id}
+            className={unavailable ? "rule rule--unavailable" : "rule"}
+          >
+            <label>
+              <input
+                type="checkbox"
+                checked={unavailable ? false : states[rule.id]}
+                disabled={disabled}
+                onChange={(event) => {
+                  void setRuleEnabled(rule.id, event.target.checked);
+                }}
+              />
+              <div>
+                <strong>
+                  {rule.label}
+                  {unavailable && <span className="badge">Unavailable</span>}
+                </strong>
+                {unavailable && snapshot?.reason && (
+                  <p className="unavailable-reason">{snapshot.reason}</p>
+                )}
+                <p>{rule.description}</p>
+              </div>
+            </label>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/extension/src/lib/api-key-storage.ts
+++ b/extension/src/lib/api-key-storage.ts
@@ -5,36 +5,22 @@
 // rule-state storage so the background service worker doesn't transitively
 // import every rule module just to read a key.
 
-const API_KEY_STORAGE_KEY = "agent-browser-shield.openai-api-key";
+import { createChromeStorageValue } from "./chrome-storage-value";
 
 // True when the build was produced with an OPENAI_API_KEY bundled in.
 // Substituted at build time via Bun `define` (see globals.d.ts / build.ts).
 export const HAS_BUILT_IN_OPENAI_KEY =
   process.env.HAS_BUILT_IN_OPENAI_KEY === "true";
 
-export async function getUserApiKey(): Promise<string> {
-  const stored = await chrome.storage.local.get(API_KEY_STORAGE_KEY);
-  const value = stored[API_KEY_STORAGE_KEY];
-  return typeof value === "string" ? value : "";
+function normalize(raw: unknown): string {
+  return typeof raw === "string" ? raw : "";
 }
 
-export async function setUserApiKey(key: string): Promise<void> {
-  await chrome.storage.local.set({ [API_KEY_STORAGE_KEY]: key });
-}
+export const apiKeyStorage = createChromeStorageValue<string>({
+  key: "agent-browser-shield.openai-api-key",
+  normalize,
+});
 
-export function subscribeUserApiKey(
-  listener: (key: string) => void,
-): () => void {
-  const handler = (
-    changes: Record<string, chrome.storage.StorageChange>,
-    areaName: string,
-  ) => {
-    if (areaName !== "local") return;
-    const change = changes[API_KEY_STORAGE_KEY];
-    if (!change) return;
-    const value = change.newValue;
-    listener(typeof value === "string" ? value : "");
-  };
-  chrome.storage.onChanged.addListener(handler);
-  return () => chrome.storage.onChanged.removeListener(handler);
-}
+export const getUserApiKey = apiKeyStorage.get;
+export const setUserApiKey = apiKeyStorage.set;
+export const subscribeUserApiKey = apiKeyStorage.subscribe;

--- a/extension/src/lib/availability.ts
+++ b/extension/src/lib/availability.ts
@@ -66,6 +66,13 @@ export function subscribeRuleAvailability(
   };
 }
 
+// Stable source bundle for use with `useChromeStorageValue`. Frozen so the
+// hook's effect dep stays referentially stable across renders.
+export const availabilitySource = Object.freeze({
+  get: getRuleAvailabilityStates,
+  subscribe: subscribeRuleAvailability,
+});
+
 // Factory for rules that depend on the OpenAI API key being available — either
 // bundled at build time or supplied by the user via the options page. The
 // snapshot recomputes when the stored user key changes so the popup/options

--- a/extension/src/lib/chrome-storage-value.ts
+++ b/extension/src/lib/chrome-storage-value.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Factory for a typed value persisted under a single key in
+// `chrome.storage.local`. Wraps the get / set / onChanged plumbing so each
+// stored setting (rule states, enforcement flag, placeholder display mode,
+// user API key) only has to declare its key, default, and normalization.
+//
+// The subscribe callback always receives both the new and previous normalized
+// values — callers that only care about the new value can take a single
+// parameter (TypeScript silently allows narrower listeners).
+
+export interface ChromeStorageValue<T> {
+  get(): Promise<T>;
+  set(value: T): Promise<void>;
+  subscribe(listener: (next: T, previous: T) => void): () => void;
+}
+
+export function createChromeStorageValue<T>(options: {
+  key: string;
+  normalize: (raw: unknown) => T;
+}): ChromeStorageValue<T> {
+  const { key, normalize } = options;
+  return {
+    async get() {
+      const stored = await chrome.storage.local.get(key);
+      return normalize(stored[key]);
+    },
+    async set(value) {
+      await chrome.storage.local.set({ [key]: value });
+    },
+    subscribe(listener) {
+      const handler = (
+        changes: Record<string, chrome.storage.StorageChange>,
+        areaName: string,
+      ) => {
+        if (areaName !== "local") return;
+        const change = changes[key];
+        if (!change) return;
+        listener(normalize(change.newValue), normalize(change.oldValue));
+      };
+      chrome.storage.onChanged.addListener(handler);
+      return () => chrome.storage.onChanged.removeListener(handler);
+    },
+  };
+}

--- a/extension/src/lib/enforcement.ts
+++ b/extension/src/lib/enforcement.ts
@@ -9,7 +9,7 @@
 // rule-state listener path and so the per-rule preferences survive across
 // disable/enable cycles.
 
-const STORAGE_KEY = "agent-browser-shield.enforcement-enabled";
+import { createChromeStorageValue } from "./chrome-storage-value";
 
 export const ENFORCEMENT_ENABLED_DEFAULT = true;
 
@@ -17,27 +17,11 @@ function normalize(raw: unknown): boolean {
   return typeof raw === "boolean" ? raw : ENFORCEMENT_ENABLED_DEFAULT;
 }
 
-export async function getEnforcementEnabled(): Promise<boolean> {
-  const stored = await chrome.storage.local.get(STORAGE_KEY);
-  return normalize(stored[STORAGE_KEY]);
-}
+export const enforcementStorage = createChromeStorageValue<boolean>({
+  key: "agent-browser-shield.enforcement-enabled",
+  normalize,
+});
 
-export async function setEnforcementEnabled(enabled: boolean): Promise<void> {
-  await chrome.storage.local.set({ [STORAGE_KEY]: enabled });
-}
-
-export function subscribeEnforcementEnabled(
-  listener: (enabled: boolean) => void,
-): () => void {
-  const handler = (
-    changes: Record<string, chrome.storage.StorageChange>,
-    areaName: string,
-  ) => {
-    if (areaName !== "local") return;
-    const change = changes[STORAGE_KEY];
-    if (!change) return;
-    listener(normalize(change.newValue));
-  };
-  chrome.storage.onChanged.addListener(handler);
-  return () => chrome.storage.onChanged.removeListener(handler);
-}
+export const getEnforcementEnabled = enforcementStorage.get;
+export const setEnforcementEnabled = enforcementStorage.set;
+export const subscribeEnforcementEnabled = enforcementStorage.subscribe;

--- a/extension/src/lib/placeholder-display.ts
+++ b/extension/src/lib/placeholder-display.ts
@@ -4,7 +4,7 @@
 // Stored separately from rule states so changing the cosmetic display mode
 // doesn't churn the rule-state listener path used by the engine and UIs.
 
-const STORAGE_KEY = "agent-browser-shield.placeholder-display-mode";
+import { createChromeStorageValue } from "./chrome-storage-value";
 
 export type PlaceholderDisplayMode = "icon" | "button";
 
@@ -16,29 +16,13 @@ function normalize(raw: unknown): PlaceholderDisplayMode {
     : PLACEHOLDER_DISPLAY_MODE_DEFAULT;
 }
 
-export async function getPlaceholderDisplayMode(): Promise<PlaceholderDisplayMode> {
-  const stored = await chrome.storage.local.get(STORAGE_KEY);
-  return normalize(stored[STORAGE_KEY]);
-}
+export const placeholderDisplayStorage =
+  createChromeStorageValue<PlaceholderDisplayMode>({
+    key: "agent-browser-shield.placeholder-display-mode",
+    normalize,
+  });
 
-export async function setPlaceholderDisplayMode(
-  mode: PlaceholderDisplayMode,
-): Promise<void> {
-  await chrome.storage.local.set({ [STORAGE_KEY]: mode });
-}
-
-export function subscribePlaceholderDisplayMode(
-  listener: (mode: PlaceholderDisplayMode) => void,
-): () => void {
-  const handler = (
-    changes: Record<string, chrome.storage.StorageChange>,
-    areaName: string,
-  ) => {
-    if (areaName !== "local") return;
-    const change = changes[STORAGE_KEY];
-    if (!change) return;
-    listener(normalize(change.newValue));
-  };
-  chrome.storage.onChanged.addListener(handler);
-  return () => chrome.storage.onChanged.removeListener(handler);
-}
+export const getPlaceholderDisplayMode = placeholderDisplayStorage.get;
+export const setPlaceholderDisplayMode = placeholderDisplayStorage.set;
+export const subscribePlaceholderDisplayMode =
+  placeholderDisplayStorage.subscribe;

--- a/extension/src/lib/storage.ts
+++ b/extension/src/lib/storage.ts
@@ -2,10 +2,9 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { RULE_IDS, RULES, type RuleId } from "../rules";
+import { createChromeStorageValue } from "./chrome-storage-value";
 
 export type RuleStates = Record<RuleId, boolean>;
-
-const STORAGE_KEY = "agent-browser-shield.rules";
 
 // Defaults derived once at module load — each rule carries its own
 // `defaultEnabled` flag. Availability is resolved separately via
@@ -31,44 +30,32 @@ function normalize(raw: unknown): RuleStates {
   return result;
 }
 
-export async function getRuleStates(): Promise<RuleStates> {
-  const stored = await chrome.storage.local.get(STORAGE_KEY);
-  return normalize(stored[STORAGE_KEY]);
-}
-
-export async function setRuleEnabled(
-  id: RuleId,
-  enabled: boolean,
-): Promise<void> {
-  const current = await getRuleStates();
-  current[id] = enabled;
-  await chrome.storage.local.set({ [STORAGE_KEY]: current });
-}
-
-export async function setAllRuleStates(
-  states: Partial<RuleStates>,
-): Promise<void> {
-  const next = normalize(states);
-  await chrome.storage.local.set({ [STORAGE_KEY]: next });
-}
+export const ruleStatesStorage = createChromeStorageValue<RuleStates>({
+  key: "agent-browser-shield.rules",
+  normalize,
+});
 
 export type RuleStatesListener = (
   next: RuleStates,
   previous: RuleStates,
 ) => void;
 
-export function subscribe(listener: RuleStatesListener): () => void {
-  const handler = (
-    changes: Record<string, chrome.storage.StorageChange>,
-    areaName: string,
-  ) => {
-    if (areaName !== "local") return;
-    const change = changes[STORAGE_KEY];
-    if (!change) return;
-    listener(normalize(change.newValue), normalize(change.oldValue));
-  };
-  chrome.storage.onChanged.addListener(handler);
-  return () => chrome.storage.onChanged.removeListener(handler);
+export const getRuleStates = ruleStatesStorage.get;
+export const subscribe = ruleStatesStorage.subscribe;
+
+export async function setRuleEnabled(
+  id: RuleId,
+  enabled: boolean,
+): Promise<void> {
+  const current = await ruleStatesStorage.get();
+  current[id] = enabled;
+  await ruleStatesStorage.set(current);
+}
+
+export async function setAllRuleStates(
+  states: Partial<RuleStates>,
+): Promise<void> {
+  await ruleStatesStorage.set(normalize(states));
 }
 
 export { RULE_IDS, type RuleId } from "../rules";

--- a/extension/src/lib/use-chrome-storage-value.ts
+++ b/extension/src/lib/use-chrome-storage-value.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import { useEffect, useState } from "react";
+
+// Async-readable source with a change subscription. `ChromeStorageValue<T>`
+// structurally satisfies this, as does the composite `availability` source.
+export interface AsyncReadableSource<T> {
+  get(): Promise<T>;
+  subscribe(listener: (next: T) => void): () => void;
+}
+
+// Reads an `AsyncReadableSource` into component state and keeps it in sync.
+// Returns `null` until the first `get()` resolves so callers can render a
+// loading state, then updates from the `subscribe` callback on every change.
+export function useChromeStorageValue<T>(
+  source: AsyncReadableSource<T>,
+): T | null {
+  const [value, setValue] = useState<T | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    source.get().then((initial) => {
+      if (!cancelled) setValue(initial);
+    });
+    const unsubscribe = source.subscribe((next) => {
+      setValue(next);
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [source]);
+  return value;
+}

--- a/extension/src/lib/use-transient-status.ts
+++ b/extension/src/lib/use-transient-status.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Brief "saved" / "applied" status messages that disappear after a delay.
+// Replaces the inline `setTimeout(setStatus(null), 1500)` pattern, which leaks
+// the timeout if the component unmounts before it fires.
+export function useTransientStatus(
+  durationMs = 1500,
+): [string | null, (message: string) => void] {
+  const [value, setValue] = useState<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+    },
+    [],
+  );
+
+  const show = useCallback(
+    (message: string) => {
+      setValue(message);
+      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        setValue(null);
+        timeoutRef.current = null;
+      }, durationMs);
+    },
+    [durationMs],
+  );
+
+  return [value, show];
+}

--- a/extension/src/options/Options.tsx
+++ b/extension/src/options/Options.tsx
@@ -2,121 +2,47 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { useEffect, useState } from "react";
-import {
-  getUserApiKey,
-  HAS_BUILT_IN_OPENAI_KEY,
-  setUserApiKey,
-} from "../lib/api-key-storage";
-import {
-  getRuleAvailabilityStates,
-  type RuleAvailabilityStates,
-  subscribeRuleAvailability,
-} from "../lib/availability";
+import { apiKeyStorage, HAS_BUILT_IN_OPENAI_KEY } from "../lib/api-key-storage";
+import { availabilitySource } from "../lib/availability";
 import { HelpLinks } from "../lib/HelpLinks";
 import {
-  getPlaceholderDisplayMode,
   type PlaceholderDisplayMode,
-  setPlaceholderDisplayMode,
-  subscribePlaceholderDisplayMode,
+  placeholderDisplayStorage,
 } from "../lib/placeholder-display";
-import {
-  getRuleStates,
-  RULE_IDS,
-  type RuleId,
-  type RuleStates,
-  setAllRuleStates,
-  setRuleEnabled,
-  subscribe,
-} from "../lib/storage";
-import { RULES } from "../rules";
-
-const RULE_ID_SET = new Set<string>(RULE_IDS);
-
-type ParseResult =
-  | { ok: true; value: Partial<RuleStates> }
-  | { ok: false; error: string };
-
-function parseConfig(input: string): ParseResult {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(input);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return { ok: false, error: `Invalid JSON: ${message}` };
-  }
-
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return {
-      ok: false,
-      error: "Expected a JSON object mapping rule IDs to booleans.",
-    };
-  }
-
-  const errors: string[] = [];
-  const result: Partial<RuleStates> = {};
-  for (const [key, value] of Object.entries(parsed)) {
-    if (!RULE_ID_SET.has(key)) {
-      errors.push(`Unknown rule: ${key}`);
-      continue;
-    }
-    if (typeof value !== "boolean") {
-      errors.push(`Non-boolean value for ${key}: ${typeof value}`);
-      continue;
-    }
-    result[key as RuleId] = value;
-  }
-
-  if (errors.length > 0) {
-    return { ok: false, error: errors.join("\n") };
-  }
-  return { ok: true, value: result };
-}
+import { RuleList } from "../lib/RuleList";
+import { ruleStatesStorage, setAllRuleStates } from "../lib/storage";
+import { useChromeStorageValue } from "../lib/use-chrome-storage-value";
+import { useTransientStatus } from "../lib/use-transient-status";
+import { parseConfig } from "./parse-config";
+import { Section } from "./Section";
 
 export function Options() {
-  const [states, setStates] = useState<RuleStates | null>(null);
+  const states = useChromeStorageValue(ruleStatesStorage);
+  const availability = useChromeStorageValue(availabilitySource);
+  const displayMode = useChromeStorageValue(placeholderDisplayStorage);
+  const storedApiKey = useChromeStorageValue(apiKeyStorage);
+
   const [draft, setDraft] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<string | null>(null);
-  const [apiKeyDraft, setApiKeyDraft] = useState("");
-  const [apiKeyStatus, setApiKeyStatus] = useState<string | null>(null);
-  const [displayMode, setDisplayMode] = useState<PlaceholderDisplayMode | null>(
-    null,
-  );
-  const [availability, setAvailability] =
-    useState<RuleAvailabilityStates | null>(null);
+  const [status, showStatus] = useTransientStatus();
+  const [apiKeyDraft, setApiKeyDraft] = useState<string | null>(null);
+  const [apiKeyStatus, showApiKeyStatus] = useTransientStatus();
 
+  // Initialize the editable API-key field from storage on first load only.
+  // Further storage changes (e.g. another tab) keep `storedApiKey` in sync via
+  // the hook; we don't blow away the user's in-progress edits.
   useEffect(() => {
-    let cancelled = false;
-    getRuleStates().then((initial) => {
-      if (!cancelled) setStates(initial);
-    });
-    getUserApiKey().then((key) => {
-      if (!cancelled) setApiKeyDraft(key);
-    });
-    getPlaceholderDisplayMode().then((mode) => {
-      if (!cancelled) setDisplayMode(mode);
-    });
-    getRuleAvailabilityStates().then((initial) => {
-      if (!cancelled) setAvailability(initial);
-    });
-    const unsubscribe = subscribe((next) => {
-      setStates(next);
-    });
-    const unsubscribeMode = subscribePlaceholderDisplayMode((mode) => {
-      setDisplayMode(mode);
-    });
-    const unsubscribeAvailability = subscribeRuleAvailability((next) => {
-      setAvailability(next);
-    });
-    return () => {
-      cancelled = true;
-      unsubscribe();
-      unsubscribeMode();
-      unsubscribeAvailability();
-    };
-  }, []);
+    if (storedApiKey !== null && apiKeyDraft === null) {
+      setApiKeyDraft(storedApiKey);
+    }
+  }, [storedApiKey, apiKeyDraft]);
 
-  if (!states || !availability) {
+  if (
+    !states ||
+    !availability ||
+    displayMode === null ||
+    apiKeyDraft === null
+  ) {
     return <div className="loading">Loading…</div>;
   }
 
@@ -138,24 +64,16 @@ export function Options() {
     const result = parseConfig(draft);
     if (!result.ok) {
       setError(result.error);
-      setStatus(null);
       return;
     }
     setError(null);
     await setAllRuleStates(result.value);
-    setStatus("Applied");
-    setTimeout(() => setStatus(null), 1500);
+    showStatus("Applied");
   };
 
   const handleSaveApiKey = async () => {
-    await setUserApiKey(apiKeyDraft.trim());
-    setApiKeyStatus("Saved");
-    setTimeout(() => setApiKeyStatus(null), 1500);
-  };
-
-  const handleDisplayModeChange = (mode: PlaceholderDisplayMode) => {
-    setDisplayMode(mode);
-    void setPlaceholderDisplayMode(mode);
+    await apiKeyStorage.set(apiKeyDraft.trim());
+    showApiKeyStatus("Saved");
   };
 
   return (
@@ -170,17 +88,7 @@ export function Options() {
         <a href="#rules">Rules</a>
       </nav>
 
-      <section id="apply" className="section">
-        <h2>
-          <a
-            href="#apply"
-            className="anchor"
-            aria-label="Link to Apply configuration"
-          >
-            #
-          </a>
-          Apply configuration
-        </h2>
+      <Section id="apply" title="Apply configuration">
         <p className="hint">
           Paste a JSON object mapping rule IDs to booleans, then click Apply.
           Replaces the full configuration: any rule not listed resets to its
@@ -209,38 +117,18 @@ export function Options() {
             </span>
           )}
         </div>
-      </section>
+      </Section>
 
-      <section id="export" className="section">
-        <h2>
-          <a
-            href="#export"
-            className="anchor"
-            aria-label="Link to Export configuration"
-          >
-            #
-          </a>
-          Export configuration
-        </h2>
+      <Section id="export" title="Export configuration">
         <p className="hint">Download the current rule state as a JSON file.</p>
         <div className="button-row">
           <button type="button" className="secondary" onClick={handleExport}>
             Export JSON
           </button>
         </div>
-      </section>
+      </Section>
 
-      <section id="display" className="section">
-        <h2>
-          <a
-            href="#display"
-            className="anchor"
-            aria-label="Link to Placeholder display"
-          >
-            #
-          </a>
-          Placeholder display
-        </h2>
+      <Section id="display" title="Placeholder display">
         <p className="hint">
           How the reveal control on each placeholder is rendered. The
           descriptive label (e.g., what kind of content was hidden) is always
@@ -248,54 +136,22 @@ export function Options() {
         </p>
         <fieldset className="radio-group">
           <legend className="visually-hidden">Reveal control style</legend>
-          <label className="radio">
-            <input
-              type="radio"
-              name="placeholder-display-mode"
-              value="icon"
-              checked={displayMode === "icon"}
-              disabled={displayMode === null}
-              onChange={() => handleDisplayModeChange("icon")}
-            />
-            <div>
-              <strong>Icon only</strong>
-              <p>
-                Compact shield icon. Best when placeholders would otherwise grow
-                larger than the content they replace.
-              </p>
-            </div>
-          </label>
-          <label className="radio">
-            <input
-              type="radio"
-              name="placeholder-display-mode"
-              value="button"
-              checked={displayMode === "button"}
-              disabled={displayMode === null}
-              onChange={() => handleDisplayModeChange("button")}
-            />
-            <div>
-              <strong>Button with label</strong>
-              <p>
-                Shield icon plus a visible label describing what was hidden.
-                Larger, but visually self-explanatory.
-              </p>
-            </div>
-          </label>
+          <DisplayModeOption
+            mode="icon"
+            current={displayMode}
+            title="Icon only"
+            description="Compact shield icon. Best when placeholders would otherwise grow larger than the content they replace."
+          />
+          <DisplayModeOption
+            mode="button"
+            current={displayMode}
+            title="Button with label"
+            description="Shield icon plus a visible label describing what was hidden. Larger, but visually self-explanatory."
+          />
         </fieldset>
-      </section>
+      </Section>
 
-      <section id="api-key" className="section">
-        <h2>
-          <a
-            href="#api-key"
-            className="anchor"
-            aria-label="Link to OpenAI API key"
-          >
-            #
-          </a>
-          OpenAI API key
-        </h2>
+      <Section id="api-key" title="OpenAI API key">
         <p className="hint">
           Used by the <code>irrelevant-sections-hide</code> rule.{" "}
           {HAS_BUILT_IN_OPENAI_KEY
@@ -323,60 +179,46 @@ export function Options() {
             </span>
           )}
         </div>
-      </section>
+      </Section>
 
-      <section id="rules" className="section">
-        <h2>
-          <a href="#rules" className="anchor" aria-label="Link to Rules">
-            #
-          </a>
-          Rules
-        </h2>
-        <ul className="rules">
-          {RULES.map((rule) => {
-            const snapshot = availability[rule.id];
-            const unavailable = !snapshot?.available;
-            return (
-              <li
-                key={rule.id}
-                className={unavailable ? "rule rule--unavailable" : "rule"}
-              >
-                <label>
-                  <input
-                    type="checkbox"
-                    checked={unavailable ? false : states[rule.id]}
-                    disabled={unavailable}
-                    onChange={(event) => {
-                      const enabled = event.target.checked;
-                      setStates((prev) =>
-                        prev ? { ...prev, [rule.id]: enabled } : prev,
-                      );
-                      void setRuleEnabled(rule.id, enabled);
-                    }}
-                  />
-                  <div>
-                    <strong>
-                      {rule.label}
-                      {unavailable && (
-                        <span className="badge">Unavailable</span>
-                      )}
-                    </strong>
-                    {unavailable && snapshot?.reason && (
-                      <p className="unavailable-reason">{snapshot.reason}</p>
-                    )}
-                    <p>{rule.description}</p>
-                  </div>
-                </label>
-              </li>
-            );
-          })}
-        </ul>
-      </section>
+      <Section id="rules" title="Rules">
+        <RuleList states={states} availability={availability} />
+      </Section>
 
       <footer className="footer">
         <HelpLinks className="footer__links" />
         <div className="footer__copyright">© PixieBrix 2026</div>
       </footer>
     </div>
+  );
+}
+
+function DisplayModeOption({
+  mode,
+  current,
+  title,
+  description,
+}: {
+  mode: PlaceholderDisplayMode;
+  current: PlaceholderDisplayMode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <label className="radio">
+      <input
+        type="radio"
+        name="placeholder-display-mode"
+        value={mode}
+        checked={current === mode}
+        onChange={() => {
+          void placeholderDisplayStorage.set(mode);
+        }}
+      />
+      <div>
+        <strong>{title}</strong>
+        <p>{description}</p>
+      </div>
+    </label>
   );
 }

--- a/extension/src/options/Section.tsx
+++ b/extension/src/options/Section.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import type { ReactNode } from "react";
+
+// One options-page section wrapped in a self-anchoring heading. The anchor
+// matches the table-of-contents entry at the top of the page.
+export function Section({
+  id,
+  title,
+  children,
+}: {
+  id: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} className="section">
+      <h2>
+        <a href={`#${id}`} className="anchor" aria-label={`Link to ${title}`}>
+          #
+        </a>
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}

--- a/extension/src/options/__tests__/parse-config.test.ts
+++ b/extension/src/options/__tests__/parse-config.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Mock the rules registry so we don't transitively pull in every rule module
+// (irrelevant-sections-hide → automation-element-reference → nanoid, whose ESM
+// build trips ts-jest's CJS transform).
+jest.mock("../../rules", () => ({
+  RULES: [
+    { id: "rule-a", defaultEnabled: true },
+    { id: "rule-b", defaultEnabled: true },
+  ],
+  RULE_IDS: ["rule-a", "rule-b"],
+}));
+
+import { parseConfig } from "../parse-config";
+
+const KNOWN_RULE_ID = "rule-a";
+
+describe("parseConfig", () => {
+  it("returns a partial map for a valid object", () => {
+    const result = parseConfig(JSON.stringify({ [KNOWN_RULE_ID]: false }));
+    expect(result).toEqual({
+      ok: true,
+      value: { [KNOWN_RULE_ID]: false },
+    });
+  });
+
+  it("rejects invalid JSON", () => {
+    const result = parseConfig("{not json");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/^Invalid JSON:/);
+    }
+  });
+
+  it("rejects a JSON array at the top level", () => {
+    const result = parseConfig("[]");
+    expect(result).toEqual({
+      ok: false,
+      error: "Expected a JSON object mapping rule IDs to booleans.",
+    });
+  });
+
+  it("rejects null at the top level", () => {
+    const result = parseConfig("null");
+    expect(result).toEqual({
+      ok: false,
+      error: "Expected a JSON object mapping rule IDs to booleans.",
+    });
+  });
+
+  it("rejects unknown rule ids", () => {
+    const result = parseConfig(JSON.stringify({ "not-a-rule": true }));
+    expect(result).toEqual({
+      ok: false,
+      error: "Unknown rule: not-a-rule",
+    });
+  });
+
+  it("rejects non-boolean values", () => {
+    const result = parseConfig(JSON.stringify({ [KNOWN_RULE_ID]: 1 }));
+    expect(result).toEqual({
+      ok: false,
+      error: `Non-boolean value for ${KNOWN_RULE_ID}: number`,
+    });
+  });
+
+  it("accumulates multiple errors", () => {
+    const result = parseConfig(
+      JSON.stringify({ "not-a-rule": true, [KNOWN_RULE_ID]: 0 }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.split("\n")).toEqual([
+        "Unknown rule: not-a-rule",
+        `Non-boolean value for ${KNOWN_RULE_ID}: number`,
+      ]);
+    }
+  });
+
+  it("accepts an empty object", () => {
+    expect(parseConfig("{}")).toEqual({ ok: true, value: {} });
+  });
+});

--- a/extension/src/options/parse-config.ts
+++ b/extension/src/options/parse-config.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import { RULE_IDS, type RuleId, type RuleStates } from "../lib/storage";
+
+const RULE_ID_SET = new Set<string>(RULE_IDS);
+
+export type ParseResult =
+  | { ok: true; value: Partial<RuleStates> }
+  | { ok: false; error: string };
+
+// Parses the JSON pasted into the "Apply configuration" textarea. Returns a
+// partial rule-state map on success; on failure returns a single multi-line
+// error string suitable for rendering in the alert region.
+export function parseConfig(input: string): ParseResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `Invalid JSON: ${message}` };
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      error: "Expected a JSON object mapping rule IDs to booleans.",
+    };
+  }
+
+  const errors: string[] = [];
+  const result: Partial<RuleStates> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!RULE_ID_SET.has(key)) {
+      errors.push(`Unknown rule: ${key}`);
+      continue;
+    }
+    if (typeof value !== "boolean") {
+      errors.push(`Non-boolean value for ${key}: ${typeof value}`);
+      continue;
+    }
+    result[key as RuleId] = value;
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, error: errors.join("\n") };
+  }
+  return { ok: true, value: result };
+}

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -1,70 +1,21 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-import { useEffect, useState } from "react";
-import {
-  getRuleAvailabilityStates,
-  type RuleAvailabilityStates,
-  subscribeRuleAvailability,
-} from "../lib/availability";
-import {
-  getEnforcementEnabled,
-  setEnforcementEnabled,
-  subscribeEnforcementEnabled,
-} from "../lib/enforcement";
+import { availabilitySource } from "../lib/availability";
+import { enforcementStorage } from "../lib/enforcement";
 import { HelpLinks } from "../lib/HelpLinks";
-import {
-  getRuleStates,
-  type RuleStates,
-  setRuleEnabled,
-  subscribe,
-} from "../lib/storage";
-import { RULES } from "../rules";
+import { RuleList } from "../lib/RuleList";
+import { ruleStatesStorage } from "../lib/storage";
+import { useChromeStorageValue } from "../lib/use-chrome-storage-value";
 
 export function Popup() {
-  const [states, setStates] = useState<RuleStates | null>(null);
-  const [enforcementEnabled, setEnforcementState] = useState<boolean | null>(
-    null,
-  );
-  const [availability, setAvailability] =
-    useState<RuleAvailabilityStates | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    getRuleStates().then((initial) => {
-      if (!cancelled) setStates(initial);
-    });
-    getEnforcementEnabled().then((value) => {
-      if (!cancelled) setEnforcementState(value);
-    });
-    getRuleAvailabilityStates().then((initial) => {
-      if (!cancelled) setAvailability(initial);
-    });
-    const unsubscribe = subscribe((next) => {
-      setStates(next);
-    });
-    const unsubscribeEnforcement = subscribeEnforcementEnabled((value) => {
-      setEnforcementState(value);
-    });
-    const unsubscribeAvailability = subscribeRuleAvailability((next) => {
-      setAvailability(next);
-    });
-    return () => {
-      cancelled = true;
-      unsubscribe();
-      unsubscribeEnforcement();
-      unsubscribeAvailability();
-    };
-  }, []);
+  const states = useChromeStorageValue(ruleStatesStorage);
+  const enforcementEnabled = useChromeStorageValue(enforcementStorage);
+  const availability = useChromeStorageValue(availabilitySource);
 
   if (!states || enforcementEnabled === null || !availability) {
     return <div className="loading">Loading…</div>;
   }
-
-  const handleEnforcementToggle = (enabled: boolean) => {
-    setEnforcementState(enabled);
-    void setEnforcementEnabled(enabled);
-  };
 
   return (
     <div className="popup">
@@ -83,17 +34,13 @@ export function Popup() {
               {enforcementEnabled ? "On" : "Off"}
             </span>
           </span>
-          <span
-            className="switch"
-            role="presentation"
-            aria-hidden={enforcementEnabled === null}
-          >
+          <span className="switch" role="presentation">
             <input
               type="checkbox"
               checked={enforcementEnabled}
-              onChange={(event) =>
-                handleEnforcementToggle(event.target.checked)
-              }
+              onChange={(event) => {
+                void enforcementStorage.set(event.target.checked);
+              }}
               aria-label="Enable enforcement"
             />
             <span className="switch__track" />
@@ -106,48 +53,11 @@ export function Popup() {
           </p>
         )}
       </div>
-      <ul
-        className={
-          enforcementEnabled ? "rules" : "rules rules--enforcement-off"
-        }
-      >
-        {RULES.map((rule) => {
-          const snapshot = availability[rule.id];
-          const unavailable = !snapshot?.available;
-          const disabled = unavailable || !enforcementEnabled;
-          return (
-            <li
-              key={rule.id}
-              className={unavailable ? "rule rule--unavailable" : "rule"}
-            >
-              <label>
-                <input
-                  type="checkbox"
-                  checked={unavailable ? false : states[rule.id]}
-                  disabled={disabled}
-                  onChange={(event) => {
-                    const enabled = event.target.checked;
-                    setStates((prev) =>
-                      prev ? { ...prev, [rule.id]: enabled } : prev,
-                    );
-                    void setRuleEnabled(rule.id, enabled);
-                  }}
-                />
-                <div>
-                  <strong>
-                    {rule.label}
-                    {unavailable && <span className="badge">Unavailable</span>}
-                  </strong>
-                  {unavailable && snapshot?.reason && (
-                    <p className="unavailable-reason">{snapshot.reason}</p>
-                  )}
-                  <p>{rule.description}</p>
-                </div>
-              </label>
-            </li>
-          );
-        })}
-      </ul>
+      <RuleList
+        states={states}
+        availability={availability}
+        disabledByEnforcement={!enforcementEnabled}
+      />
       <HelpLinks className="popup__footer" />
     </div>
   );


### PR DESCRIPTION
## Summary

- Factors the four `chrome.storage` modules onto a single `createChromeStorageValue<T>({ key, normalize })` helper (`lib/chrome-storage-value.ts`); the old `getX` / `setX` / `subscribeX` names are kept as re-exports of the factory methods so the rule engine, background script, and content script keep working unchanged.
- Adds `useChromeStorageValue<T>(source)`, an `AsyncReadableSource`-backed hook that replaces every `useState(null)` + `useEffect(cancelled-flag + .then + subscribe + cleanup)` triplet in `Popup.tsx` and `Options.tsx` with a single line. Availability gets a stable `availabilitySource` object so the hook's effect dep doesn't churn.
- Extracts the shared per-rule checkbox list as `lib/RuleList.tsx`, the options page's repeated `<h2>` + anchor heading as `options/Section.tsx`, the brief "Saved"/"Applied" status message timer as `lib/use-transient-status.ts` (now cleared on unmount), and the apply-config JSON parser as `options/parse-config.ts`.
- Adds `options/__tests__/parse-config.test.ts` covering invalid JSON, non-object/null/array top level, unknown rule ids, non-boolean values, and multi-error accumulation.
- Drops the unreachable `aria-hidden={enforcementEnabled === null}` on the popup's enforcement switch — the early `Loading…` return guarantees a boolean by the time it renders.
- Net: 7 modified files, 7 new files, –455 / +497 lines, but the new lines are largely the new helpers and tests; the React components are roughly 60% smaller.

## Test plan

- [x] `bun run check` — biome + eslint clean
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test` — 453 passing (was 445; +8 parse-config tests)
- [x] `bun run build` — extension bundles
- [ ] Load `extension/dist` in Chrome, smoke-test:
  - Popup: toggle enforcement, toggle individual rules, confirm rules grey out when enforcement is off
  - Options: paste valid + invalid JSON into Apply, export JSON, switch placeholder display mode, set/clear API key
  - Open a second window of the options page and confirm changes in one tab reflect in the other via the storage subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)