### PR TITLE
Propagate aborts to background classify fetch

### DIFF
--- a/extension/bun.lock
+++ b/extension/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "agent-browser-shield-extension",
       "dependencies": {
+        "abort-utils": "^3.0.0",
         "lodash": "^4.18.1",
         "nanoid": "^5.1.11",
         "react": "19.2.6",
@@ -395,6 +396,8 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.12.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.12.2", "", { "os": "win32", "cpu": "x64" }, "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA=="],
+
+    "abort-utils": ["abort-utils@3.0.0", "", {}, "sha512-MAKGmQk+akGbHbG/m6JDvOD1BBf4dyYTTXnFVeb0YfYx4ve0WosH0Yp4GYDnMpAlTPaVMUe8XEr/OFS/LtkrLQ=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -37,6 +37,7 @@
     "lint:eslint:fix": "eslint . --fix"
   },
   "dependencies": {
+    "abort-utils": "^3.0.0",
     "lodash": "^4.18.1",
     "nanoid": "^5.1.11",
     "react": "19.2.6",

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -2,7 +2,7 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { subscribeEnforcementEnabled } from "./lib/enforcement";
-import { handleClassify } from "./lib/llm-background";
+import { startClassifyPortListener } from "./lib/llm-background";
 
 // Per-tab, per-frame placeholder counts. Each content script reports its own
 // frame's tally; the badge shows the sum across frames for that tab.
@@ -103,16 +103,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return undefined;
   }
 
-  if (message.type === "classify-irrelevant-sections") {
-    handleClassify(message.payload)
-      .then((response) => sendResponse(response))
-      .catch((error: unknown) => {
-        const errMessage =
-          error instanceof Error ? error.message : String(error);
-        sendResponse({ error: errMessage });
-      });
-    return true;
-  }
-
   return undefined;
 });
+
+// Classify requests use a long-lived port instead of sendMessage so the
+// content-side abort can propagate to the background's fetch. See
+// `lib/llm-background.ts` for the per-port AbortController wiring.
+startClassifyPortListener();

--- a/extension/src/lib/llm-background.ts
+++ b/extension/src/lib/llm-background.ts
@@ -2,7 +2,12 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { getUserApiKey } from "./api-key-storage";
-import type { ClassifyRequest, ClassifyResponse } from "./llm-client";
+import {
+  CLASSIFY_PORT_NAME,
+  type ClassifyPortMessage,
+  type ClassifyRequest,
+  type ClassifyResponse,
+} from "./llm-client";
 
 // Injected at build time via Bun `define` (see `src/globals.d.ts`). Empty
 // string when unset so the extension still loads; classification calls then
@@ -52,6 +57,7 @@ interface ChatResponse {
 
 export async function handleClassify(
   payload: ClassifyRequest,
+  signal?: AbortSignal,
 ): Promise<ClassifyResponse> {
   const userKey = await getUserApiKey();
   const apiKey = userKey || BUILT_IN_API_KEY;
@@ -75,6 +81,7 @@ export async function handleClassify(
         { role: "user", content: JSON.stringify(payload) },
       ],
     }),
+    signal,
   });
 
   if (!response.ok) {
@@ -103,4 +110,44 @@ export async function handleClassify(
       })
     : [];
   return { irrelevant };
+}
+
+// Wire up the port handler for content-script classify requests. Each port
+// owns one AbortController: the content side disconnecting before fetch
+// completes aborts the in-flight HTTP request so we don't keep burning tokens
+// for a response no one is listening for.
+export function startClassifyPortListener(): void {
+  chrome.runtime.onConnect.addListener((port) => {
+    if (port.name !== CLASSIFY_PORT_NAME) return;
+    const controller = new AbortController();
+    // Content-side disconnect (rule torn down, page navigated, frame gone)
+    // aborts the in-flight fetch via the signal forwarded into handleClassify.
+    // Calling abort after handleClassify has resolved is a no-op, so this is
+    // safe regardless of who wins the race.
+    port.onDisconnect.addListener(() => controller.abort());
+
+    const send = (message: ClassifyPortMessage) => {
+      try {
+        port.postMessage(message);
+      } catch {
+        // Port already disconnected — caller has gone away. Nothing to do.
+      }
+    };
+
+    port.onMessage.addListener((raw: unknown) => {
+      const payload = raw as ClassifyRequest;
+      handleClassify(payload, controller.signal)
+        .then((response) => {
+          send({ kind: "response", response });
+          port.disconnect();
+        })
+        .catch((error: unknown) => {
+          if (controller.signal.aborted) return;
+          const message =
+            error instanceof Error ? error.message : String(error);
+          send({ kind: "error", error: message });
+          port.disconnect();
+        });
+    });
+  });
 }

--- a/extension/src/lib/llm-client.ts
+++ b/extension/src/lib/llm-client.ts
@@ -2,7 +2,14 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 // Content-script-side wrapper for LLM calls that must run from the background
-// worker to bypass page CSP.
+// worker to bypass page CSP. Uses a long-lived port (not sendMessage) so an
+// abort on the caller's signal disconnects the port, which the background
+// observes and forwards to fetch via its own AbortController. Without this,
+// the fetch would run to completion and burn tokens after teardown.
+
+import { onAbort } from "abort-utils";
+
+export const CLASSIFY_PORT_NAME = "classify-irrelevant-sections";
 
 export interface ClassifyRequest {
   url: string;
@@ -21,39 +28,56 @@ export interface ClassifyResponse {
   irrelevant: IrrelevantElement[];
 }
 
+// Wire-format messages from the background. Discriminated so the content side
+// can distinguish success from a propagated error without sniffing for keys.
+export type ClassifyPortMessage =
+  | { kind: "response"; response: ClassifyResponse }
+  | { kind: "error"; error: string };
+
 export async function classifyIrrelevantSections(
   request: ClassifyRequest,
   signal?: AbortSignal,
 ): Promise<ClassifyResponse> {
-  return await new Promise((resolve, reject) => {
-    const onAbort = () => {
-      reject(new DOMException("aborted", "AbortError"));
-    };
-    if (signal?.aborted) {
-      onAbort();
-      return;
-    }
-    signal?.addEventListener("abort", onAbort);
+  if (signal?.aborted) {
+    throw new DOMException("aborted", "AbortError");
+  }
 
-    chrome.runtime.sendMessage(
-      { type: "classify-irrelevant-sections", payload: request },
-      (response: ClassifyResponse | { error: string } | undefined) => {
-        signal?.removeEventListener("abort", onAbort);
-        if (signal?.aborted) return;
-        if (chrome.runtime.lastError) {
-          reject(new Error(chrome.runtime.lastError.message));
-          return;
-        }
-        if (!response) {
-          reject(new Error("Empty response from background worker"));
-          return;
-        }
-        if ("error" in response) {
-          reject(new Error(response.error));
-          return;
-        }
-        resolve(response);
-      },
-    );
+  const port = chrome.runtime.connect({ name: CLASSIFY_PORT_NAME });
+  return new Promise<ClassifyResponse>((resolve, reject) => {
+    let settled = false;
+    const finish = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup?.[Symbol.dispose]();
+      port.disconnect();
+      action();
+    };
+
+    // onAbort attaches the abort handler with `{ once: true, signal: cleanup }`
+    // so it auto-detaches when either the input signal fires or we dispose —
+    // no manual removeEventListener needed on either path.
+    const cleanup = onAbort(signal, () => {
+      finish(() => reject(new DOMException("aborted", "AbortError")));
+    });
+
+    port.onMessage.addListener((raw: unknown) => {
+      const message = raw as ClassifyPortMessage;
+      if (message.kind === "response") {
+        finish(() => resolve(message.response));
+      } else {
+        finish(() => reject(new Error(message.error)));
+      }
+    });
+
+    port.onDisconnect.addListener(() => {
+      const lastError = chrome.runtime.lastError?.message;
+      finish(() =>
+        reject(
+          new Error(lastError ?? "Background disconnected before responding"),
+        ),
+      );
+    });
+
+    port.postMessage(request);
   });
 }

--- a/extension/src/rules/irrelevant-sections-hide.ts
+++ b/extension/src/rules/irrelevant-sections-hide.ts
@@ -13,6 +13,7 @@
 // search/cart/checkout/account UI. The container-level refs let the LLM pick
 // the right granularity instead of being forced into outermost-only choices.
 
+import { ReusableAbortController } from "abort-utils";
 import {
   pruneReferences,
   resolveReference,
@@ -39,7 +40,12 @@ const MAX_VIEWPORT_HEIGHT_FRACTION = 0.7;
 // the page off-screen.
 const MAX_PLACEHOLDER_HEIGHT_PX = 200;
 
-let abortController: AbortController | null = null;
+// Single controller covers both the settle phase and every classify call
+// (initial + scroll-triggered). Teardown calls abortAndReset, which aborts the
+// shared signal and produces a fresh one for the next apply — so the previous
+// settle's waiter, the pending fetch, and any debounced scroll classification
+// all unwind together.
+const lifecycleController = new ReusableAbortController();
 let scrollHandler: (() => void) | null = null;
 let scrollDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let classifyInFlight = false;
@@ -130,8 +136,7 @@ function runClassification(): void {
     return;
   }
 
-  const controller = new AbortController();
-  abortController = controller;
+  const signal = lifecycleController.signal;
   classifyInFlight = true;
 
   log("irrelevant-sections-hide classify start", {
@@ -139,12 +144,9 @@ function runClassification(): void {
     pageTreeBytes: pageTree.length,
   });
 
-  classifyIrrelevantSections(
-    { url: location.href, pageTree },
-    controller.signal,
-  )
+  classifyIrrelevantSections({ url: location.href, pageTree }, signal)
     .then((response) => {
-      if (controller.signal.aborted) return;
+      if (signal.aborted) return;
 
       log("irrelevant-sections-hide classify response", {
         count: response.irrelevant.length,
@@ -250,7 +252,6 @@ function runClassification(): void {
       log("irrelevant-sections-hide classify failed", { error: message });
     })
     .finally(() => {
-      if (abortController === controller) abortController = null;
       classifyInFlight = false;
     });
 }
@@ -279,15 +280,14 @@ function stopScrollWatcher(): void {
 
 function apply(_root: ParentNode): void {
   log("irrelevant-sections-hide apply", { url: location.href });
-  const settleController = new AbortController();
-  abortController = settleController;
+  const signal = lifecycleController.signal;
 
   waitForSettle({
     timeout: SETTLE_TIMEOUT_MS,
     quietMs: SETTLE_QUIET_MS,
-    signal: settleController.signal,
+    signal,
   }).then(() => {
-    if (settleController.signal.aborted) {
+    if (signal.aborted) {
       log("irrelevant-sections-hide aborted before classify");
       return;
     }
@@ -298,10 +298,7 @@ function apply(_root: ParentNode): void {
 }
 
 function teardown(): void {
-  if (abortController) {
-    abortController.abort();
-    abortController = null;
-  }
+  lifecycleController.abortAndReset();
   stopScrollWatcher();
   classifyInFlight = false;
   processedElements = new WeakSet();


### PR DESCRIPTION
## Summary

- Switch the `irrelevant-sections-hide` classify call from `chrome.runtime.sendMessage` to a long-lived port. The background owns a per-port `AbortController` and listens for `port.onDisconnect` — so when the content side aborts (rule disabled, navigation, frame gone), the abort propagates into `fetch()` instead of the request running to completion and burning OpenAI tokens after teardown.
- Collapse the two reassigned `AbortController` slots in `irrelevant-sections-hide.ts` into a single module-scoped `ReusableAbortController` shared by the settle phase, the initial classify, and any scroll-triggered re-classify. `teardown()` calls `abortAndReset()` once; the next `apply()` automatically gets a fresh signal.
- Use `abort-utils`' `onAbort` for the abort listener in the port client so it auto-detaches on dispose or fire (no manual `removeEventListener`).

## Test plan

- [x] `bun run check` — biome + eslint clean
- [x] `bun run test` — 453/453 pass
- [x] `bun run build` — extension bundles
- [ ] Manual: load the unpacked extension, enable `irrelevant-sections-hide`, open a page that triggers classification, then disable the rule mid-flight and confirm no late response logs / no leftover token spend in the network panel.
- [ ] Manual: navigate away while a classify is in flight and confirm the background's fetch is aborted (DevTools → service worker → Network shows the OpenAI request as cancelled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)