### PR TITLE
Add disclaimer to README, docs, and options screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ form. Do **not** open a public issue for security problems.
 
 ## Disclaimer
 
-`agent-browser-shield` reduces the threats a browser-use agent faces on a
-page, but it can't catch everything. Take precautions when using AI agents for
-browser use. The extension is provided **as-is, without warranty of any
-kind** — see [LICENSE](./LICENSE) for the full terms.
+`agent-browser-shield` reduces the threats a browser-use agent faces on a page,
+but it can't catch everything. Take precautions when using AI agents for browser
+use. The extension is provided **as-is, without warranty of any kind** — see
+[LICENSE](./LICENSE) for the full terms.

--- a/README.md
+++ b/README.md
@@ -208,3 +208,10 @@ commercial license if you need one.
 Please report vulnerabilities privately via GitHub's
 ["Report a vulnerability"](https://github.com/pixiebrix/agent-browser-shield/security/advisories/new)
 form. Do **not** open a public issue for security problems.
+
+## Disclaimer
+
+`agent-browser-shield` reduces the threats a browser-use agent faces on a
+page, but it can't catch everything. Take precautions when using AI agents for
+browser use. The extension is provided **as-is, without warranty of any
+kind** — see [LICENSE](./LICENSE) for the full terms.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: agent-browser-shield
 description: Browser extension prototypes for improving browser-use agent performance.
 ---
 
-import { Card, CardGrid, LinkButton } from "@astrojs/starlight/components";
+import { Aside, Card, CardGrid, LinkButton } from "@astrojs/starlight/components";
 
 Prototype browser extension capabilities that make browser-use agents faster,
 safer, and more accurate.
@@ -40,3 +40,10 @@ safer, and more accurate.
 
 For the full project overview, see the
 [repository README](https://github.com/pixiebrix/agent-browser-shield#readme).
+
+<Aside type="caution" title="Disclaimer">
+  `agent-browser-shield` reduces the threats a browser-use agent faces on a
+  page, but it can't catch everything. Take precautions when using AI agents
+  for browser use. The extension is provided **as-is, without warranty of any
+  kind**.
+</Aside>

--- a/extension/src/options/Options.tsx
+++ b/extension/src/options/Options.tsx
@@ -86,6 +86,7 @@ export function Options() {
         <a href="#display">Placeholder display</a>
         <a href="#api-key">OpenAI API key</a>
         <a href="#rules">Rules</a>
+        <a href="#disclaimer">Disclaimer</a>
       </nav>
 
       <Section id="apply" title="Apply configuration">
@@ -183,6 +184,15 @@ export function Options() {
 
       <Section id="rules" title="Rules">
         <RuleList states={states} availability={availability} />
+      </Section>
+
+      <Section id="disclaimer" title="Disclaimer">
+        <p className="hint">
+          Agent Browser Shield reduces the threats a browser-use agent faces on
+          a page, but it can't catch everything. Take precautions when using AI
+          agents for browser use. The extension is provided as-is, without
+          warranty of any kind.
+        </p>
       </Section>
 
       <footer className="footer">


### PR DESCRIPTION
## Summary
- Adds a short, plain-English disclaimer to the README, the docs landing page (Starlight `<Aside>`), and a new "Disclaimer" section on the options screen (linked from the TOC).
- States that the extension can't catch every threat, that users should take precautions when using AI agents for browser use, and that it's provided as-is without warranty.

## Test plan
- [ ] Render the options page and confirm the new section appears at the bottom and is reachable via the TOC anchor.
- [ ] Build the docs site and confirm the caution callout renders on the landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)