### PR TITLE
Enforce block statements via Biome useBlockStatements

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "useBlockStatements": "error"
+      }
     }
   },
   "javascript": {

--- a/extension/build.ts
+++ b/extension/build.ts
@@ -17,7 +17,9 @@ const watch = process.argv.includes("--watch");
 const minify = process.env.NODE_ENV === "production";
 
 function readEnvValue(name: string): string {
-  if (process.env[name]) return process.env[name] ?? "";
+  if (process.env[name]) {
+    return process.env[name] ?? "";
+  }
   for (const candidate of [join(ROOT, ".env"), join(ROOT, "..", ".env")]) {
     let content: string;
     try {
@@ -27,10 +29,16 @@ function readEnvValue(name: string): string {
     }
     for (const rawLine of content.split("\n")) {
       const line = rawLine.trim();
-      if (!line || line.startsWith("#")) continue;
+      if (!line || line.startsWith("#")) {
+        continue;
+      }
       const eq = line.indexOf("=");
-      if (eq === -1) continue;
-      if (line.slice(0, eq).trim() !== name) continue;
+      if (eq === -1) {
+        continue;
+      }
+      if (line.slice(0, eq).trim() !== name) {
+        continue;
+      }
       let value = line.slice(eq + 1).trim();
       if (
         (value.startsWith('"') && value.endsWith('"')) ||
@@ -104,7 +112,9 @@ if (watch) {
   console.log(`Watching ${SRC} and ${DATA} for changes…`);
   let pending = false;
   const trigger = () => {
-    if (pending) return;
+    if (pending) {
+      return;
+    }
     pending = true;
     setTimeout(async () => {
       pending = false;

--- a/extension/eslint-rules/rule-id-matches-filename.js
+++ b/extension/eslint-rules/rule-id-matches-filename.js
@@ -6,9 +6,13 @@ import path from "node:path";
 const RULE_FILE_REGEX = /[/\\]src[/\\]rules[/\\][^/\\]+\.tsx?$/;
 
 function isRuleFile(filename) {
-  if (!RULE_FILE_REGEX.test(filename)) return false;
+  if (!RULE_FILE_REGEX.test(filename)) {
+    return false;
+  }
   const base = path.basename(filename);
-  if (base === "index.ts" || base === "types.ts") return false;
+  if (base === "index.ts" || base === "types.ts") {
+    return false;
+  }
   if (base.endsWith(".generated.ts") || base.endsWith(".generated.tsx")) {
     return false;
   }
@@ -35,11 +39,15 @@ const rule = {
   },
   create(context) {
     const filename = context.filename ?? context.getFilename();
-    if (!isRuleFile(filename)) return {};
+    if (!isRuleFile(filename)) {
+      return {};
+    }
     const expected = expectedId(filename);
 
     function check(node, value) {
-      if (typeof value !== "string") return;
+      if (typeof value !== "string") {
+        return;
+      }
       if (value !== expected) {
         context.report({
           node,

--- a/extension/scripts/build-site-data.ts
+++ b/extension/scripts/build-site-data.ts
@@ -90,7 +90,9 @@ function collectSelectorBlocks(
   const blocks: SelectorBlock[] = [];
   for (const { fileName, data } of parsed) {
     const rule = data.rules[ruleId];
-    if (!rule) continue;
+    if (!rule) {
+      continue;
+    }
     for (const entry of toEntries<SelectorRuleEntryInput>(rule)) {
       blocks.push({
         fileName,
@@ -107,7 +109,9 @@ function collectRecipeBlocks(parsed: ParsedSiteFile[]): RecipeBlock[] {
   const blocks: RecipeBlock[] = [];
   for (const { fileName, data } of parsed) {
     const rule = data.rules["search-url-helper"];
-    if (!rule) continue;
+    if (!rule) {
+      continue;
+    }
     for (const entry of toEntries<RecipeRuleEntryInput>(rule)) {
       blocks.push({
         fileName,

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -13,15 +13,23 @@ const BADGE_COLOR = "#2563eb";
 
 function totalForTab(tabId: number): number {
   const frames = tabCounts.get(tabId);
-  if (!frames) return 0;
+  if (!frames) {
+    return 0;
+  }
   let sum = 0;
-  for (const value of frames.values()) sum += value;
+  for (const value of frames.values()) {
+    sum += value;
+  }
   return sum;
 }
 
 function formatBadge(total: number): string {
-  if (total <= 0) return "";
-  if (total > 999) return "999+";
+  if (total <= 0) {
+    return "";
+  }
+  if (total > 999) {
+    return "999+";
+  }
   return String(total);
 }
 
@@ -43,7 +51,9 @@ function recordFrameCount(tabId: number, frameId: number, count: number): void {
   }
   if (count <= 0) {
     frames.delete(frameId);
-    if (frames.size === 0) tabCounts.delete(tabId);
+    if (frames.size === 0) {
+      tabCounts.delete(tabId);
+    }
   } else {
     frames.set(frameId, count);
   }
@@ -72,14 +82,18 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
 // zero counts back — but doing this synchronously keeps the badge from
 // looking stale for the duration of those mutation observer cycles.
 subscribeEnforcementEnabled((enabled) => {
-  if (enabled) return;
+  if (enabled) {
+    return;
+  }
   for (const tabId of tabCounts.keys()) {
     clearTab(tabId);
   }
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (!message || typeof message !== "object") return undefined;
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
 
   if (message.type === "open-options") {
     chrome.runtime.openOptionsPage(() => {

--- a/extension/src/lib/automation-element-reference.ts
+++ b/extension/src/lib/automation-element-reference.ts
@@ -22,7 +22,9 @@ const elementsByRef = new Map<string, WeakRef<Element>>();
 
 export function getReferenceForElement(element: Element): string {
   const existing = refsByElement.get(element);
-  if (existing) return existing;
+  if (existing) {
+    return existing;
+  }
   const ref = nanoid(REF_LENGTH);
   refsByElement.set(element, ref);
   elementsByRef.set(ref, new WeakRef(element));
@@ -31,7 +33,9 @@ export function getReferenceForElement(element: Element): string {
 
 export function resolveReference(ref: string): Element | undefined {
   const element = elementsByRef.get(ref)?.deref();
-  if (!element?.isConnected) return undefined;
+  if (!element?.isConnected) {
+    return undefined;
+  }
   return element;
 }
 
@@ -39,6 +43,8 @@ export function resolveReference(ref: string): Element | undefined {
 // keeps the reverse map from growing unbounded over long-lived tabs.
 export function pruneReferences(): void {
   for (const [ref, weakRef] of elementsByRef) {
-    if (!weakRef.deref()) elementsByRef.delete(ref);
+    if (!weakRef.deref()) {
+      elementsByRef.delete(ref);
+    }
   }
 }

--- a/extension/src/lib/availability.ts
+++ b/extension/src/lib/availability.ts
@@ -31,7 +31,9 @@ export async function resolveAvailability(
   rule: Rule,
 ): Promise<AvailabilitySnapshot> {
   const accessor = rule.available;
-  if (isReactive(accessor)) return accessor.get();
+  if (isReactive(accessor)) {
+    return accessor.get();
+  }
   if (accessor === false) {
     return { available: false, reason: rule.unavailableReason };
   }
@@ -58,11 +60,15 @@ export function subscribeRuleAvailability(
     void getRuleAvailabilityStates().then(listener);
   };
   for (const rule of RULES) {
-    if (!isReactive(rule.available)) continue;
+    if (!isReactive(rule.available)) {
+      continue;
+    }
     unsubs.push(rule.available.subscribe(refresh));
   }
   return () => {
-    for (const unsub of unsubs) unsub();
+    for (const unsub of unsubs) {
+      unsub();
+    }
   };
 }
 
@@ -80,7 +86,9 @@ export const availabilitySource = Object.freeze({
 export function createApiKeyAvailability(reason: string): RuleAvailability {
   return {
     async get() {
-      if (HAS_BUILT_IN_OPENAI_KEY) return { available: true };
+      if (HAS_BUILT_IN_OPENAI_KEY) {
+        return { available: true };
+      }
       const userKey = await getUserApiKey();
       return userKey ? { available: true } : { available: false, reason };
     },

--- a/extension/src/lib/chrome-storage-value.ts
+++ b/extension/src/lib/chrome-storage-value.ts
@@ -34,9 +34,13 @@ export function createChromeStorageValue<T>(options: {
         changes: Record<string, chrome.storage.StorageChange>,
         areaName: string,
       ) => {
-        if (areaName !== "local") return;
+        if (areaName !== "local") {
+          return;
+        }
         const change = changes[key];
-        if (!change) return;
+        if (!change) {
+          return;
+        }
         listener(normalize(change.newValue), normalize(change.oldValue));
       };
       chrome.storage.onChanged.addListener(handler);

--- a/extension/src/lib/dom-utils.ts
+++ b/extension/src/lib/dom-utils.ts
@@ -24,7 +24,9 @@ export function isNonContentTag(tagName: string): boolean {
 // common "don't re-process my own replacement" check that every hide rule
 // performs before considering a candidate.
 export function isInsidePlaceholder(element: Element): boolean {
-  if (element.classList.contains(PLACEHOLDER_CLASS)) return true;
+  if (element.classList.contains(PLACEHOLDER_CLASS)) {
+    return true;
+  }
   return element.closest(`.${PLACEHOLDER_CLASS}`) !== null;
 }
 
@@ -102,13 +104,23 @@ export function findInnermostMatches<T>(
   const { isSkipped, maxTextLength, maxDescendants, match } = options;
   const out: Array<{ element: HTMLElement; match: T }> = [];
   for (const element of root.querySelectorAll<HTMLElement>("*")) {
-    if (isNonContentTag(element.tagName)) continue;
-    if (isSkipped?.(element)) continue;
-    if (element.children.length > maxDescendants) continue;
+    if (isNonContentTag(element.tagName)) {
+      continue;
+    }
+    if (isSkipped?.(element)) {
+      continue;
+    }
+    if (element.children.length > maxDescendants) {
+      continue;
+    }
     const text = (element.textContent ?? "").trim();
-    if (text.length === 0 || text.length > maxTextLength) continue;
+    if (text.length === 0 || text.length > maxTextLength) {
+      continue;
+    }
     const matched = match(text, element);
-    if (matched === null) continue;
+    if (matched === null) {
+      continue;
+    }
     out.push({ element, match: matched });
   }
   return filterToInnermost(out, (item) => item.element);
@@ -135,12 +147,22 @@ export function walkTextNodes(
   const walker = document.createTreeWalker(root as Node, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
       const parent = node.parentElement;
-      if (!parent) return NodeFilter.FILTER_REJECT;
-      if (isNonContentTag(parent.tagName)) return NodeFilter.FILTER_REJECT;
-      if (isInsidePlaceholder(parent)) return NodeFilter.FILTER_REJECT;
-      if (shouldSkipParent?.(parent)) return NodeFilter.FILTER_REJECT;
+      if (!parent) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      if (isNonContentTag(parent.tagName)) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      if (isInsidePlaceholder(parent)) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      if (shouldSkipParent?.(parent)) {
+        return NodeFilter.FILTER_REJECT;
+      }
       const value = node.nodeValue;
-      if (!value || value.length < minLength) return NodeFilter.FILTER_REJECT;
+      if (!value || value.length < minLength) {
+        return NodeFilter.FILTER_REJECT;
+      }
       return NodeFilter.FILTER_ACCEPT;
     },
   });

--- a/extension/src/lib/llm-background.ts
+++ b/extension/src/lib/llm-background.ts
@@ -98,9 +98,13 @@ export async function handleClassify(
   const parsed = JSON.parse(content) as { irrelevant?: unknown };
   const irrelevant = Array.isArray(parsed.irrelevant)
     ? parsed.irrelevant.flatMap((entry): { ref: string; summary: string }[] => {
-        if (!entry || typeof entry !== "object") return [];
+        if (!entry || typeof entry !== "object") {
+          return [];
+        }
         const { ref, summary } = entry as Record<string, unknown>;
-        if (typeof ref !== "string") return [];
+        if (typeof ref !== "string") {
+          return [];
+        }
         return [
           {
             ref,
@@ -118,7 +122,9 @@ export async function handleClassify(
 // for a response no one is listening for.
 export function startClassifyPortListener(): void {
   chrome.runtime.onConnect.addListener((port) => {
-    if (port.name !== CLASSIFY_PORT_NAME) return;
+    if (port.name !== CLASSIFY_PORT_NAME) {
+      return;
+    }
     const controller = new AbortController();
     // Content-side disconnect (rule torn down, page navigated, frame gone)
     // aborts the in-flight fetch via the signal forwarded into handleClassify.
@@ -142,7 +148,9 @@ export function startClassifyPortListener(): void {
           port.disconnect();
         })
         .catch((error: unknown) => {
-          if (controller.signal.aborted) return;
+          if (controller.signal.aborted) {
+            return;
+          }
           const message =
             error instanceof Error ? error.message : String(error);
           send({ kind: "error", error: message });

--- a/extension/src/lib/llm-client.ts
+++ b/extension/src/lib/llm-client.ts
@@ -46,7 +46,9 @@ export async function classifyIrrelevantSections(
   return new Promise<ClassifyResponse>((resolve, reject) => {
     let settled = false;
     const finish = (action: () => void) => {
-      if (settled) return;
+      if (settled) {
+        return;
+      }
       settled = true;
       cleanup?.[Symbol.dispose]();
       port.disconnect();

--- a/extension/src/lib/options-badge.ts
+++ b/extension/src/lib/options-badge.ts
@@ -5,9 +5,13 @@ const BADGE_SELECTOR = "data-abs";
 const BADGE_VALUE = "open-options";
 
 export function injectOptionsBadge(): void {
-  if (document.querySelector(`[${BADGE_SELECTOR}="${BADGE_VALUE}"]`)) return;
+  if (document.querySelector(`[${BADGE_SELECTOR}="${BADGE_VALUE}"]`)) {
+    return;
+  }
   const host = document.body ?? document.documentElement;
-  if (!host) return;
+  if (!host) {
+    return;
+  }
 
   const badge = document.createElement("button");
   badge.type = "button";

--- a/extension/src/lib/page-tree.ts
+++ b/extension/src/lib/page-tree.ts
@@ -78,8 +78,12 @@ const MAX_TEXT_NODE_CHARS = 160;
 // whitespace so callers can skip emitting an empty text node.
 function normalizeTextContent(raw: string): string | null {
   const collapsed = raw.replaceAll(/\s+/g, " ").trim();
-  if (collapsed.length === 0) return null;
-  if (collapsed.length <= MAX_TEXT_NODE_CHARS) return collapsed;
+  if (collapsed.length === 0) {
+    return null;
+  }
+  if (collapsed.length <= MAX_TEXT_NODE_CHARS) {
+    return collapsed;
+  }
   return `${collapsed.slice(0, MAX_TEXT_NODE_CHARS).trimEnd()}…`;
 }
 
@@ -123,11 +127,15 @@ function isElementVisible(element: HTMLElement): boolean {
     return false;
   }
 
-  if (zeroDimensionAllowlist.has(element.tagName)) return true;
+  if (zeroDimensionAllowlist.has(element.tagName)) {
+    return true;
+  }
 
   // Catch zero-dimension elements (e.g. height:0 + overflow:hidden) that
   // checkVisibility considered visible.
-  if (element.offsetHeight === 0 && element.offsetWidth === 0) return false;
+  if (element.offsetHeight === 0 && element.offsetWidth === 0) {
+    return false;
+  }
 
   return true;
 }
@@ -152,9 +160,15 @@ function isInteractiveElement(element: HTMLElement): boolean {
 // block with a heading child also qualifies because that's the common shape of
 // a recommendation rail ("You might also like" + grid of cards).
 function isStampableContainer(element: HTMLElement): boolean {
-  if (containerTagAllowlist.has(element.tagName)) return true;
-  if (element.querySelector(DIRECT_HEADING_SELECTOR)) return true;
-  if (element.querySelector(NESTED_HEADING_SELECTOR)) return true;
+  if (containerTagAllowlist.has(element.tagName)) {
+    return true;
+  }
+  if (element.querySelector(DIRECT_HEADING_SELECTOR)) {
+    return true;
+  }
+  if (element.querySelector(NESTED_HEADING_SELECTOR)) {
+    return true;
+  }
   return false;
 }
 
@@ -189,10 +203,14 @@ function setValueAttributesInPlace({
 }
 
 function getElementTree(element: HTMLElement): Node | undefined {
-  if (tagDenyList.has(element.tagName)) return;
+  if (tagDenyList.has(element.tagName)) {
+    return;
+  }
 
   // Visibility must be measured on the live element, before any cloning.
-  if (!isElementVisible(element)) return;
+  if (!isElementVisible(element)) {
+    return;
+  }
 
   const compressedElement = document.createElement(element.tagName);
   const attributes = [...element.attributes].filter((attribute) =>
@@ -214,7 +232,9 @@ function getElementTree(element: HTMLElement): Node | undefined {
     const visitChildNode = (node: Node): void => {
       if (node instanceof HTMLElement) {
         const childElement = getElementTree(node);
-        if (childElement) compressedElement.append(childElement);
+        if (childElement) {
+          compressedElement.append(childElement);
+        }
       } else if (node instanceof Text) {
         const normalized = normalizeTextContent(node.textContent ?? "");
         if (normalized) {
@@ -223,18 +243,24 @@ function getElementTree(element: HTMLElement): Node | undefined {
       }
     };
 
-    for (const node of element.childNodes) visitChildNode(node);
+    for (const node of element.childNodes) {
+      visitChildNode(node);
+    }
 
     // Open shadow roots only — closed roots are opaque by design.
     if (element.shadowRoot) {
-      for (const node of element.shadowRoot.childNodes) visitChildNode(node);
+      for (const node of element.shadowRoot.childNodes) {
+        visitChildNode(node);
+      }
     }
   }
 
   // Strip styling-only wrappers that survived attribute filtering. Lift a
   // single non-text child up to its grandparent so the tree stays shallow.
   if (nonSemanticTags.has(element.tagName) && attributes.length === 0) {
-    if (compressedElement.childNodes.length === 0) return;
+    if (compressedElement.childNodes.length === 0) {
+      return;
+    }
     if (
       compressedElement.childNodes.length === 1 &&
       compressedElement.childNodes[0]?.nodeType !== Node.TEXT_NODE
@@ -255,7 +281,9 @@ export function getPageTree(): HTMLBodyElement {
   for (const child of document.body.childNodes) {
     if (child instanceof HTMLElement) {
       const elementTree = getElementTree(child);
-      if (elementTree) compressedBody.append(elementTree);
+      if (elementTree) {
+        compressedBody.append(elementTree);
+      }
     } else if (child instanceof Text) {
       const normalized = normalizeTextContent(child.textContent ?? "");
       if (normalized) {

--- a/extension/src/lib/placeholder-count.ts
+++ b/extension/src/lib/placeholder-count.ts
@@ -22,7 +22,9 @@ export interface PlaceholderCountMessage {
 }
 
 function currentCount(): number {
-  if (!document.body) return 0;
+  if (!document.body) {
+    return 0;
+  }
   return document.body.querySelectorAll(COUNT_SELECTOR).length;
 }
 
@@ -41,7 +43,9 @@ export function startPlaceholderCountReporter(): void {
   let lastReported = -1;
   const reportIfChanged = () => {
     const count = currentCount();
-    if (count === lastReported) return;
+    if (count === lastReported) {
+      return;
+    }
     lastReported = count;
     send(count);
   };
@@ -60,7 +64,9 @@ export function startPlaceholderCountReporter(): void {
   });
 
   const startObserving = () => {
-    if (!document.body) return;
+    if (!document.body) {
+      return;
+    }
     observer.observe(document.body, {
       childList: true,
       subtree: true,

--- a/extension/src/lib/placeholder.ts
+++ b/extension/src/lib/placeholder.ts
@@ -49,7 +49,9 @@ function attachReveal(container: HTMLElement, original: Node): void {
       targetIsButton: target?.tagName === "BUTTON",
       alreadyRevealed: revealed,
     });
-    if (revealed) return;
+    if (revealed) {
+      return;
+    }
     revealed = true;
     event.preventDefault();
     event.stopPropagation();
@@ -171,13 +173,17 @@ export function replaceMatchesInTextNode(
   matches: InlineMatch[],
   ruleId: RuleId,
 ): void {
-  if (matches.length === 0) return;
+  if (matches.length === 0) {
+    return;
+  }
   const text = textNode.nodeValue ?? "";
   const fragment = document.createDocumentFragment();
   let cursor = 0;
 
   for (const match of matches) {
-    if (match.start < cursor) continue;
+    if (match.start < cursor) {
+      continue;
+    }
     if (match.start > cursor) {
       fragment.append(document.createTextNode(text.slice(cursor, match.start)));
     }

--- a/extension/src/lib/rule-engine.ts
+++ b/extension/src/lib/rule-engine.ts
@@ -108,7 +108,9 @@ const PLACEHOLDER_STYLES = `
 let stylesInjected = false;
 
 function injectStyles(): void {
-  if (stylesInjected) return;
+  if (stylesInjected) {
+    return;
+  }
   stylesInjected = true;
   const style = document.createElement("style");
   style.dataset.absStyles = "";
@@ -121,12 +123,16 @@ function isApplicableHere(
   topFrame: boolean,
   availability: RuleAvailabilityStates,
 ): boolean {
-  if (!availability[rule.id]?.available) return false;
+  if (!availability[rule.id]?.available) {
+    return false;
+  }
   // topFrameOnly rules target page-wide concepts (site footer, cookie/newsletter
   // overlays, per-host URL recipes). Running them in subframes would either
   // be a no-op (selectors don't match) or actively harmful (duplicate
   // landmark injection into every iframe's body).
-  if (rule.topFrameOnly && !topFrame) return false;
+  if (rule.topFrameOnly && !topFrame) {
+    return false;
+  }
   return true;
 }
 
@@ -154,7 +160,9 @@ function applyEnabled(
     topFrame,
   });
   for (const rule of RULES) {
-    if (!isApplicableHere(rule, topFrame, availability)) continue;
+    if (!isApplicableHere(rule, topFrame, availability)) {
+      continue;
+    }
     if (states[rule.id]) {
       log("applying rule", { ruleId: rule.id });
       rule.apply(document.body);
@@ -184,7 +192,9 @@ function reconcile(
   nextAvailability: RuleAvailabilityStates,
   previousAvailability: RuleAvailabilityStates,
 ): void {
-  if (!document.body) return;
+  if (!document.body) {
+    return;
+  }
   for (const rule of RULES) {
     const wasApplied = effectivelyApplied(
       rule,
@@ -198,7 +208,9 @@ function reconcile(
       topFrame,
       nextAvailability,
     );
-    if (isApplied === wasApplied) continue;
+    if (isApplied === wasApplied) {
+      continue;
+    }
     if (isApplied) {
       log("rule enabled — applying", { ruleId: rule.id });
       rule.apply(document.body);

--- a/extension/src/lib/selector-hide-rule.ts
+++ b/extension/src/lib/selector-hide-rule.ts
@@ -98,20 +98,36 @@ export function createSelectorHideRule(
 
   function scan(root: ParentNode): void {
     const selectors = selectorsFor(globalThis.location.href);
-    if (selectors.length === 0) return;
+    if (selectors.length === 0) {
+      return;
+    }
 
     let candidates = [
       ...root.querySelectorAll<HTMLElement>(selectors.join(",")),
     ];
-    if (candidateFilter) candidates = candidates.filter(candidateFilter);
+    if (candidateFilter) {
+      candidates = candidates.filter(candidateFilter);
+    }
 
     for (const element of candidates) {
-      if (!element.isConnected) continue;
-      if (element.classList.contains(PLACEHOLDER_CLASS)) continue;
-      if (element.closest(`.${PLACEHOLDER_CLASS}`)) continue;
-      if (element.getAttribute(REVEALED_ATTR) === id) continue;
-      if (element.closest(`[${REVEALED_ATTR}="${id}"]`)) continue;
-      if (element.getAttribute(HIDDEN_ATTR) === id) continue;
+      if (!element.isConnected) {
+        continue;
+      }
+      if (element.classList.contains(PLACEHOLDER_CLASS)) {
+        continue;
+      }
+      if (element.closest(`.${PLACEHOLDER_CLASS}`)) {
+        continue;
+      }
+      if (element.getAttribute(REVEALED_ATTR) === id) {
+        continue;
+      }
+      if (element.closest(`[${REVEALED_ATTR}="${id}"]`)) {
+        continue;
+      }
+      if (element.getAttribute(HIDDEN_ATTR) === id) {
+        continue;
+      }
       // Outermost-match only — if a parent is also a candidate, skip this
       // nested one so we don't double-hide.
       if (

--- a/extension/src/lib/subtree-watcher.ts
+++ b/extension/src/lib/subtree-watcher.ts
@@ -43,30 +43,44 @@ export function createSubtreeWatcher(
   const pending = new Set<Element>();
 
   function drain(): void {
-    if (pending.size === 0) return;
+    if (pending.size === 0) {
+      return;
+    }
     const roots = [...pending].filter((root) => root.isConnected);
     pending.clear();
-    if (roots.length > 0) onSubtrees(roots);
+    if (roots.length > 0) {
+      onSubtrees(roots);
+    }
   }
 
   function enqueue(mutations: MutationRecord[]): void {
     for (const mutation of mutations) {
       for (const added of mutation.addedNodes) {
-        if (added.nodeType !== Node.ELEMENT_NODE) continue;
+        if (added.nodeType !== Node.ELEMENT_NODE) {
+          continue;
+        }
         const element = added as Element;
         if (skipPlaceholderSubtrees) {
-          if (element.classList.contains(PLACEHOLDER_CLASS)) continue;
-          if (element.closest(`.${PLACEHOLDER_CLASS}`)) continue;
+          if (element.classList.contains(PLACEHOLDER_CLASS)) {
+            continue;
+          }
+          if (element.closest(`.${PLACEHOLDER_CLASS}`)) {
+            continue;
+          }
         }
         pending.add(element);
       }
     }
-    if (pending.size > 0) throttledScan?.();
+    if (pending.size > 0) {
+      throttledScan?.();
+    }
   }
 
   return {
     start(root: ParentNode): void {
-      if (observer) return;
+      if (observer) {
+        return;
+      }
       throttledScan = throttle(drain, throttleMs, {
         leading: true,
         trailing: true,

--- a/extension/src/lib/use-chrome-storage-value.ts
+++ b/extension/src/lib/use-chrome-storage-value.ts
@@ -20,7 +20,9 @@ export function useChromeStorageValue<T>(
   useEffect(() => {
     let cancelled = false;
     source.get().then((initial) => {
-      if (!cancelled) setValue(initial);
+      if (!cancelled) {
+        setValue(initial);
+      }
     });
     const unsubscribe = source.subscribe((next) => {
       setValue(next);

--- a/extension/src/lib/use-transient-status.ts
+++ b/extension/src/lib/use-transient-status.ts
@@ -14,7 +14,9 @@ export function useTransientStatus(
 
   useEffect(
     () => () => {
-      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
     },
     [],
   );
@@ -22,7 +24,9 @@ export function useTransientStatus(
   const show = useCallback(
     (message: string) => {
       setValue(message);
-      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
       timeoutRef.current = setTimeout(() => {
         setValue(null);
         timeoutRef.current = null;

--- a/extension/src/lib/wait-for-settle.ts
+++ b/extension/src/lib/wait-for-settle.ts
@@ -36,8 +36,12 @@ export function waitForSettle(
 
     const finish = () => {
       observer.disconnect();
-      if (pollTimer) clearTimeout(pollTimer);
-      if (maxTimer) clearTimeout(maxTimer);
+      if (pollTimer) {
+        clearTimeout(pollTimer);
+      }
+      if (maxTimer) {
+        clearTimeout(maxTimer);
+      }
       signal?.removeEventListener("abort", finish);
       resolve();
     };

--- a/extension/src/rules/__tests__/countdown-timer-hide.test.ts
+++ b/extension/src/rules/__tests__/countdown-timer-hide.test.ts
@@ -96,7 +96,9 @@ describe("countdownTimerHideRule", () => {
 
     // Simulate the timer ticking down before the snapshot fires.
     const timer = document.querySelector("#t");
-    if (timer) timer.textContent = "12:34:55";
+    if (timer) {
+      timer.textContent = "12:34:55";
+    }
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
@@ -112,7 +114,9 @@ describe("countdownTimerHideRule", () => {
     countdownTimerHideRule.apply(document.body);
 
     const timer = document.querySelector("#t");
-    if (timer) timer.textContent = "5m 29s";
+    if (timer) {
+      timer.textContent = "5m 29s";
+    }
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
@@ -136,7 +140,9 @@ describe("countdownTimerHideRule", () => {
 
     // Stopwatch-style increment — should not be hidden.
     const timer = document.querySelector("#t");
-    if (timer) timer.textContent = "05:31";
+    if (timer) {
+      timer.textContent = "05:31";
+    }
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
@@ -164,7 +170,9 @@ describe("countdownTimerHideRule", () => {
     countdownTimerHideRule.apply(document.body);
 
     const inner = document.querySelector("#inner");
-    if (inner) inner.textContent = "09:59";
+    if (inner) {
+      inner.textContent = "09:59";
+    }
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
@@ -206,7 +214,9 @@ describe("countdownTimerHideRule", () => {
     countdownTimerHideRule.apply(document.body);
 
     const timer = document.querySelector("#t");
-    if (timer) timer.textContent = "09:59";
+    if (timer) {
+      timer.textContent = "09:59";
+    }
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
@@ -229,7 +239,9 @@ describe("countdownTimerHideRule", () => {
     countdownTimerHideRule.apply(document.body);
 
     const timer = document.querySelector("#t");
-    if (timer) timer.textContent = "09:59";
+    if (timer) {
+      timer.textContent = "09:59";
+    }
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
@@ -251,7 +263,9 @@ describe("countdownTimerHideRule lazy-loaded sections", () => {
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
     const timer = document.querySelector("#t");
-    if (timer) timer.textContent = "09:59";
+    if (timer) {
+      timer.textContent = "09:59";
+    }
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
@@ -295,7 +309,9 @@ describe("countdownTimerHideRule lazy-loaded sections", () => {
     jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
 
     const timer = document.querySelector("#t");
-    if (timer) timer.textContent = "09:59";
+    if (timer) {
+      timer.textContent = "09:59";
+    }
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 
@@ -308,7 +324,9 @@ describe("countdownTimerHideRule lazy-loaded sections", () => {
     countdownTimerHideRule.apply(document.body);
 
     const timer = document.querySelector("#t");
-    if (timer) timer.textContent = "09:59";
+    if (timer) {
+      timer.textContent = "09:59";
+    }
 
     countdownTimerHideRule.teardown?.();
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
@@ -322,7 +340,9 @@ describe("countdownTimerHideRule lazy-loaded sections", () => {
     countdownTimerHideRule.apply(document.body);
 
     const timer = document.querySelector("#t");
-    if (timer) timer.textContent = "09:59";
+    if (timer) {
+      timer.textContent = "09:59";
+    }
 
     jest.advanceTimersByTime(SNAPSHOT_DELAY_MS);
 

--- a/extension/src/rules/__tests__/site-data.test.ts
+++ b/extension/src/rules/__tests__/site-data.test.ts
@@ -55,10 +55,14 @@ describe("site data YAML files", () => {
 
     const hostnames = new Set<string>(parsed.hostnames);
     for (const entry of Object.values(parsed.rules)) {
-      if (!entry) continue;
+      if (!entry) {
+        continue;
+      }
       for (const item of toEntries(entry)) {
         if (item.hostnames) {
-          for (const h of item.hostnames) hostnames.add(h);
+          for (const h of item.hostnames) {
+            hostnames.add(h);
+          }
         }
       }
     }

--- a/extension/src/rules/ads-hide.ts
+++ b/extension/src/rules/ads-hide.ts
@@ -44,7 +44,9 @@ const EASYLIST_STYLESHEET_TEXT = EASYLIST_GENERIC_SELECTORS.map(
 let injectedStyle: HTMLStyleElement | null = null;
 
 function injectEasyListStylesheet(): void {
-  if (injectedStyle?.isConnected) return;
+  if (injectedStyle?.isConnected) {
+    return;
+  }
   const style = document.createElement("style");
   style.id = EASYLIST_STYLE_ID;
   style.textContent = EASYLIST_STYLESHEET_TEXT;

--- a/extension/src/rules/cart-addon-flag.ts
+++ b/extension/src/rules/cart-addon-flag.ts
@@ -95,7 +95,9 @@ export interface AddonMatch {
 export function matchAddon(text: string): AddonMatch | null {
   for (const { label, pattern } of ADDON_PATTERNS) {
     const match = pattern.exec(text);
-    if (match) return { label, matched: match[0] };
+    if (match) {
+      return { label, matched: match[0] };
+    }
   }
   return null;
 }
@@ -107,15 +109,23 @@ interface Candidate {
 }
 
 function isSkipped(element: HTMLElement): boolean {
-  if (element.hasAttribute(FLAGGED_ATTR)) return true;
+  if (element.hasAttribute(FLAGGED_ATTR)) {
+    return true;
+  }
   // Skip the chip itself and anything nested inside it so the chip's own
   // text doesn't drive a recursive re-annotation on the next scan.
-  if (element.classList.contains(FLAG_CLASS)) return true;
-  if (element.closest(`.${FLAG_CLASS}`)) return true;
+  if (element.classList.contains(FLAG_CLASS)) {
+    return true;
+  }
+  if (element.closest(`.${FLAG_CLASS}`)) {
+    return true;
+  }
   // If a descendant is already flagged, the matching text lives in that
   // descendant — annotating the enclosing container as well would be
   // redundant and noisy.
-  if (element.querySelector(`[${FLAGGED_ATTR}]`)) return true;
+  if (element.querySelector(`[${FLAGGED_ATTR}]`)) {
+    return true;
+  }
   return false;
 }
 
@@ -136,8 +146,12 @@ function findCandidates(root: ParentNode): Candidate[] {
 
 function flag(candidate: Candidate): void {
   const { element, label, matched } = candidate;
-  if (!element.isConnected) return;
-  if (element.hasAttribute(FLAGGED_ATTR)) return;
+  if (!element.isConnected) {
+    return;
+  }
+  if (element.hasAttribute(FLAGGED_ATTR)) {
+    return;
+  }
   element.setAttribute(FLAGGED_ATTR, "");
 
   const chip = document.createElement("span");
@@ -160,10 +174,16 @@ function flag(candidate: Candidate): void {
 }
 
 function scanAndFlag(root: ParentNode): void {
-  if (!isCheckoutUrl(globalThis.location.href)) return;
+  if (!isCheckoutUrl(globalThis.location.href)) {
+    return;
+  }
   const candidates = findCandidates(root);
-  if (candidates.length === 0) return;
-  for (const candidate of candidates) flag(candidate);
+  if (candidates.length === 0) {
+    return;
+  }
+  for (const candidate of candidates) {
+    flag(candidate);
+  }
   log("cart add-ons flagged", {
     count: candidates.length,
     labels: candidates.map((c) => c.label),
@@ -173,7 +193,9 @@ function scanAndFlag(root: ParentNode): void {
 
 const watcher = createSubtreeWatcher({
   onSubtrees: (roots) => {
-    for (const root of roots) scanAndFlag(root);
+    for (const root of roots) {
+      scanAndFlag(root);
+    }
   },
 });
 

--- a/extension/src/rules/checkout-checkbox-clear.ts
+++ b/extension/src/rules/checkout-checkbox-clear.ts
@@ -40,7 +40,9 @@ function uncheck(checkbox: HTMLInputElement): void {
 }
 
 function scanAndClear(root: ParentNode): void {
-  if (!isCheckoutUrl(globalThis.location.href)) return;
+  if (!isCheckoutUrl(globalThis.location.href)) {
+    return;
+  }
 
   const checkboxes = root.querySelectorAll<HTMLInputElement>(
     `input[type="checkbox"]:checked:not(:disabled):not([${CLEARED_ATTR}])`,
@@ -48,7 +50,9 @@ function scanAndClear(root: ParentNode): void {
 
   let cleared = 0;
   for (const checkbox of checkboxes) {
-    if (!checkbox.isConnected) continue;
+    if (!checkbox.isConnected) {
+      continue;
+    }
     uncheck(checkbox);
     cleared++;
   }
@@ -67,7 +71,9 @@ function scanAndClear(root: ParentNode): void {
 // we want.
 const watcher = createSubtreeWatcher({
   onSubtrees: (roots) => {
-    for (const root of roots) scanAndClear(root);
+    for (const root of roots) {
+      scanAndClear(root);
+    }
   },
 });
 

--- a/extension/src/rules/cookie-banner-hide.ts
+++ b/extension/src/rules/cookie-banner-hide.ts
@@ -18,7 +18,9 @@ const OVERLAY_ROLES = new Set(["dialog", "alertdialog"]);
 
 function isOverlay(element: HTMLElement): boolean {
   const role = element.getAttribute("role");
-  if (role && OVERLAY_ROLES.has(role)) return true;
+  if (role && OVERLAY_ROLES.has(role)) {
+    return true;
+  }
   const position = globalThis.getComputedStyle(element).position;
   return OVERLAY_POSITIONS.has(position);
 }

--- a/extension/src/rules/countdown-timer-hide.ts
+++ b/extension/src/rules/countdown-timer-hide.ts
@@ -91,9 +91,13 @@ function findCandidates(root: ParentNode): Candidate[] {
     maxTextLength: MAX_CANDIDATE_LENGTH,
     maxDescendants: MAX_CANDIDATE_DESCENDANTS,
     match: (text) => {
-      if (!matchesTimerPattern(text)) return null;
+      if (!matchesTimerPattern(text)) {
+        return null;
+      }
       const seconds = parseTotalSeconds(text);
-      if (seconds == null) return null;
+      if (seconds == null) {
+        return null;
+      }
       return { initialText: text, initialSeconds: seconds };
     },
   });
@@ -106,13 +110,23 @@ function findCandidates(root: ParentNode): Candidate[] {
 
 function reconcileCandidates(candidates: Candidate[]): void {
   for (const { element, initialText, initialSeconds } of candidates) {
-    if (!element.isConnected) continue;
-    if (isInsidePlaceholder(element)) continue;
+    if (!element.isConnected) {
+      continue;
+    }
+    if (isInsidePlaceholder(element)) {
+      continue;
+    }
     const currentText = (element.textContent ?? "").trim();
-    if (currentText === initialText) continue;
+    if (currentText === initialText) {
+      continue;
+    }
     const currentSeconds = parseTotalSeconds(currentText);
-    if (currentSeconds == null) continue;
-    if (currentSeconds >= initialSeconds) continue;
+    if (currentSeconds == null) {
+      continue;
+    }
+    if (currentSeconds >= initialSeconds) {
+      continue;
+    }
     replaceWithBlockPlaceholder(
       element,
       RULE_ID,
@@ -129,8 +143,12 @@ const pendingTimeouts = new Set<ReturnType<typeof setTimeout>>();
 const trackedElements = new WeakSet<Element>();
 
 function scheduleReconcile(candidates: Candidate[]): void {
-  if (candidates.length === 0) return;
-  for (const { element } of candidates) trackedElements.add(element);
+  if (candidates.length === 0) {
+    return;
+  }
+  for (const { element } of candidates) {
+    trackedElements.add(element);
+  }
   const timeoutId = setTimeout(() => {
     pendingTimeouts.delete(timeoutId);
     reconcileCandidates(candidates);
@@ -144,7 +162,9 @@ const watcher = createSubtreeWatcher({
     const candidates: Candidate[] = [];
     for (const root of roots) {
       for (const candidate of findCandidates(root)) {
-        if (trackedElements.has(candidate.element)) continue;
+        if (trackedElements.has(candidate.element)) {
+          continue;
+        }
         candidates.push(candidate);
       }
     }
@@ -159,7 +179,9 @@ function apply(root: ParentNode): void {
 
 function teardown(): void {
   watcher.stop();
-  for (const id of pendingTimeouts) clearTimeout(id);
+  for (const id of pendingTimeouts) {
+    clearTimeout(id);
+  }
   pendingTimeouts.clear();
 }
 

--- a/extension/src/rules/cross-origin-frame-hide.ts
+++ b/extension/src/rules/cross-origin-frame-hide.ts
@@ -27,9 +27,13 @@ const RULE_ID = "cross-origin-frame-hide" as const;
 
 function resolveOrigin(iframe: HTMLIFrameElement): string | null {
   // srcdoc iframes inherit the embedding origin — not a cross-origin threat.
-  if (iframe.hasAttribute("srcdoc")) return null;
+  if (iframe.hasAttribute("srcdoc")) {
+    return null;
+  }
   const raw = iframe.getAttribute("src");
-  if (!raw) return null;
+  if (!raw) {
+    return null;
+  }
   let url: URL;
   try {
     url = new URL(raw, document.baseURI);
@@ -39,16 +43,22 @@ function resolveOrigin(iframe: HTMLIFrameElement): string | null {
   // Only http(s) iframes carry a distinct web origin. about:, javascript:,
   // data:, blob: all either inherit the parent origin or are inert for our
   // purposes; skip them.
-  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return null;
+  }
   return url.origin;
 }
 
 function hideIfCrossOrigin(iframe: HTMLIFrameElement): void {
   // Skip iframes the user has already revealed for this rule, so the subtree
   // observer doesn't immediately re-hide the just-restored content.
-  if (iframe.getAttribute(REVEALED_ATTR) === RULE_ID) return;
+  if (iframe.getAttribute(REVEALED_ATTR) === RULE_ID) {
+    return;
+  }
   const origin = resolveOrigin(iframe);
-  if (!origin || origin === globalThis.location.origin) return;
+  if (!origin || origin === globalThis.location.origin) {
+    return;
+  }
   replaceWithBlockPlaceholder(
     iframe,
     RULE_ID,
@@ -58,14 +68,18 @@ function hideIfCrossOrigin(iframe: HTMLIFrameElement): void {
 
 function scan(root: ParentNode): void {
   for (const iframe of root.querySelectorAll<HTMLIFrameElement>("iframe")) {
-    if (!iframe.isConnected) continue;
+    if (!iframe.isConnected) {
+      continue;
+    }
     hideIfCrossOrigin(iframe);
   }
 }
 
 const watcher = createSubtreeWatcher({
   onSubtrees: (roots) => {
-    for (const root of roots) scan(root);
+    for (const root of roots) {
+      scan(root);
+    }
   },
   skipPlaceholderSubtrees: true,
 });

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -67,8 +67,12 @@ const OFFSCREEN_THRESHOLD_PX = -9999;
 
 function hasSrOnlyClass(element: Element): boolean {
   for (const cls of element.classList) {
-    if (SR_ONLY_CLASS_NAMES.has(cls)) return true;
-    if (/visuallyhidden/i.test(cls)) return true;
+    if (SR_ONLY_CLASS_NAMES.has(cls)) {
+      return true;
+    }
+    if (/visuallyhidden/i.test(cls)) {
+      return true;
+    }
   }
   return false;
 }
@@ -76,7 +80,9 @@ function hasSrOnlyClass(element: Element): boolean {
 function isExcludedAncestor(element: Element): boolean {
   let current: Element | null = element;
   while (current) {
-    if (NON_CONTENT_TAGS.has(current.tagName)) return true;
+    if (NON_CONTENT_TAGS.has(current.tagName)) {
+      return true;
+    }
     current = current.parentElement;
   }
   return false;
@@ -84,17 +90,27 @@ function isExcludedAncestor(element: Element): boolean {
 
 function parsePixelLength(value: string): number | null {
   const match = /^(-?\d+(?:\.\d+)?)px$/.exec(value);
-  if (!match?.[1]) return null;
+  if (!match?.[1]) {
+    return null;
+  }
   return Number.parseFloat(match[1]);
 }
 
 function isClippedToZero(style: CSSStyleDeclaration): boolean {
   const clipPath = style.clipPath;
-  if (clipPath === "inset(100%)") return true;
+  if (clipPath === "inset(100%)") {
+    return true;
+  }
   const clip = style.clip;
-  if (clip === "rect(0px, 0px, 0px, 0px)") return true;
-  if (clip === "rect(0px 0px 0px 0px)") return true;
-  if (clip === "rect(0, 0, 0, 0)") return true;
+  if (clip === "rect(0px, 0px, 0px, 0px)") {
+    return true;
+  }
+  if (clip === "rect(0px 0px 0px 0px)") {
+    return true;
+  }
+  if (clip === "rect(0, 0, 0, 0)") {
+    return true;
+  }
   return false;
 }
 
@@ -112,12 +128,20 @@ function isClippedToZero(style: CSSStyleDeclaration): boolean {
 // enumerate, and false-stripping a single SR-only label can wipe out
 // whole a11y trees (e.g., every Amazon SERP price disappears at once).
 function hasStructuralSrOnlyPattern(style: CSSStyleDeclaration): boolean {
-  if (style.position !== "absolute" && style.position !== "fixed") return false;
-  if (style.overflow !== "hidden") return false;
+  if (style.position !== "absolute" && style.position !== "fixed") {
+    return false;
+  }
+  if (style.overflow !== "hidden") {
+    return false;
+  }
   const width = parsePixelLength(style.width);
   const height = parsePixelLength(style.height);
-  if (width === null || width > SR_ONLY_MAX_SIZE_PX) return false;
-  if (height === null || height > SR_ONLY_MAX_SIZE_PX) return false;
+  if (width === null || width > SR_ONLY_MAX_SIZE_PX) {
+    return false;
+  }
+  if (height === null || height > SR_ONLY_MAX_SIZE_PX) {
+    return false;
+  }
   return true;
 }
 
@@ -125,8 +149,12 @@ function isHiddenByCss(style: CSSStyleDeclaration): boolean {
   if (style.visibility === "hidden" || style.visibility === "collapse") {
     return true;
   }
-  if (Number.parseFloat(style.opacity) === 0) return true;
-  if (style.fontSize === "0px") return true;
+  if (Number.parseFloat(style.opacity) === 0) {
+    return true;
+  }
+  if (style.fontSize === "0px") {
+    return true;
+  }
   if (style.position === "absolute" || style.position === "fixed") {
     const left = parsePixelLength(style.left);
     const top = parsePixelLength(style.top);
@@ -138,8 +166,12 @@ function isHiddenByCss(style: CSSStyleDeclaration): boolean {
     }
   }
   const textIndent = parsePixelLength(style.textIndent);
-  if (textIndent !== null && textIndent <= OFFSCREEN_THRESHOLD_PX) return true;
-  if (isClippedToZero(style)) return true;
+  if (textIndent !== null && textIndent <= OFFSCREEN_THRESHOLD_PX) {
+    return true;
+  }
+  if (isClippedToZero(style)) {
+    return true;
+  }
   return false;
 }
 
@@ -161,12 +193,16 @@ function parseColor(value: string): RGBA | null {
     /^rgba?\(\s*(\d+(?:\.\d+)?)[\s,]+(\d+(?:\.\d+)?)[\s,]+(\d+(?:\.\d+)?)(?:\s*[,/]\s*([\d.]+))?\s*\)$/i.exec(
       value,
     );
-  if (!match?.[1] || !match[2] || !match[3]) return null;
+  if (!match?.[1] || !match[2] || !match[3]) {
+    return null;
+  }
   const r = Number.parseFloat(match[1]);
   const g = Number.parseFloat(match[2]);
   const b = Number.parseFloat(match[3]);
   const a = match[4] === undefined ? 1 : Number.parseFloat(match[4]);
-  if ([r, g, b, a].some((n) => Number.isNaN(n))) return null;
+  if ([r, g, b, a].some((n) => Number.isNaN(n))) {
+    return null;
+  }
   return [r, g, b, a];
 }
 
@@ -203,8 +239,12 @@ function hasMatchingForeground(
   style: CSSStyleDeclaration,
 ): boolean {
   const fg = parseColor(style.color);
-  if (!fg) return false;
-  if (fg[3] === 0) return false;
+  if (!fg) {
+    return false;
+  }
+  if (fg[3] === 0) {
+    return false;
+  }
   const bg = effectiveBackgroundColor(element);
   return colorDistance([fg[0], fg[1], fg[2]], bg) <= COLOR_MATCH_DISTANCE;
 }
@@ -212,16 +252,31 @@ function hasMatchingForeground(
 function findCandidates(root: ParentNode): HTMLElement[] {
   const matches: HTMLElement[] = [];
   for (const element of root.querySelectorAll<HTMLElement>("*")) {
-    if (isNonContentTag(element.tagName)) continue;
-    if (isInsidePlaceholder(element)) continue;
-    if (element.closest('[aria-hidden="true"]')) continue;
-    if (hasSrOnlyClass(element)) continue;
-    if (isExcludedAncestor(element)) continue;
-    if (!hasNonemptyText(element)) continue;
-    const style = globalThis.getComputedStyle(element);
-    if (hasStructuralSrOnlyPattern(style)) continue;
-    if (!isHiddenByCss(style) && !hasMatchingForeground(element, style))
+    if (isNonContentTag(element.tagName)) {
       continue;
+    }
+    if (isInsidePlaceholder(element)) {
+      continue;
+    }
+    if (element.closest('[aria-hidden="true"]')) {
+      continue;
+    }
+    if (hasSrOnlyClass(element)) {
+      continue;
+    }
+    if (isExcludedAncestor(element)) {
+      continue;
+    }
+    if (!hasNonemptyText(element)) {
+      continue;
+    }
+    const style = globalThis.getComputedStyle(element);
+    if (hasStructuralSrOnlyPattern(style)) {
+      continue;
+    }
+    if (!isHiddenByCss(style) && !hasMatchingForeground(element, style)) {
+      continue;
+    }
     matches.push(element);
   }
   return filterToOutermost(matches);
@@ -229,7 +284,9 @@ function findCandidates(root: ParentNode): HTMLElement[] {
 
 function scanAndStrip(root: ParentNode): void {
   for (const element of findCandidates(root)) {
-    if (!element.isConnected) continue;
+    if (!element.isConnected) {
+      continue;
+    }
     log("hidden text removed", {
       ruleId: RULE_ID,
       tag: element.tagName,
@@ -244,7 +301,9 @@ function scanAndStrip(root: ParentNode): void {
 const watcher = createSubtreeWatcher({
   skipPlaceholderSubtrees: true,
   onSubtrees: (roots) => {
-    for (const root of roots) scanAndStrip(root);
+    for (const root of roots) {
+      scanAndStrip(root);
+    }
   },
 });
 

--- a/extension/src/rules/html-comment-strip.ts
+++ b/extension/src/rules/html-comment-strip.ts
@@ -21,7 +21,9 @@ const RULE_ID = "html-comment-strip" as const;
 const EXCLUDED_PARENT_TAGS = new Set(["SCRIPT", "STYLE", "NOSCRIPT"]);
 
 function isExcludedParent(parent: Node | null): boolean {
-  if (!parent || parent.nodeType !== Node.ELEMENT_NODE) return false;
+  if (!parent || parent.nodeType !== Node.ELEMENT_NODE) {
+    return false;
+  }
   return EXCLUDED_PARENT_TAGS.has((parent as Element).tagName);
 }
 
@@ -45,7 +47,9 @@ function stripComments(root: ParentNode): void {
 
 const watcher = createSubtreeWatcher({
   onSubtrees: (roots) => {
-    for (const root of roots) stripComments(root);
+    for (const root of roots) {
+      stripComments(root);
+    }
   },
 });
 

--- a/extension/src/rules/irrelevant-sections-hide.ts
+++ b/extension/src/rules/irrelevant-sections-hide.ts
@@ -78,16 +78,30 @@ function describeElement(element: Element): Record<string, unknown> {
 // machine-readable reason string when it isn't. Two parallel predicates used
 // to drift; one function eliminates the risk.
 function checkHideable(element: Element): string | null {
-  if (!(element instanceof HTMLElement)) return "not-an-htmlelement";
-  if (!element.isConnected) return "detached-from-dom";
-  if (processedElements.has(element)) return "already-processed";
-  if (isInsidePlaceholder(element)) return "inside-placeholder";
+  if (!(element instanceof HTMLElement)) {
+    return "not-an-htmlelement";
+  }
+  if (!element.isConnected) {
+    return "detached-from-dom";
+  }
+  if (processedElements.has(element)) {
+    return "already-processed";
+  }
+  if (isInsidePlaceholder(element)) {
+    return "inside-placeholder";
+  }
 
   // Protect the same categories the prompt is instructed to skip, in case the
   // LLM ignores the instruction.
-  if (element.closest("article")) return "inside-article";
-  if (element.closest("header")) return "inside-header";
-  if (element.closest('[role="banner"]')) return "inside-banner";
+  if (element.closest("article")) {
+    return "inside-article";
+  }
+  if (element.closest("header")) {
+    return "inside-header";
+  }
+  if (element.closest('[role="banner"]')) {
+    return "inside-banner";
+  }
 
   // Sticky / fixed elements leave a layout hole behind if replaced.
   const position = globalThis.getComputedStyle(element).position;
@@ -127,7 +141,9 @@ function serializePageTree(): string {
 }
 
 function runClassification(): void {
-  if (classifyInFlight) return;
+  if (classifyInFlight) {
+    return;
+  }
 
   pruneReferences();
   const pageTree = serializePageTree();
@@ -146,7 +162,9 @@ function runClassification(): void {
 
   classifyIrrelevantSections({ url: location.href, pageTree }, signal)
     .then((response) => {
-      if (signal.aborted) return;
+      if (signal.aborted) {
+        return;
+      }
 
       log("irrelevant-sections-hide classify response", {
         count: response.irrelevant.length,
@@ -247,7 +265,9 @@ function runClassification(): void {
       });
     })
     .catch((error: unknown) => {
-      if (error instanceof DOMException && error.name === "AbortError") return;
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
       const message = error instanceof Error ? error.message : String(error);
       log("irrelevant-sections-hide classify failed", { error: message });
     })
@@ -258,7 +278,9 @@ function runClassification(): void {
 
 function startScrollWatcher(): void {
   scrollHandler = () => {
-    if (scrollDebounceTimer) clearTimeout(scrollDebounceTimer);
+    if (scrollDebounceTimer) {
+      clearTimeout(scrollDebounceTimer);
+    }
     scrollDebounceTimer = setTimeout(() => {
       scrollDebounceTimer = null;
       runClassification();

--- a/extension/src/rules/newsletter-modal-hide.ts
+++ b/extension/src/rules/newsletter-modal-hide.ts
@@ -25,7 +25,9 @@ const MIN_VIEWPORT_AREA_RATIO = 0.25;
 
 function looksLikeNewsletterModal(element: HTMLElement): boolean {
   const style = globalThis.getComputedStyle(element);
-  if (style.position !== "fixed" && style.position !== "sticky") return false;
+  if (style.position !== "fixed" && style.position !== "sticky") {
+    return false;
+  }
 
   // In real browsers, getBoundingClientRect returns layout dimensions; in
   // jsdom it returns 0. Skip the area gate when the rect is zero so unit
@@ -42,7 +44,9 @@ function looksLikeNewsletterModal(element: HTMLElement): boolean {
   }
 
   const text = element.textContent ?? "";
-  if (!NEWSLETTER_TEXT.test(text)) return false;
+  if (!NEWSLETTER_TEXT.test(text)) {
+    return false;
+  }
 
   if (
     !element.querySelector('input[type="email"]') &&

--- a/extension/src/rules/pii-mask.ts
+++ b/extension/src/rules/pii-mask.ts
@@ -15,14 +15,18 @@ const PHONE_PATTERN =
 
 function passesLuhn(raw: string): boolean {
   const digits = raw.replaceAll(/\D/g, "");
-  if (digits.length < 13 || digits.length > 19) return false;
+  if (digits.length < 13 || digits.length > 19) {
+    return false;
+  }
   let sum = 0;
   let alt = false;
   for (let i = digits.length - 1; i >= 0; i--) {
     let n = Number(digits[i]);
     if (alt) {
       n *= 2;
-      if (n > 9) n -= 9;
+      if (n > 9) {
+        n -= 9;
+      }
     }
     sum += n;
     alt = !alt;
@@ -34,8 +38,12 @@ function collectMatches(text: string): InlineMatch[] {
   const matches: InlineMatch[] = [];
 
   for (const m of text.matchAll(CC_PATTERN)) {
-    if (m.index === undefined) continue;
-    if (!passesLuhn(m[0])) continue;
+    if (m.index === undefined) {
+      continue;
+    }
+    if (!passesLuhn(m[0])) {
+      continue;
+    }
     matches.push({
       start: m.index,
       end: m.index + m[0].length,
@@ -43,7 +51,9 @@ function collectMatches(text: string): InlineMatch[] {
     });
   }
   for (const m of text.matchAll(SSN_PATTERN)) {
-    if (m.index === undefined) continue;
+    if (m.index === undefined) {
+      continue;
+    }
     matches.push({
       start: m.index,
       end: m.index + m[0].length,
@@ -51,7 +61,9 @@ function collectMatches(text: string): InlineMatch[] {
     });
   }
   for (const m of text.matchAll(PHONE_PATTERN)) {
-    if (m.index === undefined) continue;
+    if (m.index === undefined) {
+      continue;
+    }
     matches.push({
       start: m.index,
       end: m.index + m[0].length,
@@ -63,7 +75,9 @@ function collectMatches(text: string): InlineMatch[] {
   const merged: InlineMatch[] = [];
   for (const match of matches) {
     const last = merged.at(-1);
-    if (last && match.start < last.end) continue;
+    if (last && match.start < last.end) {
+      continue;
+    }
     merged.push(match);
   }
   return merged;

--- a/extension/src/rules/prompt-injection-hide.ts
+++ b/extension/src/rules/prompt-injection-hide.ts
@@ -37,26 +37,40 @@ function containsInjection(text: string): boolean {
 
 function findContainer(textNode: Text): HTMLElement | null {
   const parent = textNode.parentElement;
-  if (!parent) return null;
+  if (!parent) {
+    return null;
+  }
   const block = parent.closest<HTMLElement>(BLOCK_CONTAINER_SELECTOR);
-  if (block) return block;
+  if (block) {
+    return block;
+  }
   // No block-level ancestor — fall back to the text node's direct parent,
   // but never escalate to BODY/HTML (would hide the whole page).
-  if (parent.tagName === "BODY" || parent.tagName === "HTML") return null;
+  if (parent.tagName === "BODY" || parent.tagName === "HTML") {
+    return null;
+  }
   return parent;
 }
 
 function apply(root: ParentNode): void {
   const containers = new Set<HTMLElement>();
   for (const node of walkTextNodes(root, { minLength: MIN_TEXT_LENGTH })) {
-    if (!containsInjection(node.nodeValue ?? "")) continue;
+    if (!containsInjection(node.nodeValue ?? "")) {
+      continue;
+    }
     const container = findContainer(node);
-    if (container) containers.add(container);
+    if (container) {
+      containers.add(container);
+    }
   }
 
   for (const element of filterToOutermost([...containers])) {
-    if (!element.isConnected) continue;
-    if (isInsidePlaceholder(element)) continue;
+    if (!element.isConnected) {
+      continue;
+    }
+    if (isInsidePlaceholder(element)) {
+      continue;
+    }
     replaceWithBlockPlaceholder(
       element,
       RULE_ID,

--- a/extension/src/rules/scarcity-hide.ts
+++ b/extension/src/rules/scarcity-hide.ts
@@ -58,9 +58,15 @@ export function matchesScarcityPattern(text: string): boolean {
 }
 
 function isSkipped(element: HTMLElement): boolean {
-  if (isInsidePlaceholder(element)) return true;
-  if (element.getAttribute(REVEALED_ATTR) === RULE_ID) return true;
-  if (element.closest(`[${REVEALED_ATTR}="${RULE_ID}"]`)) return true;
+  if (isInsidePlaceholder(element)) {
+    return true;
+  }
+  if (element.getAttribute(REVEALED_ATTR) === RULE_ID) {
+    return true;
+  }
+  if (element.closest(`[${REVEALED_ATTR}="${RULE_ID}"]`)) {
+    return true;
+  }
   return false;
 }
 
@@ -75,8 +81,12 @@ function scanAndHide(root: ParentNode): void {
     match: (text) => (matchesScarcityPattern(text) ? true : null),
   });
   for (const { element } of matches) {
-    if (!element.isConnected) continue;
-    if (isInsidePlaceholder(element)) continue;
+    if (!element.isConnected) {
+      continue;
+    }
+    if (isInsidePlaceholder(element)) {
+      continue;
+    }
     replaceWithBlockPlaceholder(
       element,
       RULE_ID,
@@ -88,7 +98,9 @@ function scanAndHide(root: ParentNode): void {
 const watcher = createSubtreeWatcher({
   skipPlaceholderSubtrees: true,
   onSubtrees: (roots) => {
-    for (const root of roots) scanAndHide(root);
+    for (const root of roots) {
+      scanAndHide(root);
+    }
   },
 });
 

--- a/extension/src/rules/search-url-helper.ts
+++ b/extension/src/rules/search-url-helper.ts
@@ -27,7 +27,9 @@ const LANDMARK_SELECTOR = `section[${RULE_ATTR}="${RULE_ID}"]`;
 
 function findRecipe(url: string): string | null {
   for (const { patterns, recipe } of SEARCH_URL_HELPER_RECIPES) {
-    if (patterns.some((pattern) => pattern.test(url))) return recipe;
+    if (patterns.some((pattern) => pattern.test(url))) {
+      return recipe;
+    }
   }
   return null;
 }
@@ -48,11 +50,15 @@ function buildLandmark(recipe: string): HTMLElement {
 
 function apply(_root: ParentNode): void {
   const recipe = findRecipe(globalThis.location.href);
-  if (recipe === null) return;
+  if (recipe === null) {
+    return;
+  }
   // Idempotent: a previous apply (initial pass, re-enable from the
   // options page, or rule-engine re-fire on history navigation) may
   // already have inserted the landmark.
-  if (document.querySelector(LANDMARK_SELECTOR)) return;
+  if (document.querySelector(LANDMARK_SELECTOR)) {
+    return;
+  }
   // The engine passes document.body, but we always inject at body level
   // (regardless of which subtree root was handed in) so the landmark is
   // the first element of <body> at the top of the a11y tree.

--- a/extension/src/rules/secrets-mask.ts
+++ b/extension/src/rules/secrets-mask.ts
@@ -86,7 +86,9 @@ function collectPattern(
   matches: InlineMatch[],
 ): void {
   for (const m of text.matchAll(pattern.regex)) {
-    if (m.index === undefined) continue;
+    if (m.index === undefined) {
+      continue;
+    }
     matches.push({
       start: m.index,
       end: m.index + m[0].length,
@@ -97,8 +99,12 @@ function collectPattern(
 
 function collectEntropy(text: string, matches: InlineMatch[]): void {
   for (const m of text.matchAll(ENTROPY_CANDIDATE)) {
-    if (m.index === undefined) continue;
-    if (shannonEntropy(m[0]) < BASE64_ENTROPY_THRESHOLD) continue;
+    if (m.index === undefined) {
+      continue;
+    }
+    if (shannonEntropy(m[0]) < BASE64_ENTROPY_THRESHOLD) {
+      continue;
+    }
     matches.push({
       start: m.index,
       end: m.index + m[0].length,
@@ -106,8 +112,12 @@ function collectEntropy(text: string, matches: InlineMatch[]): void {
     });
   }
   for (const m of text.matchAll(HEX_CANDIDATE)) {
-    if (m.index === undefined) continue;
-    if (shannonEntropy(m[0]) < HEX_ENTROPY_THRESHOLD) continue;
+    if (m.index === undefined) {
+      continue;
+    }
+    if (shannonEntropy(m[0]) < HEX_ENTROPY_THRESHOLD) {
+      continue;
+    }
     matches.push({
       start: m.index,
       end: m.index + m[0].length,
@@ -136,7 +146,9 @@ function collectMatches(text: string): InlineMatch[] {
   const merged: InlineMatch[] = [];
   for (const match of matches) {
     const last = merged.at(-1);
-    if (last && match.start < last.end) continue;
+    if (last && match.start < last.end) {
+      continue;
+    }
     merged.push(match);
   }
   return merged;

--- a/extension/src/rules/svg-sprite-suppress.ts
+++ b/extension/src/rules/svg-sprite-suppress.ts
@@ -27,32 +27,50 @@ function collectReferencedSymbolIds(): Set<string> {
   const refs = new Set<string>();
   for (const use of document.querySelectorAll("use")) {
     const href = use.getAttribute("href") ?? use.getAttribute("xlink:href");
-    if (!href) continue;
+    if (!href) {
+      continue;
+    }
     const hashIdx = href.lastIndexOf("#");
-    if (hashIdx === -1) continue;
+    if (hashIdx === -1) {
+      continue;
+    }
     const id = href.slice(hashIdx + 1);
-    if (id) refs.add(id);
+    if (id) {
+      refs.add(id);
+    }
   }
   return refs;
 }
 
 function isSpriteShaped(svg: SVGSVGElement): boolean {
   const children = [...svg.children];
-  if (children.length === 0) return false;
+  if (children.length === 0) {
+    return false;
+  }
   let hasSymbolOrDefs = false;
   for (const child of children) {
     const tag = child.tagName.toLowerCase();
-    if (!STRUCTURAL_TAGS.has(tag)) return false;
-    if (tag === "symbol" || tag === "defs") hasSymbolOrDefs = true;
+    if (!STRUCTURAL_TAGS.has(tag)) {
+      return false;
+    }
+    if (tag === "symbol" || tag === "defs") {
+      hasSymbolOrDefs = true;
+    }
   }
   return hasSymbolOrDefs;
 }
 
 function isHidden(svg: SVGSVGElement): boolean {
-  if (svg.getAttribute("aria-hidden") === "true") return true;
+  if (svg.getAttribute("aria-hidden") === "true") {
+    return true;
+  }
   const style = globalThis.getComputedStyle(svg);
-  if (style.display === "none") return true;
-  if (style.visibility === "hidden") return true;
+  if (style.display === "none") {
+    return true;
+  }
+  if (style.visibility === "hidden") {
+    return true;
+  }
   if (svg.getAttribute("width") === "0" || svg.getAttribute("height") === "0") {
     return true;
   }
@@ -69,11 +87,19 @@ function isHidden(svg: SVGSVGElement): boolean {
 function scan(root: ParentNode): void {
   const referenced = collectReferencedSymbolIds();
   for (const svg of root.querySelectorAll<SVGSVGElement>("svg")) {
-    if (!svg.isConnected) continue;
-    if (!isSpriteShaped(svg)) continue;
-    if (!isHidden(svg)) continue;
+    if (!svg.isConnected) {
+      continue;
+    }
+    if (!isSpriteShaped(svg)) {
+      continue;
+    }
+    if (!isHidden(svg)) {
+      continue;
+    }
     const symbols = [...svg.querySelectorAll<SVGSymbolElement>("symbol[id]")];
-    if (symbols.some((s) => referenced.has(s.id))) continue;
+    if (symbols.some((s) => referenced.has(s.id))) {
+      continue;
+    }
     svg.remove();
   }
 }


### PR DESCRIPTION
## Summary
- Enable Biome's [`useBlockStatements`](https://biomejs.dev/linter/rules/use-block-statements/) rule (style group, opt-in) so single-line control-flow bodies like `if (x) return;` are now lint errors.
- Auto-wrap existing violations across 38 files via `biome check --write --unsafe`. Changes are mechanical brace-wrapping only.
- Kept in `biome.json` rather than ESLint's `curly` to honor the "no rule duplicated between linters" convention from CLAUDE.md.

## Test plan
- [x] `bun run check` clean
- [x] `bun run test` — 453 tests pass
- [x] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)