### PR TITLE
Enable unicorn/prevent-abbreviations with project overrides

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -44,8 +44,37 @@ export default tseslint.config(
       "unicorn/no-array-callback-reference": "off",
       "unicorn/no-nested-ternary": "off",
 
+      "unicorn/prevent-abbreviations": [
+        "error",
+        {
+          replacements: {
+            // Idiomatic in JS/TS — kept as-is.
+            props: false,
+            params: false,
+            param: false,
+            ref: false,
+            refs: false,
+            args: false,
+            db: false,
+            // Node/build conventions. `env` is required by `NodeJS.ProcessEnv`;
+            // `src` is the standard `fs.cp` filter callback parameter name.
+            env: false,
+            src: false,
+            // Common file/module naming convention (`dom-utils.ts`, etc.).
+            utils: false,
+            util: false,
+            // Loop counters and map/filter callback params. The rule is
+            // not scope-aware, so these are allowed globally.
+            i: false,
+            j: false,
+            k: false,
+            x: false,
+            y: false,
+          },
+        },
+      ],
+
       // Disabled — too opinionated for this codebase.
-      "unicorn/prevent-abbreviations": "off",
       "unicorn/no-null": "off",
       "unicorn/no-array-reduce": "off",
       "unicorn/no-array-for-each": "off",

--- a/extension/scripts/build-injection-patterns.ts
+++ b/extension/scripts/build-injection-patterns.ts
@@ -66,16 +66,16 @@ function buildOutput(
 
 export function generateInjectionPatterns(): void {
   const raw = readFileSync(INPUT, "utf8");
-  let doc: unknown;
+  let parsed: unknown;
   try {
-    doc = load(raw);
+    parsed = load(raw);
   } catch (error) {
     throw new Error(
       `${relative(ROOT, INPUT)}: YAML parse error — ${(error as Error).message}`,
       { cause: error },
     );
   }
-  const result = PatternFile.safeParse(doc);
+  const result = PatternFile.safeParse(parsed);
   if (!result.success) {
     const issues = result.error.issues
       .map((issue) => `${issue.path.join(".") || "(root)"} — ${issue.message}`)

--- a/extension/scripts/build-site-data.ts
+++ b/extension/scripts/build-site-data.ts
@@ -54,16 +54,16 @@ function loadSites(): ParsedSiteFile[] {
   for (const fileName of entries) {
     const path = join(SITES_DIR, fileName);
     const raw = readFileSync(path, "utf8");
-    let doc: unknown;
+    let parsedYaml: unknown;
     try {
-      doc = load(raw);
+      parsedYaml = load(raw);
     } catch (error) {
       errors.push(
         `${relative(ROOT, path)}: YAML parse error — ${(error as Error).message}`,
       );
       continue;
     }
-    const result = SiteFileSchema.safeParse(doc);
+    const result = SiteFileSchema.safeParse(parsedYaml);
     if (!result.success) {
       for (const issue of result.error.issues) {
         errors.push(

--- a/extension/src/lib/placeholder.ts
+++ b/extension/src/lib/placeholder.ts
@@ -26,11 +26,11 @@ export interface InlineMatch {
 
 function describeNode(node: Node): Record<string, unknown> {
   if (node.nodeType === Node.ELEMENT_NODE) {
-    const el = node as Element;
+    const element = node as Element;
     return {
-      tag: el.tagName,
-      id: el.id || undefined,
-      classes: el.className || undefined,
+      tag: element.tagName,
+      id: element.id || undefined,
+      classes: element.className || undefined,
     };
   }
   return { nodeType: node.nodeType };

--- a/extension/src/rules/__tests__/pii-mask.test.ts
+++ b/extension/src/rules/__tests__/pii-mask.test.ts
@@ -51,7 +51,7 @@ describe("pii-mask", () => {
 
     const placeholders = document.querySelectorAll(`.${PLACEHOLDER_CLASS}`);
     expect(placeholders).toHaveLength(2);
-    const labels = Array.from(placeholders, (el) => el.textContent);
+    const labels = Array.from(placeholders, (element) => element.textContent);
     expect(labels).toContain("[phone hidden]");
     expect(labels).toContain("[ssn hidden]");
   });

--- a/extension/src/rules/__tests__/secrets-mask.test.ts
+++ b/extension/src/rules/__tests__/secrets-mask.test.ts
@@ -144,7 +144,7 @@ describe("secrets-mask", () => {
 
     const labels = Array.from(
       document.querySelectorAll(`.${PLACEHOLDER_CLASS}`),
-      (el) => el.textContent,
+      (element) => element.textContent,
     );
     expect(labels).toContain("[aws key hidden]");
     expect(labels).toContain("[jwt hidden]");

--- a/extension/src/rules/__tests__/site-data.test.ts
+++ b/extension/src/rules/__tests__/site-data.test.ts
@@ -35,8 +35,8 @@ describe("site data YAML files", () => {
 
   it.each(files)("%s parses + validates against the schema", (fileName) => {
     const raw = readFileSync(join(SITES_DIR, fileName), "utf8");
-    const doc = load(raw);
-    const result = SiteFileSchema.safeParse(doc);
+    const parsedYaml = load(raw);
+    const result = SiteFileSchema.safeParse(parsedYaml);
     if (!result.success) {
       throw new Error(
         `${fileName}: ${result.error.issues
@@ -50,8 +50,8 @@ describe("site data YAML files", () => {
 
   it.each(files)("%s hostnames construct as URLPattern", (fileName) => {
     const raw = readFileSync(join(SITES_DIR, fileName), "utf8");
-    const doc = load(raw);
-    const parsed = SiteFileSchema.parse(doc);
+    const parsedYaml = load(raw);
+    const parsed = SiteFileSchema.parse(parsedYaml);
 
     const hostnames = new Set<string>(parsed.hostnames);
     for (const entry of Object.values(parsed.rules)) {
@@ -75,8 +75,8 @@ describe("site data YAML files", () => {
     const allowedIds = new Set<string>(SITE_DATA_RULE_IDS);
     for (const fileName of files) {
       const raw = readFileSync(join(SITES_DIR, fileName), "utf8");
-      const doc = load(raw) as { rules?: Record<string, unknown> };
-      for (const key of Object.keys(doc?.rules ?? {})) {
+      const parsed = load(raw) as { rules?: Record<string, unknown> };
+      for (const key of Object.keys(parsed?.rules ?? {})) {
         expect({
           file: fileName,
           ruleId: key,

--- a/extension/src/rules/ads-hide.ts
+++ b/extension/src/rules/ads-hide.ts
@@ -61,8 +61,8 @@ function removeEasyListStylesheet(): void {
   injectedStyle = null;
   // Defensive: also drop any orphaned stylesheet from a prior apply that
   // wasn't cleaned up (e.g., page navigated without teardown firing).
-  for (const el of document.querySelectorAll(`#${EASYLIST_STYLE_ID}`)) {
-    el.remove();
+  for (const element of document.querySelectorAll(`#${EASYLIST_STYLE_ID}`)) {
+    element.remove();
   }
 }
 

--- a/extension/src/rules/svg-sprite-suppress.ts
+++ b/extension/src/rules/svg-sprite-suppress.ts
@@ -30,11 +30,11 @@ function collectReferencedSymbolIds(): Set<string> {
     if (!href) {
       continue;
     }
-    const hashIdx = href.lastIndexOf("#");
-    if (hashIdx === -1) {
+    const hashIndex = href.lastIndexOf("#");
+    if (hashIndex === -1) {
       continue;
     }
-    const id = href.slice(hashIdx + 1);
+    const id = href.slice(hashIndex + 1);
     if (id) {
       refs.add(id);
     }


### PR DESCRIPTION
## Summary

- Turn on `unicorn/prevent-abbreviations` (previously disabled as "too opinionated") with a curated `replacements` allow-list for terms idiomatic to this codebase.
- Rename the handful of remaining abbreviations the rule flagged.

## Allowed terms

- **JS/TS idioms:** `props`, `params`/`param`, `ref`/`refs`, `args`, `db`
- **Node/build conventions:** `env` (required by `NodeJS.ProcessEnv`), `src` (standard `fs.cp` filter callback param)
- **File naming:** `utils`/`util` (e.g., `dom-utils.ts`)
- **Loop counters / callback params:** `i`, `j`, `k`, `x`, `y` (the rule isn't scope-aware, so these are allowed globally)

## Renames

- `el` → `element` in `ads-hide.ts`, `lib/placeholder.ts`, and 2 tests
- `doc` → `parsedYaml` (and one `parsed`) in `build-site-data.ts`, `build-injection-patterns.ts`, and `site-data.test.ts`
- `hashIdx` → `hashIndex` in `svg-sprite-suppress.ts`

## Test plan

- [x] `bun run check` passes (biome + eslint clean)
- [x] `bun run test` passes (453 tests)
- [x] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)