### PR TITLE
Add reporting-issues section to ClawHub SKILL.md

### DIFF
--- a/clawhub/agent-browser-shield/SKILL.md
+++ b/clawhub/agent-browser-shield/SKILL.md
@@ -5,10 +5,6 @@ description: Install and operate the agent-browser-shield Chromium extension —
 
 # agent-browser-shield
 
-<!-- Canonical maintainer-facing skills live in pixiebrix/agent-browser-shield
-     under skills/agent-browser-shield/ and skills/agent-browser-shield-install/.
-     This file is the curated public surface — keep it short. -->
-
 A Chromium MV3 extension that runs in the browser session **before the agent
 sees the page**: masks PII and secrets, neutralizes cart sneak-ins and
 pre-checked checkout boxes, strips prompt-injection surfaces, and hides
@@ -112,3 +108,10 @@ Use when OpenClaw is connecting to a Chromium you launch yourself.
 
 Open the options page (shield icon in the Chromium toolbar) to toggle individual
 rules. Per-site rule overrides are also available there.
+
+## Reporting issues
+
+Bug reports and feature requests:
+<https://github.com/pixiebrix/agent-browser-shield/issues>. Include the rule ID
+(from `data-abs-rule`) and the page URL when reporting a false positive or
+missed detection.


### PR DESCRIPTION
## Summary
- Add a **Reporting issues** section pointing users at the GitHub issues tracker, with a nudge to include the rule ID (`data-abs-rule`) and page URL.
- Remove the maintainer-facing HTML comment from the top of the file. Nothing in the publish pipeline strips comments, and the raw markdown is what loads into the agent's context window per session — same reason the README warns to keep the file short.

## Test plan
- [ ] Eyeball the rendered SKILL.md on GitHub.
- [ ] On next ClawHub publish, run the `clawhub skill publish … --dry-run --card` preview to confirm the new section renders and no stray comment appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)