### PR TITLE
Add import-x, jest, react-hooks ESLint plugins + preflight

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ bun run check       # Biome (lint + format) + ESLint (unicorn + custom rules)
 bun run preflight   # everything CI gates on: codegen + lint + typecheck + knip + test
 ```
 
-Run `bun run preflight` before opening a PR — it runs the same checks CI does
-in the same order, so green locally means green in CI.
+Run `bun run preflight` before opening a PR — it runs the same checks CI does in
+the same order, so green locally means green in CI.
 
 Load `extension/dist/` as unpacked at `chrome://extensions`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,11 @@ bun run build       # writes extension/dist/
 bun run watch       # rebuilds on change
 bun run test        # Jest unit tests
 bun run check       # Biome (lint + format) + ESLint (unicorn + custom rules)
+bun run preflight   # everything CI gates on: codegen + lint + typecheck + knip + test
 ```
+
+Run `bun run preflight` before opening a PR — it runs the same checks CI does
+in the same order, so green locally means green in CI.
 
 Load `extension/dist/` as unpacked at `chrome://extensions`.
 

--- a/extension/bun.lock
+++ b/extension/bun.lock
@@ -25,6 +25,9 @@
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "eslint": "10.4.0",
+        "eslint-plugin-import-x": "^4.16.2",
+        "eslint-plugin-jest": "^29.15.2",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-unicorn": "64.0.0",
         "globals": "17.6.0",
         "jest": "^30",
@@ -320,6 +323,8 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.20.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw=="],
 
+    "@package-json/types": ["@package-json/types@0.0.12", "", {}, "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw=="],
+
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@pkgr/core": ["@pkgr/core@0.3.6", "", {}, "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA=="],
@@ -558,6 +563,8 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "comment-parser": ["comment-parser@1.4.7", "", {}, "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ=="],
+
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
@@ -603,6 +610,14 @@
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "eslint": ["eslint@10.4.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ=="],
+
+    "eslint-import-context": ["eslint-import-context@0.1.9", "", { "dependencies": { "get-tsconfig": "^4.10.1", "stable-hash-x": "^0.2.0" }, "peerDependencies": { "unrs-resolver": "^1.0.0" }, "optionalPeers": ["unrs-resolver"] }, "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg=="],
+
+    "eslint-plugin-import-x": ["eslint-plugin-import-x@4.16.2", "", { "dependencies": { "@package-json/types": "^0.0.12", "@typescript-eslint/types": "^8.56.0", "comment-parser": "^1.4.1", "debug": "^4.4.1", "eslint-import-context": "^0.1.9", "is-glob": "^4.0.3", "minimatch": "^9.0.3 || ^10.1.2", "semver": "^7.7.2", "stable-hash-x": "^0.2.0", "unrs-resolver": "^1.9.2" }, "peerDependencies": { "@typescript-eslint/utils": "^8.56.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "eslint-import-resolver-node": "*" }, "optionalPeers": ["@typescript-eslint/utils", "eslint-import-resolver-node"] }, "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw=="],
+
+    "eslint-plugin-jest": ["eslint-plugin-jest@29.15.2", "", { "dependencies": { "@typescript-eslint/utils": "^8.0.0" }, "peerDependencies": { "@typescript-eslint/eslint-plugin": "^8.0.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "jest": "*", "typescript": ">=4.8.4 <7.0.0" }, "optionalPeers": ["@typescript-eslint/eslint-plugin", "jest", "typescript"] }, "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ=="],
+
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
 
     "eslint-plugin-unicorn": ["eslint-plugin-unicorn@64.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "@eslint-community/eslint-utils": "^4.9.1", "change-case": "^5.4.4", "ci-info": "^4.4.0", "clean-regexp": "^1.0.0", "core-js-compat": "^3.49.0", "find-up-simple": "^1.0.1", "globals": "^17.4.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regexp-tree": "^0.1.27", "regjsparser": "^0.13.0", "semver": "^7.7.4", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=9.38.0" } }, "sha512-rNZwalHh8i0UfPlhNwg5BTUO1CMdKNmjqe+TgzOTZnpKoi8VBgsW7u9qCHIdpxEzZ1uwrJrPF0uRb7l//K38gA=="],
 
@@ -681,6 +696,10 @@
     "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
+
+    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
@@ -966,6 +985,8 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
+    "stable-hash-x": ["stable-hash-x@0.2.0", "", {}, "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ=="],
+
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
     "string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ=="],
@@ -1089,6 +1110,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -6,6 +6,9 @@
 // modern-API hints) plus this project's custom rules in `eslint-rules/`.
 
 import js from "@eslint/js";
+import importX from "eslint-plugin-import-x";
+import jest from "eslint-plugin-jest";
+import reactHooks from "eslint-plugin-react-hooks";
 import unicorn from "eslint-plugin-unicorn";
 import globals from "globals";
 import tseslint from "typescript-eslint";
@@ -42,9 +45,27 @@ export default tseslint.config(
     },
     plugins: {
       "agent-browser-shield": localPlugin,
+      "import-x": importX,
+    },
+    settings: {
+      "import-x/resolver-next": [
+        importX.createNodeResolver({
+          extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"],
+        }),
+      ],
     },
     rules: {
       "agent-browser-shield/rule-id-matches-filename": "error",
+
+      // Import hygiene — TS handles existence/named-export checking, so
+      // import-x here only owns structural issues TS can't see: cycles,
+      // duplicate import statements, self-imports, useless path segments,
+      // and inconsistent type-specifier style.
+      "import-x/no-cycle": ["error", { maxDepth: 10, ignoreExternal: true }],
+      "import-x/no-self-import": "error",
+      "import-x/no-duplicates": "error",
+      "import-x/no-useless-path-segments": "error",
+      "import-x/consistent-type-specifier-style": ["error", "prefer-top-level"],
 
       // Disabled — overlaps with Biome's recommended set or its formatter.
       "unicorn/no-useless-undefined": "off",
@@ -127,12 +148,38 @@ export default tseslint.config(
   },
   {
     files: ["src/**/__tests__/**/*.{ts,tsx}"],
+    plugins: { jest },
     rules: {
       // Tests legitimately use literal nulls and many small `for` loops.
       "unicorn/no-useless-undefined": "off",
       "unicorn/consistent-function-scoping": "off",
       // Jest matchers and mock patterns routinely pass methods by reference.
       "@typescript-eslint/unbound-method": "off",
+
+      // Catch common test mistakes — focused/disabled tests left in,
+      // assertions that don't run, expects in unexpected places.
+      "jest/no-focused-tests": "error",
+      "jest/no-disabled-tests": "error",
+      "jest/valid-expect": "error",
+      "jest/no-standalone-expect": "error",
+      "jest/no-identical-title": "error",
+      "jest/valid-title": "error",
+
+      // `expect*` recognizes in-file helpers like `expectHidden(el)` that
+      // wrap one or more real `expect()` calls — without this, every rule
+      // test that delegates to such a helper trips the rule.
+      "jest/expect-expect": [
+        "error",
+        { assertFunctionNames: ["expect", "expect*"] },
+      ],
+
+      // Off: the codebase relies on TS discriminated-union narrowing
+      //   expect(result.ok).toBe(false);
+      //   if (!result.ok) { expect(result.error).toMatch(/.../); }
+      // The rule flags any `expect` inside an `if`, which is too coarse for
+      // this pattern. Both branches of an `it.each` matrix also legitimately
+      // assert different things.
+      "jest/no-conditional-expect": "off",
     },
   },
   {
@@ -142,6 +189,17 @@ export default tseslint.config(
     },
     rules: {
       "unicorn/no-process-exit": "off",
+    },
+  },
+  {
+    // Rules of Hooks + exhaustive-deps catch stale-closure and conditional-
+    // hook bugs that TypeScript can't see. Scoped to the React surfaces
+    // (popup/options + components under lib/).
+    files: ["src/**/*.tsx"],
+    plugins: { "react-hooks": reactHooks },
+    rules: {
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "error",
     },
   },
 );

--- a/extension/package.json
+++ b/extension/package.json
@@ -35,7 +35,9 @@
     "lint": "biome lint . && eslint .",
     "lint:eslint": "eslint .",
     "lint:eslint:fix": "eslint . --fix",
-    "knip": "knip"
+    "knip": "knip",
+    "typecheck": "tsc --noEmit",
+    "preflight": "bun run build-site-data && bun run build-injection-patterns && bun run check && bun run typecheck && bun run knip && bun run test"
   },
   "dependencies": {
     "abort-utils": "^3.0.0",
@@ -58,6 +60,9 @@
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "eslint": "10.4.0",
+    "eslint-plugin-import-x": "^4.16.2",
+    "eslint-plugin-jest": "^29.15.2",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-unicorn": "64.0.0",
     "globals": "17.6.0",
     "jest": "^30",

--- a/extension/scripts/build-site-data.ts
+++ b/extension/scripts/build-site-data.ts
@@ -12,11 +12,13 @@
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { load } from "js-yaml";
+import type {
+  RecipeRuleEntryInput,
+  SelectorRuleEntryInput,
+  SiteFile,
+} from "../data/site-rules.schema";
 import {
-  type RecipeRuleEntryInput,
-  type SelectorRuleEntryInput,
   SITE_DATA_RULE_IDS,
-  type SiteFile,
   SiteFileSchema,
   toEntries,
 } from "../data/site-rules.schema";

--- a/extension/src/lib/RuleList.tsx
+++ b/extension/src/lib/RuleList.tsx
@@ -3,7 +3,8 @@
 
 import { RULES } from "../rules";
 import type { RuleAvailabilityStates } from "./availability";
-import { type RuleStates, setRuleEnabled } from "./storage";
+import type { RuleStates } from "./storage";
+import { setRuleEnabled } from "./storage";
 
 // Shared per-rule checkbox list rendered by both the popup and options page.
 // Pass `disabledByEnforcement` when the surface should grey out every rule

--- a/extension/src/lib/availability.ts
+++ b/extension/src/lib/availability.ts
@@ -7,7 +7,8 @@
 // split behind a snapshot map so the engine, popup, and options page don't
 // each duplicate the resolution.
 
-import { RULES, type RuleId } from "../rules";
+import type { RuleId } from "../rules";
+import { RULES } from "../rules";
 import type {
   AvailabilitySnapshot,
   Rule,

--- a/extension/src/lib/llm-background.ts
+++ b/extension/src/lib/llm-background.ts
@@ -2,12 +2,12 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { getUserApiKey } from "./api-key-storage";
-import {
-  CLASSIFY_PORT_NAME,
-  type ClassifyPortMessage,
-  type ClassifyRequest,
-  type ClassifyResponse,
+import type {
+  ClassifyPortMessage,
+  ClassifyRequest,
+  ClassifyResponse,
 } from "./llm-client";
+import { CLASSIFY_PORT_NAME } from "./llm-client";
 
 // Injected at build time via Bun `define` (see `src/globals.d.ts`). Empty
 // string when unset so the extension still loads; classification calls then

--- a/extension/src/lib/rule-engine.ts
+++ b/extension/src/lib/rule-engine.ts
@@ -1,10 +1,11 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-import { RULES, type Rule } from "../rules";
+import type { Rule } from "../rules";
+import { RULES } from "../rules";
+import type { RuleAvailabilityStates } from "./availability";
 import {
   getRuleAvailabilityStates,
-  type RuleAvailabilityStates,
   subscribeRuleAvailability,
 } from "./availability";
 import {
@@ -20,13 +21,14 @@ import {
   PLACEHOLDER_CLASS,
   revealAll,
 } from "./placeholder";
+import type { PlaceholderDisplayMode } from "./placeholder-display";
 import {
   getPlaceholderDisplayMode,
   PLACEHOLDER_DISPLAY_MODE_DEFAULT,
-  type PlaceholderDisplayMode,
   subscribePlaceholderDisplayMode,
 } from "./placeholder-display";
-import { getRuleStates, type RuleStates, subscribe } from "./storage";
+import type { RuleStates } from "./storage";
+import { getRuleStates, subscribe } from "./storage";
 
 const PLACEHOLDER_MODE_ATTR = "data-abs-placeholder-mode";
 

--- a/extension/src/lib/storage.ts
+++ b/extension/src/lib/storage.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-import { RULE_IDS, RULES, type RuleId } from "../rules";
+import type { RuleId } from "../rules";
+import { RULE_IDS, RULES } from "../rules";
 import { createChromeStorageValue } from "./chrome-storage-value";
 
 export type RuleStates = Record<RuleId, boolean>;

--- a/extension/src/options/Options.tsx
+++ b/extension/src/options/Options.tsx
@@ -5,10 +5,8 @@ import { useEffect, useState } from "react";
 import { apiKeyStorage, HAS_BUILT_IN_OPENAI_KEY } from "../lib/api-key-storage";
 import { availabilitySource } from "../lib/availability";
 import { HelpLinks } from "../lib/HelpLinks";
-import {
-  type PlaceholderDisplayMode,
-  placeholderDisplayStorage,
-} from "../lib/placeholder-display";
+import type { PlaceholderDisplayMode } from "../lib/placeholder-display";
+import { placeholderDisplayStorage } from "../lib/placeholder-display";
 import { RuleList } from "../lib/RuleList";
 import { ruleStatesStorage, setAllRuleStates } from "../lib/storage";
 import { useChromeStorageValue } from "../lib/use-chrome-storage-value";

--- a/extension/src/options/parse-config.ts
+++ b/extension/src/options/parse-config.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-import { RULE_IDS, type RuleStates } from "../lib/storage";
+import type { RuleStates } from "../lib/storage";
+import { RULE_IDS } from "../lib/storage";
 
 const RULE_ID_SET = new Set<string>(RULE_IDS);
 

--- a/extension/src/rules/__tests__/site-data.test.ts
+++ b/extension/src/rules/__tests__/site-data.test.ts
@@ -37,15 +37,14 @@ describe("site data YAML files", () => {
     const raw = readFileSync(join(SITES_DIR, fileName), "utf8");
     const parsedYaml = load(raw);
     const result = SiteFileSchema.safeParse(parsedYaml);
-    if (!result.success) {
-      throw new Error(
-        `${fileName}: ${result.error.issues
+    const errorSummary = result.success
+      ? null
+      : `${fileName}: ${result.error.issues
           .map(
             (issue) => `${issue.path.join(".") || "(root)"} — ${issue.message}`,
           )
-          .join("; ")}`,
-      );
-    }
+          .join("; ")}`;
+    expect(errorSummary).toBeNull();
   });
 
   it.each(files)("%s hostnames construct as URLPattern", (fileName) => {

--- a/extension/src/rules/pii-mask.ts
+++ b/extension/src/rules/pii-mask.ts
@@ -2,7 +2,8 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { walkTextNodes } from "../lib/dom-utils";
-import { type InlineMatch, replaceMatchesInTextNode } from "../lib/placeholder";
+import type { InlineMatch } from "../lib/placeholder";
+import { replaceMatchesInTextNode } from "../lib/placeholder";
 import type { Rule } from "./types";
 
 const RULE_ID = "pii-mask" as const;

--- a/extension/src/rules/secrets-mask.ts
+++ b/extension/src/rules/secrets-mask.ts
@@ -2,7 +2,8 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { walkTextNodes } from "../lib/dom-utils";
-import { type InlineMatch, replaceMatchesInTextNode } from "../lib/placeholder";
+import type { InlineMatch } from "../lib/placeholder";
+import { replaceMatchesInTextNode } from "../lib/placeholder";
 import type { Rule } from "./types";
 
 const RULE_ID = "secrets-mask" as const;


### PR DESCRIPTION
## Summary

Static-analysis additions targeting bug classes AI agents (and humans) commonly introduce, plus a one-shot local preflight that matches CI.

- **`eslint-plugin-import-x`** — `no-cycle` (maxDepth 10, `ignoreExternal`), `no-self-import`, `no-duplicates`, `no-useless-path-segments`, `consistent-type-specifier-style`. Circular deps cause subtle init-order bugs TS can't see. The autofix already separated 13 inline `type` specifiers into top-level `import type` statements.
- **`eslint-plugin-jest`** — `no-focused-tests`, `no-disabled-tests`, `expect-expect`, `valid-expect`, `no-standalone-expect`, `no-identical-title`, `valid-title`. Scoped to `__tests__/`. `expect-expect` uses `assertFunctionNames: ["expect", "expect*"]` so in-file helpers (`expectHidden`, etc.) count as assertions. `no-conditional-expect` is **off** — too many false positives on TS discriminated-union narrowing (`if (!result.ok) { expect(result.error)… }`). One real test fix in `site-data.test.ts`: a throw-only "test" now uses `expect()`.
- **`eslint-plugin-react-hooks`** — `rules-of-hooks` + `exhaustive-deps`, scoped to `*.tsx`. Narrow current footprint (one file uses hooks today) but free insurance as React surfaces grow.
- **`bun run preflight`** — regenerates codegen, then runs lint + typecheck + knip + test, mirroring CI order. Documented in `CONTRIBUTING.md`.

## Test plan

- [x] `bun run preflight` (locally — clean: 27 suites, 453 tests pass)
- [x] `bun run lint:eslint` (clean, including newly-introduced rules)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)