### PR TITLE
Add on-page options button toggle and migrate storage to webext-storage

### DIFF
--- a/extension/bun.lock
+++ b/extension/bun.lock
@@ -11,6 +11,7 @@
         "react": "19.2.6",
         "react-dom": "19.2.6",
         "urlpattern-polyfill": "10.1.0",
+        "webext-storage": "^3.1.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
@@ -1071,6 +1072,8 @@
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
+
+    "webext-storage": ["webext-storage@3.1.0", "", {}, "sha512-tjOqhDCNfNNh5fj36jI84LJys1oYHNPEc1wjivEQe18Cz9QCuaqtIjzMQ29Io/IaM4nq3Er+HWgEXoN3u/Ox7g=="],
 
     "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 

--- a/extension/jest.config.cjs
+++ b/extension/jest.config.cjs
@@ -26,5 +26,12 @@ module.exports = {
     ],
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
+  // `webext-storage` is published as ESM-only and our ts-jest config emits
+  // CommonJS, so importing it directly trips a `SyntaxError: Unexpected token
+  // 'export'`. None of our tests exercise the real storage flow (they mock the
+  // storage modules wholesale), so route the import to a small CJS stub.
+  moduleNameMapper: {
+    "^webext-storage$": "<rootDir>/src/__test-mocks__/webext-storage.ts",
+  },
   clearMocks: true,
 };

--- a/extension/package.json
+++ b/extension/package.json
@@ -45,7 +45,8 @@
     "nanoid": "^5.1.11",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "urlpattern-polyfill": "10.1.0"
+    "urlpattern-polyfill": "10.1.0",
+    "webext-storage": "^3.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",

--- a/extension/src/__test-mocks__/webext-storage.ts
+++ b/extension/src/__test-mocks__/webext-storage.ts
@@ -23,7 +23,9 @@ export class StorageItem<Base, Return = Base | undefined> {
 
   constructor(key: string, options: StorageItemOptions<Return> = {}) {
     this.key = key;
-    this.defaultValue = options.defaultValue;
+    if (options.defaultValue !== undefined) {
+      this.defaultValue = options.defaultValue;
+    }
   }
 
   get(): Promise<Return> {

--- a/extension/src/__test-mocks__/webext-storage.ts
+++ b/extension/src/__test-mocks__/webext-storage.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// In-memory stub of the subset of `webext-storage` we use. Wired up via
+// `moduleNameMapper` in `jest.config.cjs` so tests can import storage modules
+// without pulling in the real ESM-only package (which trips ts-jest's CJS
+// transform). The stub keeps a per-key value so `get()` round-trips through
+// `set()` and `onChanged` fires on writes — enough for any future test that
+// wants to exercise the storage adapter end to end. Today every storage-aware
+// test mocks the wrapping module wholesale and never reaches this code.
+
+interface StorageItemOptions<T> {
+  area?: string;
+  defaultValue?: T;
+}
+
+const values = new Map<string, unknown>();
+const listeners = new Map<string, Set<(next: unknown) => void>>();
+
+export class StorageItem<Base, Return = Base | undefined> {
+  readonly key: string;
+  readonly defaultValue?: Return;
+
+  constructor(key: string, options: StorageItemOptions<Return> = {}) {
+    this.key = key;
+    this.defaultValue = options.defaultValue;
+  }
+
+  get(): Promise<Return> {
+    const value = values.has(this.key)
+      ? values.get(this.key)
+      : this.defaultValue;
+    return Promise.resolve(value as Return);
+  }
+
+  set(value: Exclude<Return, undefined>): Promise<void> {
+    values.set(this.key, value);
+    for (const listener of listeners.get(this.key) ?? []) {
+      listener(value);
+    }
+    return Promise.resolve();
+  }
+
+  has(): Promise<boolean> {
+    return Promise.resolve(values.has(this.key));
+  }
+
+  remove(): Promise<void> {
+    values.delete(this.key);
+    return Promise.resolve();
+  }
+
+  onChanged(
+    callback: (value: Exclude<Return, undefined>) => void,
+    signal?: AbortSignal,
+  ): void {
+    const set = listeners.get(this.key) ?? new Set();
+    const wrapped = (next: unknown) => {
+      callback(next as Exclude<Return, undefined>);
+    };
+    set.add(wrapped);
+    listeners.set(this.key, set);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        set.delete(wrapped);
+      },
+      { once: true },
+    );
+  }
+}
+
+export class StorageItemMap<T> {
+  constructor(
+    public readonly key: string,
+    public readonly options: StorageItemOptions<T> = {},
+  ) {}
+}

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -2,7 +2,7 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { isTopFrame } from "./lib/frame";
-import { injectOptionsBadge } from "./lib/options-badge";
+import { startOptionsBadge } from "./lib/options-badge";
 import { startPlaceholderCountReporter } from "./lib/placeholder-count";
 import { start } from "./lib/rule-engine";
 
@@ -21,5 +21,5 @@ start().catch((error: unknown) => {
 startPlaceholderCountReporter();
 
 if (isTopFrame()) {
-  injectOptionsBadge();
+  startOptionsBadge();
 }

--- a/extension/src/lib/api-key-storage.ts
+++ b/extension/src/lib/api-key-storage.ts
@@ -12,13 +12,9 @@ import { createChromeStorageValue } from "./chrome-storage-value";
 export const HAS_BUILT_IN_OPENAI_KEY =
   process.env.HAS_BUILT_IN_OPENAI_KEY === "true";
 
-function normalize(raw: unknown): string {
-  return typeof raw === "string" ? raw : "";
-}
-
 export const apiKeyStorage = createChromeStorageValue<string>({
   key: "agent-browser-shield.openai-api-key",
-  normalize,
+  defaultValue: "",
 });
 
 export const getUserApiKey = apiKeyStorage.get;

--- a/extension/src/lib/chrome-storage-value.ts
+++ b/extension/src/lib/chrome-storage-value.ts
@@ -20,7 +20,14 @@ export interface ChromeStorageValue<T> {
   subscribe: (listener: (next: T) => void) => () => void;
 }
 
-export function createChromeStorageValue<T>(options: {
+// `T extends NonNullable<unknown>` rules out `undefined` (and `null`), which
+// `StorageItem.set` / `onChanged` also forbid — passing `undefined` to
+// `StorageItem.set` is overloaded to remove the key, so it has to be excluded
+// from the value type. The constraint lets us forward `T` to those methods
+// without per-call casts.
+export function createChromeStorageValue<
+  T extends NonNullable<unknown>,
+>(options: {
   key: string;
   defaultValue: T;
   // `normalize` is only needed for stored shapes that can drift from `T` across

--- a/extension/src/lib/chrome-storage-value.ts
+++ b/extension/src/lib/chrome-storage-value.ts
@@ -1,51 +1,51 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-// Factory for a typed value persisted under a single key in
-// `chrome.storage.local`. Wraps the get / set / onChanged plumbing so each
-// stored setting (rule states, enforcement flag, placeholder display mode,
-// user API key) only has to declare its key, default, and normalization.
-//
-// The subscribe callback always receives both the new and previous normalized
-// values — callers that only care about the new value can take a single
-// parameter (TypeScript silently allows narrower listeners).
+// Thin adapter over `webext-storage` that produces the `{ get, set, subscribe }`
+// shape the rest of the codebase (and the `useChromeStorageValue` hook) reads.
+// `webext-storage` owns the typed-key plumbing and the `onChanged` listener
+// filtering; this wrapper exists to:
+//   1. expose `subscribe` returning an unsubscribe (the hook's contract),
+//      built on `StorageItem.onChanged` + an `AbortController`.
+//   2. let callers thread an optional `normalize` for legacy/cross-version
+//      data shapes (e.g. `RuleStates` where the rule catalog can grow between
+//      releases). For values we always write through a typed `.set()` and the
+//      default covers the missing-key case, `normalize` is unnecessary.
+
+import { StorageItem } from "webext-storage";
 
 export interface ChromeStorageValue<T> {
   get: () => Promise<T>;
   set: (value: T) => Promise<void>;
-  subscribe: (listener: (next: T, previous: T) => void) => () => void;
+  subscribe: (listener: (next: T) => void) => () => void;
 }
 
 export function createChromeStorageValue<T>(options: {
   key: string;
-  normalize: (raw: unknown) => T;
+  defaultValue: T;
+  // `normalize` is only needed for stored shapes that can drift from `T` across
+  // versions (e.g. `RuleStates`, where new rule ids appear in the catalog
+  // between releases). Typed as `(raw: unknown)` rather than `(raw: T)` so the
+  // implementation can defensively type-check stored values.
+  normalize?: (raw: unknown) => T;
 }): ChromeStorageValue<T> {
-  const { key, normalize } = options;
+  const { key, defaultValue, normalize } = options;
+  const item = new StorageItem<T, T>(key, { defaultValue });
+  const read = (raw: T): T => (normalize ? normalize(raw) : raw);
   return {
     async get() {
-      const stored = await chrome.storage.local.get(key);
-      return normalize(stored[key]);
+      return read(await item.get());
     },
     async set(value) {
-      await chrome.storage.local.set({ [key]: value });
+      await item.set(value);
     },
     subscribe(listener) {
-      const handler = (
-        changes: Record<string, chrome.storage.StorageChange>,
-        areaName: string,
-      ) => {
-        if (areaName !== "local") {
-          return;
-        }
-        const change = changes[key];
-        if (!change) {
-          return;
-        }
-        listener(normalize(change.newValue), normalize(change.oldValue));
-      };
-      chrome.storage.onChanged.addListener(handler);
+      const controller = new AbortController();
+      item.onChanged((next) => {
+        listener(read(next));
+      }, controller.signal);
       return () => {
-        chrome.storage.onChanged.removeListener(handler);
+        controller.abort();
       };
     },
   };

--- a/extension/src/lib/enforcement.ts
+++ b/extension/src/lib/enforcement.ts
@@ -13,13 +13,9 @@ import { createChromeStorageValue } from "./chrome-storage-value";
 
 export const ENFORCEMENT_ENABLED_DEFAULT = true;
 
-function normalize(raw: unknown): boolean {
-  return typeof raw === "boolean" ? raw : ENFORCEMENT_ENABLED_DEFAULT;
-}
-
 export const enforcementStorage = createChromeStorageValue<boolean>({
   key: "agent-browser-shield.enforcement-enabled",
-  normalize,
+  defaultValue: ENFORCEMENT_ENABLED_DEFAULT,
 });
 
 export const getEnforcementEnabled = enforcementStorage.get;

--- a/extension/src/lib/options-badge.ts
+++ b/extension/src/lib/options-badge.ts
@@ -1,15 +1,19 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
+import { optionsButtonStorage } from "./options-button-toggle";
+
 const BADGE_SELECTOR = "data-abs";
 const BADGE_VALUE = "open-options";
 
-export function injectOptionsBadge(): void {
-  if (document.querySelector(`[${BADGE_SELECTOR}="${BADGE_VALUE}"]`)) {
+function findBadge(): HTMLElement | null {
+  return document.querySelector(`[${BADGE_SELECTOR}="${BADGE_VALUE}"]`);
+}
+
+function injectBadge(): void {
+  if (findBadge()) {
     return;
   }
-  const host = document.body;
-
   const badge = document.createElement("button");
   badge.type = "button";
   badge.setAttribute(BADGE_SELECTOR, BADGE_VALUE);
@@ -54,5 +58,29 @@ export function injectOptionsBadge(): void {
       });
   });
 
-  host.append(badge);
+  document.body.append(badge);
+}
+
+function removeBadge(): void {
+  findBadge()?.remove();
+}
+
+// Wire the badge to the user's toggle: inject on enable, remove on disable.
+// The initial read is async; the subscription handles every later change.
+// Callers receive an unsubscribe so tests can tear down between cases.
+export function startOptionsBadge(): () => void {
+  void optionsButtonStorage.get().then((enabled) => {
+    if (enabled) {
+      injectBadge();
+    } else {
+      removeBadge();
+    }
+  });
+  return optionsButtonStorage.subscribe((enabled) => {
+    if (enabled) {
+      injectBadge();
+    } else {
+      removeBadge();
+    }
+  });
 }

--- a/extension/src/lib/options-button-toggle.ts
+++ b/extension/src/lib/options-button-toggle.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// User-controlled visibility of the floating on-page button that opens the
+// extension's options page. The button only exists for browser-use agents
+// driving the page via the accessibility tree (which can't click browser
+// chrome) — humans can ignore it or hide it via this setting.
+
+import { createChromeStorageValue } from "./chrome-storage-value";
+
+export const OPTIONS_BUTTON_ENABLED_DEFAULT = true;
+
+export const optionsButtonStorage = createChromeStorageValue<boolean>({
+  key: "agent-browser-shield.options-button-enabled",
+  defaultValue: OPTIONS_BUTTON_ENABLED_DEFAULT,
+});

--- a/extension/src/lib/placeholder-display.ts
+++ b/extension/src/lib/placeholder-display.ts
@@ -10,16 +10,10 @@ export type PlaceholderDisplayMode = "icon" | "button";
 
 export const PLACEHOLDER_DISPLAY_MODE_DEFAULT: PlaceholderDisplayMode = "icon";
 
-function normalize(raw: unknown): PlaceholderDisplayMode {
-  return raw === "button" || raw === "icon"
-    ? raw
-    : PLACEHOLDER_DISPLAY_MODE_DEFAULT;
-}
-
 export const placeholderDisplayStorage =
   createChromeStorageValue<PlaceholderDisplayMode>({
     key: "agent-browser-shield.placeholder-display-mode",
-    normalize,
+    defaultValue: PLACEHOLDER_DISPLAY_MODE_DEFAULT,
   });
 
 export const getPlaceholderDisplayMode = placeholderDisplayStorage.get;

--- a/extension/src/lib/storage.ts
+++ b/extension/src/lib/storage.ts
@@ -33,6 +33,7 @@ function normalize(raw: unknown): RuleStates {
 
 export const ruleStatesStorage = createChromeStorageValue<RuleStates>({
   key: "agent-browser-shield.rules",
+  defaultValue: DEFAULT_STATES,
   normalize,
 });
 

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -261,6 +261,72 @@
         color: #666;
         line-height: 1.3;
       }
+      .switch-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        cursor: pointer;
+        padding: 6px;
+        border-radius: 4px;
+      }
+      .switch-row:hover {
+        background: #f4f4f5;
+      }
+      .switch-row__text {
+        display: inline-flex;
+        flex-direction: column;
+        gap: 1px;
+        flex: 1;
+      }
+      .switch-row__state {
+        font-size: 11px;
+        color: #555;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .switch {
+        position: relative;
+        display: inline-block;
+        width: 32px;
+        height: 18px;
+        flex: none;
+      }
+      .switch input {
+        position: absolute;
+        inset: 0;
+        opacity: 0;
+        margin: 0;
+        cursor: pointer;
+      }
+      .switch__track {
+        position: absolute;
+        inset: 0;
+        background: #d4d4d8;
+        border-radius: 999px;
+        transition: background 120ms ease;
+      }
+      .switch__track::after {
+        content: "";
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 14px;
+        height: 14px;
+        background: #fff;
+        border-radius: 50%;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+        transition: transform 120ms ease;
+      }
+      .switch input:checked + .switch__track {
+        background: #2563eb;
+      }
+      .switch input:checked + .switch__track::after {
+        transform: translateX(14px);
+      }
+      .switch input:focus-visible + .switch__track {
+        outline: 2px solid #2563eb;
+        outline-offset: 2px;
+      }
       .visually-hidden {
         position: absolute;
         width: 1px;

--- a/extension/src/options/Options.tsx
+++ b/extension/src/options/Options.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { apiKeyStorage, HAS_BUILT_IN_OPENAI_KEY } from "../lib/api-key-storage";
 import { availabilitySource } from "../lib/availability";
 import { HelpLinks } from "../lib/HelpLinks";
+import { optionsButtonStorage } from "../lib/options-button-toggle";
 import type { PlaceholderDisplayMode } from "../lib/placeholder-display";
 import { placeholderDisplayStorage } from "../lib/placeholder-display";
 import { RuleList } from "../lib/RuleList";
@@ -19,6 +20,7 @@ export function Options() {
   const availability = useChromeStorageValue(availabilitySource);
   const displayMode = useChromeStorageValue(placeholderDisplayStorage);
   const storedApiKey = useChromeStorageValue(apiKeyStorage);
+  const optionsButtonEnabled = useChromeStorageValue(optionsButtonStorage);
 
   const [draft, setDraft] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -39,7 +41,8 @@ export function Options() {
     !states ||
     !availability ||
     displayMode === null ||
-    apiKeyDraft === null
+    apiKeyDraft === null ||
+    optionsButtonEnabled === null
   ) {
     return <div className="loading">Loading…</div>;
   }
@@ -82,6 +85,7 @@ export function Options() {
         <a href="#apply">Apply configuration</a>
         <a href="#export">Export configuration</a>
         <a href="#display">Placeholder display</a>
+        <a href="#options-button">On-page options button</a>
         <a href="#api-key">OpenAI API key</a>
         <a href="#rules">Rules</a>
         <a href="#disclaimer">Disclaimer</a>
@@ -155,6 +159,34 @@ export function Options() {
             description="Shield icon plus a visible label describing what was hidden. Larger, but visually self-explanatory."
           />
         </fieldset>
+      </Section>
+
+      <Section id="options-button" title="On-page options button">
+        <p className="hint">
+          Floating shield button in the bottom-right of every page. It only
+          exists so browser-use agents driving the page via the accessibility
+          tree — which can't click browser chrome — can open this options page.
+          Turn it off to hide the button on all pages.
+        </p>
+        <label className="switch-row">
+          <span className="switch-row__text">
+            <strong>Show on-page button</strong>
+            <span className="switch-row__state">
+              {optionsButtonEnabled ? "On" : "Off"}
+            </span>
+          </span>
+          <span className="switch" role="presentation">
+            <input
+              type="checkbox"
+              checked={optionsButtonEnabled}
+              onChange={(event) => {
+                void optionsButtonStorage.set(event.target.checked);
+              }}
+              aria-label="Show on-page options button"
+            />
+            <span className="switch__track" />
+          </span>
+        </label>
       </Section>
 
       <Section id="api-key" title="OpenAI API key">

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -174,6 +174,31 @@
         border-radius: 3px;
         vertical-align: middle;
       }
+      .options-button-toggle {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin: 12px 0 0;
+        padding: 8px 10px;
+        border: 1px solid #e4e4e7;
+        border-radius: 6px;
+        background: #fafafa;
+        cursor: pointer;
+      }
+      .options-button-toggle__text {
+        flex: 1;
+        display: inline-flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+      .options-button-toggle__text strong {
+        font-size: 13px;
+      }
+      .options-button-toggle__hint {
+        font-size: 11px;
+        color: #666;
+        line-height: 1.3;
+      }
       .loading {
         padding: 14px;
         color: #888;

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -4,6 +4,7 @@
 import { availabilitySource } from "../lib/availability";
 import { enforcementStorage } from "../lib/enforcement";
 import { HelpLinks } from "../lib/HelpLinks";
+import { optionsButtonStorage } from "../lib/options-button-toggle";
 import { RuleList } from "../lib/RuleList";
 import { ruleStatesStorage } from "../lib/storage";
 import { useChromeStorageValue } from "../lib/use-chrome-storage-value";
@@ -12,8 +13,14 @@ export function Popup() {
   const states = useChromeStorageValue(ruleStatesStorage);
   const enforcementEnabled = useChromeStorageValue(enforcementStorage);
   const availability = useChromeStorageValue(availabilitySource);
+  const optionsButtonEnabled = useChromeStorageValue(optionsButtonStorage);
 
-  if (!states || enforcementEnabled === null || !availability) {
+  if (
+    !states ||
+    enforcementEnabled === null ||
+    !availability ||
+    optionsButtonEnabled === null
+  ) {
     return <div className="loading">Loading…</div>;
   }
 
@@ -58,6 +65,26 @@ export function Popup() {
         availability={availability}
         disabledByEnforcement={!enforcementEnabled}
       />
+      <label className="options-button-toggle">
+        <span className="options-button-toggle__text">
+          <strong>On-page options button</strong>
+          <span className="options-button-toggle__hint">
+            Floating shield button that lets browser-use agents open this
+            options page from the page itself.
+          </span>
+        </span>
+        <span className="switch" role="presentation">
+          <input
+            type="checkbox"
+            checked={optionsButtonEnabled}
+            onChange={(event) => {
+              void optionsButtonStorage.set(event.target.checked);
+            }}
+            aria-label="Show on-page options button"
+          />
+          <span className="switch__track" />
+        </span>
+      </label>
       <HelpLinks className="popup__footer" />
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds a user-controlled toggle (in the popup and on the options page) for the floating on-page shield button. The button exists so browser-use agents driving via the a11y tree can open the options page without clicking browser chrome; humans can now hide it. Default is on (preserves current behavior). The button injects/removes reactively when the toggle is flipped.
- Migrates the storage layer to [`webext-storage`](https://github.com/fregante/webext-storage), matching the convention used in PixieBrix's other extension code. `createChromeStorageValue` becomes a thin adapter over `StorageItem` with a required `defaultValue` and optional `normalize` (only `RuleStates` still needs it — for catalog drift across versions).
- `webext-storage` is published ESM-only and ts-jest emits CJS; a small in-memory CJS stub at `src/__test-mocks__/webext-storage.ts` is routed in via Jest's `moduleNameMapper`. No existing test exercises the real storage path (they mock storage modules wholesale), but the stub keeps `get/set/onChanged` round-tripping for any future test.

## Test plan

- [x] `bun run check` (Biome + ESLint) — clean
- [x] `bun run test` — 479 tests, 28 suites pass
- [x] `bun run build` — succeeds
- [x] `bun run knip` — no new unused exports
- [ ] Load `extension/dist` unpacked: confirm the on-page shield button appears by default, hides immediately when toggled off in popup, reappears when toggled on, and that the toggle on the options page tracks the popup state across tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)