### PR TITLE
Lift rule defaults to data/rule-defaults.json + build-time override flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,13 @@ jobs:
       # Codegen freshness is its own step because preflight regenerates the
       # files internally — the diff has to be captured against pristine git
       # state before preflight runs.
-      - name: Codegen freshness (site data + injection patterns)
+      - name: Codegen freshness (site data + injection patterns + rule defaults)
         run: |
           bun run build-site-data
           bun run build-injection-patterns
-          if ! git diff --exit-code -- src/rules/site-data.generated.ts src/rules/injection-patterns.generated.ts; then
-            echo "::error::Generated files are out of date. Run \`bun run build-site-data && bun run build-injection-patterns\` locally and commit the result."
+          bun run build-rule-defaults
+          if ! git diff --exit-code -- src/rules/site-data.generated.ts src/rules/injection-patterns.generated.ts src/rules/rule-defaults.generated.ts; then
+            echo "::error::Generated files are out of date. Run \`bun run build-site-data && bun run build-injection-patterns && bun run build-rule-defaults\` locally and commit the result."
             exit 1
           fi
       - name: Preflight (lint + typecheck + knip + test)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,22 @@ duplicate a rule between them.
 - `bun run check` runs Biome then ESLint; `bun run check:fix` runs both with
   `--fix`/`--write`.
 
+## Rule defaults
+
+The initial enabled/disabled state for each rule lives in
+`extension/data/rule-defaults.json`, not on the rule modules themselves. The
+codegen in `extension/scripts/build-rule-defaults.ts` validates that every
+registered rule id has a default (and that no unknown ids appear) and emits
+`extension/src/rules/rule-defaults.generated.ts`, which `extension/src/lib/storage.ts`
+imports. Adding a rule without picking a default fails the build; do not edit
+the generated file.
+
+`extension/build.ts` accepts a `--defaults <path>` CLI flag (or
+`EXTENSION_DEFAULTS_FILE` env var) pointing at a JSON file in the same shape
+as the Options-page export. Validated overrides are injected into the bundle
+via `process.env.EXTENSION_DEFAULT_OVERRIDES`. Override only affects fresh
+`chrome.storage`; existing user toggles persist.
+
 ## Site-specific rule data
 
 Selectors and URL recipes for individual sites live in
@@ -114,3 +130,10 @@ When changing the site-rule schema (`SITE_DATA_RULE_IDS` in
 `extension/data/site-rules.schema.ts`) or the Playwright MCP setup
 (`.mcp.json`), update `skills/agent-browser-shield-site-rules/SKILL.md` so its
 rule-type list and workflow stay in sync.
+
+When changing build-time inputs in `extension/build.ts` (CLI flags, env vars,
+`define:` substitutions) — especially anything that affects how operators
+configure a deployed build — update
+`skills/agent-browser-shield-install/SKILL.md` and
+`docs/src/content/docs/install.md` so the build-time customization workflow
+stays accurate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,14 +61,14 @@ The initial enabled/disabled state for each rule lives in
 `extension/data/rule-defaults.json`, not on the rule modules themselves. The
 codegen in `extension/scripts/build-rule-defaults.ts` validates that every
 registered rule id has a default (and that no unknown ids appear) and emits
-`extension/src/rules/rule-defaults.generated.ts`, which `extension/src/lib/storage.ts`
-imports. Adding a rule without picking a default fails the build; do not edit
-the generated file.
+`extension/src/rules/rule-defaults.generated.ts`, which
+`extension/src/lib/storage.ts` imports. Adding a rule without picking a default
+fails the build; do not edit the generated file.
 
 `extension/build.ts` accepts a `--defaults <path>` CLI flag (or
-`EXTENSION_DEFAULTS_FILE` env var) pointing at a JSON file in the same shape
-as the Options-page export. Validated overrides are injected into the bundle
-via `process.env.EXTENSION_DEFAULT_OVERRIDES`. Override only affects fresh
+`EXTENSION_DEFAULTS_FILE` env var) pointing at a JSON file in the same shape as
+the Options-page export. Validated overrides are injected into the bundle via
+`process.env.EXTENSION_DEFAULT_OVERRIDES`. Override only affects fresh
 `chrome.storage`; existing user toggles persist.
 
 ## Site-specific rule data

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ bun install
 bun run build
 ```
 
+### Customize default-enabled rules
+
+Which rules ship on by default is enumerated in
+[`extension/data/rule-defaults.json`](./extension/data/rule-defaults.json). To
+ship a build with a custom set without forking the repo, pass a partial
+override file (same JSON shape as the Options-page export) to `bun run build`:
+
+```sh
+bun run build --defaults ./my-defaults.json
+# or:
+EXTENSION_DEFAULTS_FILE=./my-defaults.json bun run build
+```
+
+Overrides only apply to fresh `chrome.storage`; users with toggled state keep
+their preferences. See
+[the install guide](https://agent-browser-shield.pixiebrix.com/install/#customizing-defaults-at-build-time)
+for details.
+
 ### Watch for changes
 
 `bun run watch` rebuilds `extension/dist/` whenever a file in `extension/src/`

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ bun run build
 
 Which rules ship on by default is enumerated in
 [`extension/data/rule-defaults.json`](./extension/data/rule-defaults.json). To
-ship a build with a custom set without forking the repo, pass a partial
-override file (same JSON shape as the Options-page export) to `bun run build`:
+ship a build with a custom set without forking the repo, pass a partial override
+file (same JSON shape as the Options-page export) to `bun run build`:
 
 ```sh
 bun run build --defaults ./my-defaults.json

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -53,9 +53,9 @@ Which rules ship on by default is enumerated in
 [`extension/data/rule-defaults.json`](https://github.com/pixiebrix/agent-browser-shield/blob/main/extension/data/rule-defaults.json).
 For one-off changes, edit that file and rebuild.
 
-For infrastructure deployments where the same custom set of defaults should
-ship in every build (so an agent doesn't have to flip toggles in the Options
-page on each fresh session), pass a JSON override file to `bun run build`:
+For infrastructure deployments where the same custom set of defaults should ship
+in every build (so an agent doesn't have to flip toggles in the Options page on
+each fresh session), pass a JSON override file to `bun run build`:
 
 ```sh
 cat > my-defaults.json <<'EOF'
@@ -73,13 +73,13 @@ EXTENSION_DEFAULTS_FILE=./my-defaults.json bun run build
 The override file is a flat `{ "<rule-id>": <boolean> }` map — the same shape
 the Options page exports and imports, so a JSON file exported from a tuned
 extension instance can be fed straight into the next build. The file may be
-partial; rules not listed keep the committed default. Unknown rule ids fail
-the build with a message naming them.
+partial; rules not listed keep the committed default. Unknown rule ids fail the
+build with a message naming them.
 
-Build-time overrides only affect **fresh** `chrome.storage` — users who
-already toggled rules in the Options UI keep their preferences. The typical
-target is short-lived browser instances (e.g. browserbase containers) where
-storage starts empty each session.
+Build-time overrides only affect **fresh** `chrome.storage` — users who already
+toggled rules in the Options UI keep their preferences. The typical target is
+short-lived browser instances (e.g. browserbase containers) where storage starts
+empty each session.
 
 See [Rules](/rules/) for the full list of rule ids and what each does.
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -47,6 +47,42 @@ Build output is written to `extension/dist/`.
 
 The extension is now active. Reload any open tabs to pick up the content script.
 
+## Customizing defaults at build time
+
+Which rules ship on by default is enumerated in
+[`extension/data/rule-defaults.json`](https://github.com/pixiebrix/agent-browser-shield/blob/main/extension/data/rule-defaults.json).
+For one-off changes, edit that file and rebuild.
+
+For infrastructure deployments where the same custom set of defaults should
+ship in every build (so an agent doesn't have to flip toggles in the Options
+page on each fresh session), pass a JSON override file to `bun run build`:
+
+```sh
+cat > my-defaults.json <<'EOF'
+{
+  "reviews-hide": false,
+  "ads-hide": false
+}
+EOF
+
+bun run build --defaults ./my-defaults.json
+# or, equivalent:
+EXTENSION_DEFAULTS_FILE=./my-defaults.json bun run build
+```
+
+The override file is a flat `{ "<rule-id>": <boolean> }` map — the same shape
+the Options page exports and imports, so a JSON file exported from a tuned
+extension instance can be fed straight into the next build. The file may be
+partial; rules not listed keep the committed default. Unknown rule ids fail
+the build with a message naming them.
+
+Build-time overrides only affect **fresh** `chrome.storage` — users who
+already toggled rules in the Options UI keep their preferences. The typical
+target is short-lived browser instances (e.g. browserbase containers) where
+storage starts empty each session.
+
+See [Rules](/rules/) for the full list of rule ids and what each does.
+
 ## Iterating
 
 `bun run watch` rebuilds `extension/dist/` whenever a file in `extension/src/`

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -12,8 +12,12 @@ targets (footers, cookie overlays, URL recipes) so they don't fire pointlessly
 in every embedded frame.
 
 The authoritative source for these definitions is
-[`extension/src/rules/`](https://github.com/pixiebrix/agent-browser-shield/tree/main/extension/src/rules).
-If this page disagrees with the source, trust the source.
+[`extension/src/rules/`](https://github.com/pixiebrix/agent-browser-shield/tree/main/extension/src/rules);
+the initial enabled/disabled state for each rule lives in
+[`extension/data/rule-defaults.json`](https://github.com/pixiebrix/agent-browser-shield/blob/main/extension/data/rule-defaults.json).
+If this page disagrees with either, trust the source. The
+[Install page](/install/#customizing-defaults-at-build-time) covers how to
+override defaults at build time without forking the repo.
 
 ## Sensitive data masking
 

--- a/extension/build.ts
+++ b/extension/build.ts
@@ -3,9 +3,11 @@
 
 import { readFileSync } from "node:fs";
 import { cp, mkdir, rm } from "node:fs/promises";
-import { join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { generateInjectionPatterns } from "./scripts/build-injection-patterns";
+import { generateRuleDefaults } from "./scripts/build-rule-defaults";
 import { generateSiteData } from "./scripts/build-site-data";
+import { loadDefaultOverrides } from "./scripts/load-default-overrides";
 
 const ROOT = import.meta.dir;
 const SRC = join(ROOT, "src");
@@ -15,6 +17,26 @@ const DIST = join(ROOT, "dist");
 
 const watch = process.argv.includes("--watch");
 const minify = process.env.NODE_ENV === "production";
+
+// Accept `--defaults <path>` or `--defaults=<path>`. CLI flag wins over the
+// EXTENSION_DEFAULTS_FILE env var if both are set; behaviour mirrors the
+// readEnvValue helper's .env file fallback.
+function parseDefaultsFlag(argv: readonly string[]): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const argument = argv[i];
+    if (argument === "--defaults") {
+      const next = argv[i + 1];
+      if (!next || next.startsWith("--")) {
+        throw new Error("--defaults requires a path argument");
+      }
+      return next;
+    }
+    if (argument?.startsWith("--defaults=")) {
+      return argument.slice("--defaults=".length);
+    }
+  }
+  return undefined;
+}
 
 function readEnvValue(name: string): string {
   if (process.env[name]) {
@@ -55,12 +77,39 @@ function readEnvValue(name: string): string {
 const OPENAI_API_KEY =
   readEnvValue("OPENAI_API_KEY") || readEnvValue("MODEL_API_KEY");
 
+const defaultsFlagPath = parseDefaultsFlag(process.argv);
+const defaultsEnvPath = readEnvValue("EXTENSION_DEFAULTS_FILE");
+const defaultsPath = defaultsFlagPath ?? (defaultsEnvPath || undefined);
+
 async function build(): Promise<void> {
-  // Regenerate src/rules/site-data.generated.ts from data/sites/*.yaml and
-  // src/rules/injection-patterns.generated.ts from data/injection-patterns.yaml.
+  // Regenerate src/rules/site-data.generated.ts from data/sites/*.yaml,
+  // src/rules/injection-patterns.generated.ts from data/injection-patterns.yaml,
+  // and src/rules/rule-defaults.generated.ts from data/rule-defaults.json.
   // Cheap and idempotent; ensures dev never forgets to rerun codegen.
   generateSiteData();
   generateInjectionPatterns();
+  await generateRuleDefaults();
+
+  // Resolve the optional --defaults / EXTENSION_DEFAULTS_FILE override
+  // against the codegen output's RULE_DEFAULTS so the validator knows the
+  // current rule registry. Importing the generated file after codegen above
+  // means the rule id set is always fresh.
+  const { RULE_DEFAULTS } = await import("./src/rules/rule-defaults.generated");
+  const knownRuleIds = Object.keys(RULE_DEFAULTS);
+  const overrides = defaultsPath
+    ? loadDefaultOverrides({
+        path: isAbsolute(defaultsPath)
+          ? defaultsPath
+          : resolve(process.cwd(), defaultsPath),
+        knownRuleIds,
+      })
+    : {};
+  if (defaultsPath) {
+    const changed = Object.keys(overrides).length;
+    console.log(
+      `Applying ${changed} build-time default override(s) from ${defaultsPath}.`,
+    );
+  }
 
   await rm(DIST, { recursive: true, force: true });
   await mkdir(DIST, { recursive: true });
@@ -84,6 +133,9 @@ async function build(): Promise<void> {
       "process.env.OPENAI_API_KEY": JSON.stringify(OPENAI_API_KEY),
       "process.env.HAS_BUILT_IN_OPENAI_KEY": JSON.stringify(
         Boolean(OPENAI_API_KEY),
+      ),
+      "process.env.EXTENSION_DEFAULT_OVERRIDES": JSON.stringify(
+        JSON.stringify(overrides),
       ),
     },
   });

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -1,0 +1,25 @@
+{
+  "defaults": {
+    "pii-mask": true,
+    "secrets-mask": true,
+    "reviews-hide": true,
+    "comments-hide": true,
+    "prompt-injection-hide": true,
+    "countdown-timer-hide": true,
+    "scarcity-hide": true,
+    "footer-hide": true,
+    "checkout-checkbox-clear": true,
+    "cookie-banner-hide": true,
+    "chat-widget-hide": true,
+    "html-comment-strip": true,
+    "hidden-text-strip": true,
+    "newsletter-modal-hide": true,
+    "svg-sprite-suppress": true,
+    "social-embed-hide": true,
+    "ads-hide": true,
+    "cart-addon-flag": true,
+    "search-url-helper": true,
+    "irrelevant-sections-hide": false,
+    "cross-origin-frame-hide": false
+  }
+}

--- a/extension/data/rule-defaults.schema.ts
+++ b/extension/data/rule-defaults.schema.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Schema for extension/data/rule-defaults.json — the single source of truth
+// for which rules ship on by default in the prebuilt extension. The codegen
+// script `scripts/build-rule-defaults.ts` validates the JSON against
+// `RuleDefaultsSchema` and emits `src/rules/rule-defaults.generated.ts`.
+//
+// Completeness (every registered rule id appears, no extras) is enforced by
+// the codegen, not by zod, because it has to read `RULE_IDS` from the rule
+// registry at generate time. This schema just enforces the file shape:
+// `{ "defaults": Record<string, boolean> }` with no other top-level keys, so
+// the file can grow sibling metadata later (e.g. preset names) without
+// breaking older builds.
+
+import { z } from "zod";
+
+export const RuleDefaultsSchema = z
+  .object({
+    defaults: z.record(z.string().min(1), z.boolean()),
+  })
+  .strict();
+
+export type RuleDefaultsFile = z.infer<typeof RuleDefaultsSchema>;

--- a/extension/jest.config.cjs
+++ b/extension/jest.config.cjs
@@ -4,7 +4,10 @@
 /** @type {import("jest").Config} */
 module.exports = {
   testEnvironment: "jsdom",
-  testMatch: ["<rootDir>/src/**/__tests__/**/*.test.ts"],
+  testMatch: [
+    "<rootDir>/src/**/__tests__/**/*.test.ts",
+    "<rootDir>/scripts/**/__tests__/**/*.test.ts",
+  ],
   transform: {
     "^.+\\.tsx?$": [
       "ts-jest",

--- a/extension/knip.json
+++ b/extension/knip.json
@@ -9,8 +9,6 @@
     "eslint-rules/index.js"
   ],
   "project": ["src/**/*.{ts,tsx}", "scripts/**/*.ts", "eslint-rules/**/*.js"],
-  "ignore": ["src/**/*.generated.ts"],
   "ignoreExportsUsedInFile": true,
-  "ignoreBinaries": ["uv"],
-  "ignoreDependencies": ["jsdom", "@types/jsdom"]
+  "ignoreBinaries": ["uv"]
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -26,6 +26,7 @@
     "fetch-easylist": "uv run --directory .. scripts/fetch_easylist.py",
     "build-site-data": "bun run scripts/build-site-data.ts",
     "build-injection-patterns": "bun run scripts/build-injection-patterns.ts",
+    "build-rule-defaults": "bun run scripts/build-rule-defaults.ts",
     "build-icons": "bun run scripts/build-icons.ts",
     "clean": "rm -rf dist",
     "test": "jest",
@@ -37,7 +38,7 @@
     "lint:eslint:fix": "eslint . --fix",
     "knip": "knip",
     "typecheck": "tsc --noEmit",
-    "preflight": "bun run build-site-data && bun run build-injection-patterns && bun run check && bun run typecheck && bun run knip && bun run test"
+    "preflight": "bun run build-site-data && bun run build-injection-patterns && bun run build-rule-defaults && bun run check && bun run typecheck && bun run knip && bun run test"
   },
   "dependencies": {
     "abort-utils": "^3.0.0",

--- a/extension/scripts/__tests__/load-default-overrides.test.ts
+++ b/extension/scripts/__tests__/load-default-overrides.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadDefaultOverrides } from "../load-default-overrides";
+
+const KNOWN_IDS = ["pii-mask", "reviews-hide", "ads-hide"] as const;
+
+describe("loadDefaultOverrides", () => {
+  let temporary: string;
+
+  beforeEach(() => {
+    temporary = mkdtempSync(join(tmpdir(), "abs-defaults-"));
+  });
+
+  afterEach(() => {
+    rmSync(temporary, { recursive: true, force: true });
+  });
+
+  function writeFile(name: string, body: string): string {
+    const file = join(temporary, name);
+    writeFileSync(file, body);
+    return file;
+  }
+
+  it("returns a partial map for a valid file", () => {
+    const file = writeFile(
+      "ok.json",
+      JSON.stringify({ "pii-mask": true, "reviews-hide": false }),
+    );
+    expect(
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toEqual({ "pii-mask": true, "reviews-hide": false });
+  });
+
+  it("accepts an empty object", () => {
+    const file = writeFile("empty.json", "{}");
+    expect(
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toEqual({});
+  });
+
+  it("throws when the file does not exist", () => {
+    expect(() =>
+      loadDefaultOverrides({
+        path: join(temporary, "does-not-exist.json"),
+        knownRuleIds: KNOWN_IDS,
+      }),
+    ).toThrow(/could not be read/);
+  });
+
+  it("throws on invalid JSON", () => {
+    const file = writeFile("bad.json", "{ not json");
+    expect(() =>
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toThrow(/is not valid JSON/);
+  });
+
+  it("throws when the root is not an object", () => {
+    const file = writeFile("array.json", "[]");
+    expect(() =>
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toThrow(/must be a JSON object/);
+  });
+
+  it("rejects unknown rule ids", () => {
+    const file = writeFile(
+      "unknown.json",
+      JSON.stringify({ "pii-mask": true, "bogus-rule": false }),
+    );
+    expect(() =>
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toThrow(/unknown rule ids: bogus-rule/);
+  });
+
+  it("rejects non-boolean values", () => {
+    const file = writeFile(
+      "nonbool.json",
+      JSON.stringify({ "pii-mask": "yes" }),
+    );
+    expect(() =>
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toThrow(/non-boolean values for: pii-mask/);
+  });
+
+  it("reports unknown ids and non-boolean values together", () => {
+    const file = writeFile(
+      "mixed.json",
+      JSON.stringify({ "bogus-rule": true, "pii-mask": 1 }),
+    );
+    expect(() =>
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toThrow(/unknown rule ids: bogus-rule.*non-boolean values for: pii-mask/);
+  });
+});

--- a/extension/scripts/build-rule-defaults.ts
+++ b/extension/scripts/build-rule-defaults.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Compiles extension/data/rule-defaults.json into a TypeScript module
+// consumed by `src/lib/storage.ts`. Same pattern as build-site-data.ts and
+// build-injection-patterns.ts — generated output is committed and bundled
+// statically, the runtime never reads JSON at startup.
+//
+// The JSON is the single source of truth for which rules ship on by default
+// in the prebuilt extension. To audit defaults, scan one file; to change
+// them, edit that file and rerun `bun run build-rule-defaults`.
+//
+// Codegen enforces completeness: every id in `RULE_IDS` must appear in the
+// JSON, and the JSON must not mention any unknown id. Mismatch fails the
+// build with a message listing offenders — adding a new rule without
+// picking a default is a build error, not a silent fallback.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { JSDOM } from "jsdom";
+import { RuleDefaultsSchema } from "../data/rule-defaults.schema";
+
+const ROOT = join(import.meta.dir, "..");
+const INPUT = join(ROOT, "data", "rule-defaults.json");
+const OUTPUT = join(ROOT, "src", "rules", "rule-defaults.generated.ts");
+
+// A handful of rule modules touch DOM constructors at top level (e.g.
+// `HTMLInputElement.prototype` in checkout-checkbox-clear.ts) to capture
+// native setters before any framework can override them. Importing
+// `../src/rules` from this Node-context script therefore needs DOM globals
+// in scope. Jest already runs tests under jsdom; we reuse the same window
+// here so the codegen sees the same surface as `__tests__/catalog.test.ts`.
+function ensureDomGlobals(): void {
+  if ((globalThis as { HTMLElement?: unknown }).HTMLElement !== undefined) {
+    return;
+  }
+  const { window } = new JSDOM("");
+  for (const name of [
+    "HTMLElement",
+    "HTMLInputElement",
+    "HTMLAnchorElement",
+    "Element",
+    "Node",
+    "document",
+    "window",
+    "navigator",
+  ] as const) {
+    if ((globalThis as Record<string, unknown>)[name] === undefined) {
+      (globalThis as Record<string, unknown>)[name] = (
+        window as unknown as Record<string, unknown>
+      )[name];
+    }
+  }
+}
+
+function buildOutput(
+  defaults: Record<string, boolean>,
+  ruleIds: readonly string[],
+): string {
+  const lines: string[] = [
+    "// AUTO-GENERATED — do not edit by hand.",
+    "// Source: extension/data/rule-defaults.json",
+    "// Regenerate with `bun run build-rule-defaults`.",
+    "",
+    'import type { RuleId } from "./index";',
+    "",
+    "export const RULE_DEFAULTS: Readonly<Record<RuleId, boolean>> = {",
+  ];
+  // Emit in RULE_IDS order so the generated file's diff stays stable as the
+  // registry evolves, regardless of how the JSON happens to be ordered.
+  for (const id of ruleIds) {
+    lines.push(`  ${JSON.stringify(id)}: ${defaults[id]},`);
+  }
+  lines.push("};", "");
+  return lines.join("\n");
+}
+
+export async function generateRuleDefaults(): Promise<void> {
+  ensureDomGlobals();
+  // Dynamic import after stubbing so the rule registry's transitive DOM
+  // touches resolve against the jsdom globals above.
+  const { RULE_IDS } = (await import("../src/rules")) as {
+    RULE_IDS: readonly string[];
+  };
+
+  const raw = readFileSync(INPUT, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `${relative(ROOT, INPUT)}: JSON parse error — ${(error as Error).message}`,
+      { cause: error },
+    );
+  }
+  const result = RuleDefaultsSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "(root)"} — ${issue.message}`)
+      .join("\n  - ");
+    throw new Error(
+      `${relative(ROOT, INPUT)}: schema validation failed:\n  - ${issues}`,
+    );
+  }
+
+  const declared = result.data.defaults;
+  const declaredKeys = new Set(Object.keys(declared));
+  const known = new Set<string>(RULE_IDS);
+
+  const missing = RULE_IDS.filter((id) => !declaredKeys.has(id));
+  const unknown = [...declaredKeys].filter((id) => !known.has(id));
+  if (missing.length > 0 || unknown.length > 0) {
+    const parts: string[] = [];
+    if (missing.length > 0) {
+      parts.push(`missing defaults for: ${missing.join(", ")}`);
+    }
+    if (unknown.length > 0) {
+      parts.push(`unknown rule ids: ${unknown.join(", ")}`);
+    }
+    throw new Error(
+      `${relative(ROOT, INPUT)}: defaults out of sync with rule registry — ${parts.join("; ")}`,
+    );
+  }
+
+  writeFileSync(OUTPUT, buildOutput(declared, RULE_IDS));
+  console.log(
+    `Generated ${relative(ROOT, OUTPUT)} from ${RULE_IDS.length} rules.`,
+  );
+}
+
+if (import.meta.main) {
+  await generateRuleDefaults();
+}

--- a/extension/scripts/load-default-overrides.ts
+++ b/extension/scripts/load-default-overrides.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Loads and validates a build-time rule-defaults override file. Consumed by
+// build.ts when the operator passes `--defaults <path>` or
+// `EXTENSION_DEFAULTS_FILE=<path>`. The file shape matches the JSON the
+// in-extension Options page exports/imports — flat
+// `{ "<rule-id>": <boolean>, ... }` — so the same file works in both
+// places.
+//
+// Validation is strict: unknown rule ids and non-boolean values fail the
+// build. Infra operators want loud failures, not silent drift if a rule was
+// renamed.
+
+import { readFileSync } from "node:fs";
+
+export interface LoadOverridesOptions {
+  path: string;
+  knownRuleIds: readonly string[];
+}
+
+export function loadDefaultOverrides(
+  options: LoadOverridesOptions,
+): Record<string, boolean> {
+  const { path, knownRuleIds } = options;
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Defaults file ${path} could not be read: ${message}`, {
+      cause: error,
+    });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Defaults file ${path} is not valid JSON: ${message}`, {
+      cause: error,
+    });
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `Defaults file ${path} must be a JSON object mapping rule ids to booleans.`,
+    );
+  }
+
+  const known = new Set<string>(knownRuleIds);
+  const unknownIds: string[] = [];
+  const nonBooleanIds: string[] = [];
+  const result: Record<string, boolean> = {};
+
+  for (const [key, value] of Object.entries(
+    parsed as Record<string, unknown>,
+  )) {
+    if (!known.has(key)) {
+      unknownIds.push(key);
+      continue;
+    }
+    if (typeof value !== "boolean") {
+      nonBooleanIds.push(key);
+      continue;
+    }
+    result[key] = value;
+  }
+
+  const issues: string[] = [];
+  if (unknownIds.length > 0) {
+    issues.push(`unknown rule ids: ${unknownIds.join(", ")}`);
+  }
+  if (nonBooleanIds.length > 0) {
+    issues.push(`non-boolean values for: ${nonBooleanIds.join(", ")}`);
+  }
+  if (issues.length > 0) {
+    throw new Error(
+      `Defaults file ${path} failed validation — ${issues.join("; ")}`,
+    );
+  }
+
+  return result;
+}

--- a/extension/src/globals.d.ts
+++ b/extension/src/globals.d.ts
@@ -7,5 +7,8 @@ declare namespace NodeJS {
   interface ProcessEnv {
     OPENAI_API_KEY: string;
     HAS_BUILT_IN_OPENAI_KEY: string;
+    // JSON-stringified Partial<Record<RuleId, boolean>>. Empty `"{}"` when no
+    // build-time defaults override file is supplied.
+    EXTENSION_DEFAULT_OVERRIDES: string;
   }
 }

--- a/extension/src/lib/__tests__/rule-engine.test.ts
+++ b/extension/src/lib/__tests__/rule-engine.test.ts
@@ -12,7 +12,6 @@ const buildRule = (id: string, overrides: Partial<Rule> = {}): Rule => ({
   id,
   label: id,
   description: id,
-  defaultEnabled: true,
   apply: jest.fn(),
   teardown: jest.fn(),
   ...overrides,

--- a/extension/src/lib/__tests__/storage.test.ts
+++ b/extension/src/lib/__tests__/storage.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Exercises how `lib/storage.ts` composes its `DEFAULT_STATES` from the
+// committed `RULE_DEFAULTS` and the build-time
+// `process.env.EXTENSION_DEFAULT_OVERRIDES` injection. The override is
+// parsed at module load, so each case sets the env var and then reloads
+// the module via `jest.isolateModules`. The webext-storage stub
+// (jest.config.cjs `moduleNameMapper`) is also re-instantiated inside the
+// isolate, so its in-memory map starts empty — `getRuleStates()` returns
+// the freshly-derived defaults instead of any stale stored value from a
+// previous case.
+
+// Storage transitively pulls in the full rule catalog, which imports
+// `nanoid` and `abort-utils`. Both are pure-ESM; ts-jest with
+// `useESM: false` (jest.config.cjs) can't transform them. The catalog
+// invariants test mocks the same modules for the same reason.
+jest.mock("nanoid", () => ({ nanoid: () => "test-ref" }));
+jest.mock("abort-utils", () => ({
+  ReusableAbortController: class {
+    abort(): void {
+      // noop
+    }
+    get signal(): AbortSignal {
+      return new AbortController().signal;
+    }
+  },
+  onAbort: (): (() => void) => () => {
+    // noop
+  },
+}));
+
+import { RULE_DEFAULTS } from "../../rules/rule-defaults.generated";
+import type { getRuleStates as GetRuleStates } from "../storage";
+
+interface StorageModule {
+  getRuleStates: typeof GetRuleStates;
+}
+
+async function loadStorage(): Promise<StorageModule> {
+  let module!: StorageModule;
+  await jest.isolateModulesAsync(async () => {
+    module = await import("../storage");
+  });
+  return module;
+}
+
+describe("storage default states", () => {
+  // `ProcessEnv.EXTENSION_DEFAULT_OVERRIDES` is declared as `string` in
+  // globals.d.ts (Bun substitutes a literal at build time, so the runtime
+  // value is never undefined in the shipped bundle). In tests the env var
+  // genuinely might be unset, so widen the type for the save/restore dance.
+  const original = (process.env as Record<string, string | undefined>)
+    .EXTENSION_DEFAULT_OVERRIDES;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete (process.env as Record<string, unknown>)
+        .EXTENSION_DEFAULT_OVERRIDES;
+    } else {
+      process.env.EXTENSION_DEFAULT_OVERRIDES = original;
+    }
+  });
+
+  it("uses RULE_DEFAULTS when no override is set", async () => {
+    delete process.env.EXTENSION_DEFAULT_OVERRIDES;
+    const { getRuleStates } = await loadStorage();
+    const states = await getRuleStates();
+    expect(states).toEqual(RULE_DEFAULTS);
+  });
+
+  it("uses RULE_DEFAULTS when override is an empty object", async () => {
+    process.env.EXTENSION_DEFAULT_OVERRIDES = "{}";
+    const { getRuleStates } = await loadStorage();
+    const states = await getRuleStates();
+    expect(states).toEqual(RULE_DEFAULTS);
+  });
+
+  it("flips only the rules listed in a partial override", async () => {
+    // Pick one rule that defaults true and one that defaults false so the
+    // test exercises both directions regardless of which way the committed
+    // defaults happen to lean.
+    const trueRule = Object.entries(RULE_DEFAULTS).find(
+      ([, value]) => value,
+    )?.[0];
+    const falseRule = Object.entries(RULE_DEFAULTS).find(
+      ([, value]) => !value,
+    )?.[0];
+    if (trueRule === undefined || falseRule === undefined) {
+      throw new Error(
+        "Expected RULE_DEFAULTS to include at least one true and one false default for this test.",
+      );
+    }
+    process.env.EXTENSION_DEFAULT_OVERRIDES = JSON.stringify({
+      [trueRule]: false,
+      [falseRule]: true,
+    });
+    const { getRuleStates } = await loadStorage();
+    const states = await getRuleStates();
+    expect(states[trueRule]).toBe(false);
+    expect(states[falseRule]).toBe(true);
+    // Untouched rules keep their committed defaults.
+    for (const [id, value] of Object.entries(RULE_DEFAULTS)) {
+      if (id === trueRule || id === falseRule) {
+        continue;
+      }
+      expect(states[id]).toBe(value);
+    }
+  });
+
+  it("falls back to RULE_DEFAULTS when the override env var is malformed JSON", async () => {
+    process.env.EXTENSION_DEFAULT_OVERRIDES = "{ not json";
+    const { getRuleStates } = await loadStorage();
+    const states = await getRuleStates();
+    expect(states).toEqual(RULE_DEFAULTS);
+  });
+
+  it("ignores non-boolean override values without throwing", async () => {
+    const someRule = Object.keys(RULE_DEFAULTS)[0] as string;
+    process.env.EXTENSION_DEFAULT_OVERRIDES = JSON.stringify({
+      [someRule]: "yes",
+    });
+    const { getRuleStates } = await loadStorage();
+    const states = await getRuleStates();
+    expect(states).toEqual(RULE_DEFAULTS);
+  });
+
+  it("ignores unknown rule ids in the override env var", async () => {
+    process.env.EXTENSION_DEFAULT_OVERRIDES = JSON.stringify({
+      "rule-that-does-not-exist": true,
+    });
+    const { getRuleStates } = await loadStorage();
+    const states = await getRuleStates();
+    expect(states).toEqual(RULE_DEFAULTS);
+  });
+});

--- a/extension/src/lib/selector-hide-rule.ts
+++ b/extension/src/lib/selector-hide-rule.ts
@@ -33,7 +33,6 @@ interface SelectorHideRuleOptions {
   id: RuleId;
   label: string;
   description: string;
-  defaultEnabled: boolean;
   // Text shown on the placeholder's reveal button. Required unless
   // `removeEntirely` is true.
   hideLabel?: string;
@@ -70,7 +69,6 @@ export function createSelectorHideRule(
     id,
     label,
     description,
-    defaultEnabled,
     hideLabel,
     alwaysOnSelectors,
     siteRules = [],
@@ -178,14 +176,13 @@ export function createSelectorHideRule(
         id,
         label,
         description,
-        defaultEnabled,
         topFrameOnly,
         apply,
         teardown: () => {
           watcher.stop();
         },
       }
-    : { id, label, description, defaultEnabled, topFrameOnly, apply };
+    : { id, label, description, topFrameOnly, apply };
 
   return { rule, selectorsFor };
 }

--- a/extension/src/lib/storage.ts
+++ b/extension/src/lib/storage.ts
@@ -2,21 +2,55 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import type { RuleId } from "../rules";
-import { RULE_IDS, RULES } from "../rules";
+import { RULE_IDS } from "../rules";
+import { RULE_DEFAULTS } from "../rules/rule-defaults.generated";
 import { createChromeStorageValue } from "./chrome-storage-value";
 
 export type RuleStates = Record<RuleId, boolean>;
 
-// Defaults derived once at module load — each rule carries its own
-// `defaultEnabled` flag. Availability is resolved separately via
-// `lib/availability.ts` (which supports reactive accessors), and the rule
-// engine gates application on it at apply time. We deliberately don't mask
-// unavailable rules' stored state here: if availability is reactive (e.g.
-// gated on a user-supplied API key) we want the user's toggle preference
-// preserved so it takes effect the moment the rule becomes available.
+// Defaults come from extension/data/rule-defaults.json via codegen — one
+// scannable file lists every rule's initial state. Availability is resolved
+// separately via `lib/availability.ts` (which supports reactive accessors),
+// and the rule engine gates application on it at apply time. We deliberately
+// don't mask unavailable rules' stored state here: if availability is
+// reactive (e.g. gated on a user-supplied API key) we want the user's toggle
+// preference preserved so it takes effect the moment the rule becomes
+// available.
+//
+// `EXTENSION_DEFAULT_OVERRIDES` is injected by build.ts when the operator
+// passes --defaults or EXTENSION_DEFAULTS_FILE; it layers on top of the
+// committed defaults so infra teams can ship a build with their own initial
+// state without their agent flipping toggles via the Options UI. Only
+// affects fresh chrome.storage — existing users keep their toggles.
+function parseOverrides(): Partial<RuleStates> {
+  const raw = process.env.EXTENSION_DEFAULT_OVERRIDES;
+  if (!raw) {
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {};
+  }
+  const result: Partial<RuleStates> = {};
+  for (const id of RULE_IDS) {
+    const value = (parsed as Record<string, unknown>)[id];
+    if (typeof value === "boolean") {
+      result[id] = value;
+    }
+  }
+  return result;
+}
+
+const OVERRIDES: Partial<RuleStates> = parseOverrides();
+
 const DEFAULT_STATES: RuleStates = Object.fromEntries(
-  RULES.map((rule) => [rule.id, rule.defaultEnabled]),
-);
+  RULE_IDS.map((id) => [id, OVERRIDES[id] ?? RULE_DEFAULTS[id]]),
+) as RuleStates;
 
 function normalize(raw: unknown): RuleStates {
   const result: RuleStates = { ...DEFAULT_STATES };

--- a/extension/src/options/__tests__/parse-config.test.ts
+++ b/extension/src/options/__tests__/parse-config.test.ts
@@ -5,10 +5,7 @@
 // (irrelevant-sections-hide → automation-element-reference → nanoid, whose ESM
 // build trips ts-jest's CJS transform).
 jest.mock("../../rules", () => ({
-  RULES: [
-    { id: "rule-a", defaultEnabled: true },
-    { id: "rule-b", defaultEnabled: true },
-  ],
+  RULES: [{ id: "rule-a" }, { id: "rule-b" }],
   RULE_IDS: ["rule-a", "rule-b"],
 }));
 

--- a/extension/src/rules/__tests__/catalog.test.ts
+++ b/extension/src/rules/__tests__/catalog.test.ts
@@ -25,6 +25,7 @@ jest.mock("abort-utils", () => ({
 }));
 
 import { RULE_IDS, RULES } from "..";
+import { RULE_DEFAULTS } from "../rule-defaults.generated";
 
 describe("rule catalog invariants", () => {
   it("ships at least one rule", () => {
@@ -50,8 +51,23 @@ describe("rule catalog invariants", () => {
     expect(rule.label.length).toBeGreaterThan(0);
     expect(typeof rule.description).toBe("string");
     expect(rule.description.length).toBeGreaterThan(0);
-    expect(typeof rule.defaultEnabled).toBe("boolean");
     expect(typeof rule.apply).toBe("function");
+  });
+
+  // Defaults live in extension/data/rule-defaults.json and flow through
+  // codegen into RULE_DEFAULTS. Codegen rejects mismatches at build time;
+  // this test is a belt-and-suspenders so adding a rule without picking a
+  // default fails fast in `bun run test` too.
+  it("declares a default for every rule and no extras", () => {
+    const defaultsKeys = Object.keys(RULE_DEFAULTS).toSorted();
+    expect(defaultsKeys).toEqual([...RULE_IDS].toSorted());
+  });
+
+  it("every default is a boolean", () => {
+    const offenders = Object.entries(RULE_DEFAULTS).filter(
+      ([, value]) => typeof value !== "boolean",
+    );
+    expect(offenders).toEqual([]);
   });
 
   // `available: false` rules turn into a disabled toggle in the UI and need a

--- a/extension/src/rules/ads-hide.ts
+++ b/extension/src/rules/ads-hide.ts
@@ -69,7 +69,6 @@ const { rule: baseRule } = createSelectorHideRule({
   label: "Hide Ads & Sponsored Results",
   description:
     "Remove display ads and paid/sponsored search results. Uses EasyList for broad coverage.",
-  defaultEnabled: true,
   removeEntirely: true,
   alwaysOnSelectors: [
     // Google AdSense

--- a/extension/src/rules/cart-addon-flag.ts
+++ b/extension/src/rules/cart-addon-flag.ts
@@ -209,7 +209,6 @@ export const cartAddonFlagRule = {
   label: "Flag Cart Add-Ons (Sneak-Into-Basket)",
   description:
     "On checkout pages, flag likely sneak-into-basket line items (protection plans, warranties, insurance, donations, gift wrap, etc.) with a visible annotation. Items are not removed.",
-  defaultEnabled: true,
   apply,
   teardown: () => {
     watcher.stop();

--- a/extension/src/rules/chat-widget-hide.ts
+++ b/extension/src/rules/chat-widget-hide.ts
@@ -17,7 +17,6 @@ const { rule } = createSelectorHideRule({
   id: "chat-widget-hide",
   label: "Remove Chat Widgets",
   description: "Remove live-chat widgets (Intercom, Drift, Zendesk, etc.).",
-  defaultEnabled: true,
   removeEntirely: true,
   alwaysOnSelectors: [
     // Intercom

--- a/extension/src/rules/checkout-checkbox-clear.ts
+++ b/extension/src/rules/checkout-checkbox-clear.ts
@@ -90,7 +90,6 @@ export const checkoutCheckboxClearRule = {
   label: "Clear Checkout Checkboxes",
   description:
     "On checkout pages, uncheck pre-checked checkboxes so the agent doesn't silently inherit add-ons or marketing opt-ins.",
-  defaultEnabled: true,
   apply,
   teardown: () => {
     watcher.stop();

--- a/extension/src/rules/comments-hide.ts
+++ b/extension/src/rules/comments-hide.ts
@@ -16,7 +16,6 @@ const { rule, selectorsFor } = createSelectorHideRule({
   label: "Hide Comments",
   description:
     "Hide user-generated comment threads (Disqus, Facebook, Reddit, YouTube, Hacker News).",
-  defaultEnabled: true,
   hideLabel: "[comment section hidden — click to reveal]",
   // Selectors that ship on many sites (Disqus, Livefyre, Facebook comment
   // plugin embeds, generic WordPress/blog comment markup). Derived from

--- a/extension/src/rules/cookie-banner-hide.ts
+++ b/extension/src/rules/cookie-banner-hide.ts
@@ -29,7 +29,6 @@ const { rule } = createSelectorHideRule({
   id: "cookie-banner-hide",
   label: "Remove Cookie Banners",
   description: "Remove GDPR/CCPA cookie consent banners.",
-  defaultEnabled: true,
   removeEntirely: true,
   alwaysOnSelectors: [
     // OneTrust

--- a/extension/src/rules/countdown-timer-hide.ts
+++ b/extension/src/rules/countdown-timer-hide.ts
@@ -190,7 +190,6 @@ export const countdownTimerHideRule = {
   label: "Hide Countdown Timers",
   description:
     "Hide running countdown timers (artificial-urgency dark pattern).",
-  defaultEnabled: true,
   apply,
   teardown,
 } satisfies Rule;

--- a/extension/src/rules/cross-origin-frame-hide.ts
+++ b/extension/src/rules/cross-origin-frame-hide.ts
@@ -100,7 +100,6 @@ export const crossOriginFrameHideRule = {
   label: "Hide Cross-Origin Frames (Experimental)",
   description:
     "Remove cross-origin iframes from the page and replace them with a click-to-reveal placeholder, so browser-use agents don't ingest embedded-origin content unless the user opts in.",
-  defaultEnabled: false,
   apply,
   teardown,
 } satisfies Rule;

--- a/extension/src/rules/footer-hide.ts
+++ b/extension/src/rules/footer-hide.ts
@@ -30,7 +30,6 @@ const { rule, selectorsFor } = createSelectorHideRule({
   label: "Hide Page Footer",
   description:
     "Hide the page footer (legal links, sitemap, social) to save tokens.",
-  defaultEnabled: true,
   hideLabel: "[footer hidden — click to reveal]",
   alwaysOnSelectors: [
     "footer",

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -320,7 +320,6 @@ export const hiddenTextStripRule = {
   label: "Strip Hidden Text",
   description:
     'Remove text invisible to humans but readable by agents. Defends against "unseeable" prompt injection; screen-reader-only text is preserved.',
-  defaultEnabled: true,
   apply,
   teardown: () => {
     watcher.stop();

--- a/extension/src/rules/html-comment-strip.ts
+++ b/extension/src/rules/html-comment-strip.ts
@@ -60,7 +60,6 @@ export const htmlCommentStripRule = {
   label: "Strip HTML Comments",
   description:
     "Remove HTML comments. Invisible to humans but readable by agents and can carry prompt-injection payloads.",
-  defaultEnabled: true,
   apply,
   teardown: () => {
     watcher.stop();

--- a/extension/src/rules/irrelevant-sections-hide.ts
+++ b/extension/src/rules/irrelevant-sections-hide.ts
@@ -331,7 +331,6 @@ export const irrelevantSectionsHideRule = {
   label: "Hide Irrelevant Sections (AI)",
   description:
     "Use a small LLM to identify engagement rails (related products, recommended articles, trending now) and replace them with click-to-reveal placeholders.",
-  defaultEnabled: false,
   available: createApiKeyAvailability(
     "Set an OpenAI API key on the options page to enable this rule.",
   ),

--- a/extension/src/rules/newsletter-modal-hide.ts
+++ b/extension/src/rules/newsletter-modal-hide.ts
@@ -61,7 +61,6 @@ const { rule } = createSelectorHideRule({
   label: "Remove Newsletter Modals",
   description:
     "Remove interstitial newsletter signup modals. Login modals and paywalls stay visible.",
-  defaultEnabled: true,
   removeEntirely: true,
   alwaysOnSelectors: [
     // Sumo

--- a/extension/src/rules/pii-mask.ts
+++ b/extension/src/rules/pii-mask.ts
@@ -88,6 +88,5 @@ export const piiMaskRule = {
   id: RULE_ID,
   label: "Mask PII",
   description: "Hide credit card numbers, phone numbers, and SSNs.",
-  defaultEnabled: true,
   apply,
 } satisfies Rule;

--- a/extension/src/rules/prompt-injection-hide.ts
+++ b/extension/src/rules/prompt-injection-hide.ts
@@ -84,6 +84,5 @@ export const promptInjectionHideRule = {
   label: "Hide Prompt Injection",
   description:
     "Hide page sections containing phrases common in prompt-injection attacks.",
-  defaultEnabled: true,
   apply,
 } satisfies Rule;

--- a/extension/src/rules/reviews-hide.ts
+++ b/extension/src/rules/reviews-hide.ts
@@ -16,7 +16,6 @@ const { rule, selectorsFor } = createSelectorHideRule({
   label: "Hide Reviews",
   description:
     "Hide user-generated review text. Aggregate star ratings stay visible.",
-  defaultEnabled: true,
   hideLabel: "[review section hidden — click to reveal]",
   // schema.org/Review marks UGC. schema.org/AggregateRating is the summary
   // node (count + average) and is left visible — sites like Costco render the

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -1,0 +1,29 @@
+// AUTO-GENERATED — do not edit by hand.
+// Source: extension/data/rule-defaults.json
+// Regenerate with `bun run build-rule-defaults`.
+
+import type { RuleId } from "./index";
+
+export const RULE_DEFAULTS: Readonly<Record<RuleId, boolean>> = {
+  "pii-mask": true,
+  "secrets-mask": true,
+  "reviews-hide": true,
+  "comments-hide": true,
+  "prompt-injection-hide": true,
+  "countdown-timer-hide": true,
+  "scarcity-hide": true,
+  "footer-hide": true,
+  "checkout-checkbox-clear": true,
+  "cookie-banner-hide": true,
+  "chat-widget-hide": true,
+  "html-comment-strip": true,
+  "hidden-text-strip": true,
+  "newsletter-modal-hide": true,
+  "svg-sprite-suppress": true,
+  "social-embed-hide": true,
+  "ads-hide": true,
+  "cart-addon-flag": true,
+  "search-url-helper": true,
+  "irrelevant-sections-hide": false,
+  "cross-origin-frame-hide": false,
+};

--- a/extension/src/rules/scarcity-hide.ts
+++ b/extension/src/rules/scarcity-hide.ts
@@ -114,7 +114,6 @@ export const scarcityHideRule = {
   label: "Hide Scarcity Warnings",
   description:
     'Hide scarcity messages like "Only 3 left" or "12 viewing now". Out-of-stock indicators and bestseller badges stay visible.',
-  defaultEnabled: true,
   apply,
   teardown: () => {
     watcher.stop();

--- a/extension/src/rules/search-url-helper.ts
+++ b/extension/src/rules/search-url-helper.ts
@@ -80,7 +80,6 @@ export const searchUrlHelperRule = {
   label: "Embed Search URL Recipes",
   description:
     "On covered hosts, embed a screen-reader-only landmark describing how to run searches and filters by URL, so agents can navigate by URL instead of clicking through search UI.",
-  defaultEnabled: true,
   // Recipes are URL navigation hints for the page the agent is viewing —
   // the top-level URL — not for whatever third-party content happens to be
   // iframed in. Injecting a landmark into every same-origin iframe would

--- a/extension/src/rules/secrets-mask.ts
+++ b/extension/src/rules/secrets-mask.ts
@@ -160,6 +160,5 @@ export const secretsMaskRule = {
   label: "Mask Secrets",
   description:
     "Hide API keys, tokens, JWTs, private keys, and other high-entropy credentials.",
-  defaultEnabled: true,
   apply,
 } satisfies Rule;

--- a/extension/src/rules/social-embed-hide.ts
+++ b/extension/src/rules/social-embed-hide.ts
@@ -24,7 +24,6 @@ const { rule } = createSelectorHideRule({
   label: "Hide Social Embeds",
   description:
     "Hide embedded social-media widgets (Twitter/X, YouTube, Facebook, Instagram, TikTok, etc.). Replaced with a placeholder.",
-  defaultEnabled: true,
   hideLabel: "[social embed hidden — click to reveal]",
   alwaysOnSelectors: [
     // Twitter / X

--- a/extension/src/rules/svg-sprite-suppress.ts
+++ b/extension/src/rules/svg-sprite-suppress.ts
@@ -120,7 +120,6 @@ export const svgSpriteSuppressRule = {
   label: "Remove Unused SVG Sprites",
   description:
     "Remove hidden SVG sprite containers whose symbols aren't referenced on the page.",
-  defaultEnabled: true,
   apply,
   teardown: () => {
     watcher.stop();

--- a/extension/src/rules/types.ts
+++ b/extension/src/rules/types.ts
@@ -22,9 +22,6 @@ export interface Rule {
   id: string;
   label: string;
   description: string;
-  // Initial state on a fresh install. Overridden by anything the user has
-  // toggled in the popup/options page.
-  defaultEnabled: boolean;
   // - omitted / `true` — always available
   // - `false` — statically unavailable (e.g. backing capability turned off at
   //   build time); pair with `unavailableReason` for the UI

--- a/skills/agent-browser-shield-config/SKILL.md
+++ b/skills/agent-browser-shield-config/SKILL.md
@@ -35,9 +35,15 @@ Paste an object mapping rule IDs to booleans, then click *Apply*:
 ```
 
 **Apply replaces the full config.** Any rule omitted from the pasted JSON resets
-to its default (enabled). To disable only one rule while preserving others,
-first click *Export JSON*, edit the downloaded file, then paste it back. Unknown
-keys and non-boolean values are rejected with an error.
+to its default. To disable only one rule while preserving others, first click
+*Export JSON*, edit the downloaded file, then paste it back. Unknown keys and
+non-boolean values are rejected with an error.
+
+The same JSON shape can also be passed at build time via
+`bun run build --defaults <path>` or `EXTENSION_DEFAULTS_FILE=<path>`. That's
+the right tool for infrastructure deployments that need a custom default set
+in every fresh session without the agent flipping toggles each time — see the
+`agent-browser-shield-install` skill for the build-time workflow.
 
 ## Rule IDs
 

--- a/skills/agent-browser-shield-config/SKILL.md
+++ b/skills/agent-browser-shield-config/SKILL.md
@@ -41,8 +41,8 @@ non-boolean values are rejected with an error.
 
 The same JSON shape can also be passed at build time via
 `bun run build --defaults <path>` or `EXTENSION_DEFAULTS_FILE=<path>`. That's
-the right tool for infrastructure deployments that need a custom default set
-in every fresh session without the agent flipping toggles each time — see the
+the right tool for infrastructure deployments that need a custom default set in
+every fresh session without the agent flipping toggles each time — see the
 `agent-browser-shield-install` skill for the build-time workflow.
 
 ## Rule IDs

--- a/skills/agent-browser-shield-install/SKILL.md
+++ b/skills/agent-browser-shield-install/SKILL.md
@@ -157,11 +157,11 @@ After the browser is up and you've navigated to any non-trivial page:
 ## Customizing default-enabled rules at build time
 
 For infra deployments where the same custom defaults should ship every session
-(so the agent doesn't have to flip toggles at runtime), build from source with
-a JSON override file instead of using the hosted ZIP.
+(so the agent doesn't have to flip toggles at runtime), build from source with a
+JSON override file instead of using the hosted ZIP.
 
-1. Write a JSON file using the same shape the Options page exports — a flat
-   map of `<rule-id>` to boolean. Partial is fine; rules not listed keep their
+1. Write a JSON file using the same shape the Options page exports — a flat map
+   of `<rule-id>` to boolean. Partial is fine; rules not listed keep their
    committed default from `extension/data/rule-defaults.json`:
 
    ```json
@@ -183,8 +183,8 @@ a JSON override file instead of using the hosted ZIP.
 3. Unknown rule ids fail the build with a clear error — catch typos before
    shipping.
 
-4. Package and deploy as usual (`bun run package` then upload via Path A / B /
-   C above). The overrides are baked into the bundle.
+4. Package and deploy as usual (`bun run package` then upload via Path A / B / C
+   above). The overrides are baked into the bundle.
 
 Build-time overrides apply only when `chrome.storage` is empty (fresh session).
 Users with previously toggled state keep their preferences. The right fit is

--- a/skills/agent-browser-shield-install/SKILL.md
+++ b/skills/agent-browser-shield-install/SKILL.md
@@ -154,6 +154,42 @@ After the browser is up and you've navigated to any non-trivial page:
   cart-addon-flag, a page with an email address for pii-mask) and recheck. If
   still nothing, the extension is not installed.
 
+## Customizing default-enabled rules at build time
+
+For infra deployments where the same custom defaults should ship every session
+(so the agent doesn't have to flip toggles at runtime), build from source with
+a JSON override file instead of using the hosted ZIP.
+
+1. Write a JSON file using the same shape the Options page exports — a flat
+   map of `<rule-id>` to boolean. Partial is fine; rules not listed keep their
+   committed default from `extension/data/rule-defaults.json`:
+
+   ```json
+   {
+     "reviews-hide": false,
+     "ads-hide": false
+   }
+   ```
+
+2. Pass the path via CLI flag or env var to `bun run build`:
+
+   ```sh
+   cd extension
+   bun run build --defaults /abs/path/to/defaults.json
+   # or:
+   EXTENSION_DEFAULTS_FILE=/abs/path/to/defaults.json bun run build
+   ```
+
+3. Unknown rule ids fail the build with a clear error — catch typos before
+   shipping.
+
+4. Package and deploy as usual (`bun run package` then upload via Path A / B /
+   C above). The overrides are baked into the bundle.
+
+Build-time overrides apply only when `chrome.storage` is empty (fresh session).
+Users with previously toggled state keep their preferences. The right fit is
+short-lived browser instances (e.g. fresh Browserbase containers per session).
+
 ## After install
 
 Load the companion skills if your runtime supports it:


### PR DESCRIPTION
## Summary

- Move per-rule `defaultEnabled` out of the 21 rule modules into a single committed `extension/data/rule-defaults.json`. Codegen validates completeness against the live rule registry and emits `rule-defaults.generated.ts`; adding a rule without picking a default is now a build error.
- Add `bun run build --defaults <path>` (and `EXTENSION_DEFAULTS_FILE=<path>`) so infra deployments can ship a build with a custom default set without their agent flipping toggles via the Options UI each session. The override file shape matches the Options-page export, so the same JSON works in both places. Unknown rule ids fail the build.
- Build-time overrides apply only to fresh `chrome.storage` — existing user toggles persist (current `normalize()` semantics).

## Test plan

- [ ] `cd extension && bun run preflight` — biome + eslint + tsc + knip + jest (all 30 suites / 495 tests pass)
- [ ] `bun run build` produces a bundle with `raw = "{}"` for `EXTENSION_DEFAULT_OVERRIDES`
- [ ] `bun run build --defaults /tmp/abs.json` (partial JSON) bakes the listed overrides into the bundle and logs the override count
- [ ] `EXTENSION_DEFAULTS_FILE=/tmp/abs.json bun run build` has the same effect
- [ ] `bun run build --defaults /tmp/bad.json` (with `{"bogus-rule":true}`) fails the build with `unknown rule ids: bogus-rule`
- [ ] Load `extension/dist/` into a fresh Chrome profile after a build-with-override and confirm Options page shows the expected initial toggle states; previously-toggled storage is unaffected on rebuild
- [ ] CI codegen-freshness step covers the new `rule-defaults.generated.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)