### PR TITLE
Cite Mathur et al. for countdown-timer snapshot approach

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -145,8 +145,8 @@ sections.
 
 The snapshot-and-confirm approach follows Mathur et al.,
 [*Dark Patterns at Scale: Findings from a Crawl of 11K Shopping Websites*](https://webtransparency.cs.princeton.edu/dark-patterns/)
-(CSCW 2019), who detected countdown timers by capturing DOM mutations over
-time and comparing successive snapshots to confirm a ticking value.
+(CSCW 2019), who detected countdown timers by capturing DOM mutations over time
+and comparing successive snapshots to confirm a ticking value.
 
 ### Hide Scarcity Warnings
 

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -143,6 +143,11 @@ time-sensitivity dark pattern. Snapshots timer-shaped text and confirms the
 value decreased after 1.5s; re-scans on subtree mutations to catch lazy-loaded
 sections.
 
+The snapshot-and-confirm approach follows Mathur et al.,
+[*Dark Patterns at Scale: Findings from a Crawl of 11K Shopping Websites*](https://webtransparency.cs.princeton.edu/dark-patterns/)
+(CSCW 2019), who detected countdown timers by capturing DOM mutations over
+time and comparing successive snapshots to confirm a ticking value.
+
 ### Hide Scarcity Warnings
 
 - **ID:** `scarcity-hide`


### PR DESCRIPTION
## Summary
- Adds a citation to Mathur et al., *Dark Patterns at Scale* (CSCW 2019) under the `countdown-timer-hide` rule docs, since their crawler-based DOM-mutation snapshot method is the methodological precedent for our snapshot-and-confirm detection.

## Test plan
- [ ] Skim the rendered `rules.md` page to confirm the link renders and sits cleanly under the existing countdown-timer description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)