### PR TITLE
Typecheck tests + add coverage threshold ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
             echo "::error::Generated files are out of date. Run \`bun run build-site-data && bun run build-injection-patterns && bun run build-rule-defaults\` locally and commit the result."
             exit 1
           fi
-      - name: Preflight (lint + typecheck + knip + test)
+      - name: Preflight (lint + typecheck + knip + test with coverage)
         run: bun run preflight
       - name: Build
         run: bun run build

--- a/extension/jest.config.cjs
+++ b/extension/jest.config.cjs
@@ -37,4 +37,53 @@ module.exports = {
     "^webext-storage$": "<rootDir>/src/__test-mocks__/webext-storage.ts",
   },
   clearMocks: true,
+  collectCoverageFrom: [
+    "src/lib/**/*.ts",
+    "src/rules/**/*.ts",
+    "src/options/parse-config.ts",
+    "scripts/**/*.ts",
+    "data/site-rules.schema.ts",
+    "!**/*.generated.*",
+    "!**/__tests__/**",
+    "!src/__test-mocks__/**",
+    // UI/React glue and runtime entry points aren't unit-tested via jest —
+    // exercising them requires the loaded extension. Counting them here would
+    // make the threshold meaningless. If we add component tests for them
+    // later, include them then.
+    "!src/lib/*.tsx",
+    "!src/lib/options-badge.ts",
+    "!src/lib/options-button-toggle.ts",
+    "!src/lib/use-chrome-storage-value.ts",
+    "!src/lib/use-transient-status.ts",
+    "!src/lib/placeholder-count.ts",
+    "!src/lib/placeholder-display.ts",
+    "!src/lib/llm-background.ts",
+    "!src/lib/llm-client.ts",
+    "!src/lib/page-tree.ts",
+    "!src/lib/wait-for-settle.ts",
+    "!src/lib/automation-element-reference.ts",
+    "!src/lib/enforcement.ts",
+    "!src/lib/frame.ts",
+  ],
+  // Ratchet, not aspiration: thresholds sit just under the current baseline so
+  // CI fails on a regression but doesn't block today's PR. Per Jest's rules,
+  // path-specific thresholds (./src/rules/) are evaluated against those files
+  // only; "global" applies to the rest (lib/, options/parse-config, scripts/,
+  // data/). The two ranges differ because src/rules/ is the security surface
+  // and held to a higher bar. Ratchet up as untested rules
+  // (cross-origin-frame-hide, irrelevant-sections-hide) get tests.
+  coverageThreshold: {
+    global: {
+      statements: 60,
+      branches: 50,
+      functions: 55,
+      lines: 60,
+    },
+    "./src/rules/": {
+      statements: 75,
+      branches: 58,
+      functions: 75,
+      lines: 75,
+    },
+  },
 };

--- a/extension/package.json
+++ b/extension/package.json
@@ -30,6 +30,7 @@
     "build-icons": "bun run scripts/build-icons.ts",
     "clean": "rm -rf dist",
     "test": "jest",
+    "test:coverage": "jest --coverage --coverageReporters=text-summary",
     "check": "biome check . && eslint .",
     "check:fix": "biome check --write . && eslint . --fix",
     "format": "biome format --write .",
@@ -37,8 +38,8 @@
     "lint:eslint": "eslint .",
     "lint:eslint:fix": "eslint . --fix",
     "knip": "knip",
-    "typecheck": "tsc --noEmit",
-    "preflight": "bun run build-site-data && bun run build-injection-patterns && bun run build-rule-defaults && bun run check && bun run typecheck && bun run knip && bun run test"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json --noEmit",
+    "preflight": "bun run build-site-data && bun run build-injection-patterns && bun run build-rule-defaults && bun run check && bun run typecheck && bun run knip && bun run test:coverage"
   },
   "dependencies": {
     "abort-utils": "^3.0.0",

--- a/extension/src/rules/__tests__/cart-addon-flag.test.ts
+++ b/extension/src/rules/__tests__/cart-addon-flag.test.ts
@@ -145,7 +145,7 @@ describe("cartAddonFlagRule on checkout URLs", () => {
     // guarded by the contains-flagged-descendant check.
     const flagged = document.querySelectorAll(`[${FLAGGED_ATTR}]`);
     expect(flagged.length).toBe(1);
-    expect(flagged[0].tagName).toBe("SPAN");
+    expect(flagged[0]?.tagName).toBe("SPAN");
   });
 
   it("skips elements with too many descendants (cart-wide container)", () => {

--- a/extension/src/rules/__tests__/prompt-injection-hide.test.ts
+++ b/extension/src/rules/__tests__/prompt-injection-hide.test.ts
@@ -16,7 +16,7 @@ describe("prompt-injection-hide", () => {
 
     const paragraphs = document.querySelectorAll("p");
     expect(paragraphs).toHaveLength(1);
-    expect(paragraphs[0].textContent).toBe("Welcome to our product page.");
+    expect(paragraphs[0]?.textContent).toBe("Welcome to our product page.");
     expect(
       document.querySelector(`.${PLACEHOLDER_CLASS}`)?.textContent,
     ).toContain("possible prompt injection hidden");

--- a/extension/src/rules/__tests__/secrets-mask.test.ts
+++ b/extension/src/rules/__tests__/secrets-mask.test.ts
@@ -135,7 +135,7 @@ describe("secrets-mask", () => {
 
     const placeholders = document.querySelectorAll(`.${PLACEHOLDER_CLASS}`);
     expect(placeholders).toHaveLength(1);
-    expect(placeholders[0].textContent).toBe("[github token hidden]");
+    expect(placeholders[0]?.textContent).toBe("[github token hidden]");
   });
 
   it("masks multiple secrets in the same text node", () => {

--- a/extension/src/rules/__tests__/site-data.test.ts
+++ b/extension/src/rules/__tests__/site-data.test.ts
@@ -54,6 +54,9 @@ describe("site data YAML files", () => {
 
     const hostnames = new Set<string>(parsed.hostnames);
     for (const entry of Object.values(parsed.rules)) {
+      if (!entry) {
+        continue;
+      }
       for (const item of toEntries(entry)) {
         if (item.hostnames) {
           for (const h of item.hostnames) {

--- a/extension/tsconfig.test.json
+++ b/extension/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["chrome", "bun", "jest", "node"]
+  },
+  "include": [
+    "src/**/__tests__/**/*.ts",
+    "src/**/__tests__/**/*.tsx",
+    "src/__test-mocks__/**/*.ts",
+    "scripts/**/__tests__/**/*.ts"
+  ],
+  "exclude": ["dist", "node_modules", "src/**/*.generated.*"]
+}


### PR DESCRIPTION
## Summary

- **Typecheck tests.** `extension/tsconfig.json` excluded `src/**/__tests__/**`, so `bun run typecheck` skipped tests entirely. A new `tsconfig.test.json` closes the gap and is wired into the existing `typecheck` script (which preflight + CI already run). This surfaced five real type errors the ts-jest pipeline was masking — fixed inline (`prompt-injection-hide`, `cart-addon-flag`, `secrets-mask`, `site-data` tests).

- **Jest coverage thresholds.** No `coverageThreshold` was set. Added thresholds calibrated as a regression *ratchet*, not aspiration: numbers sit just under the current baseline so CI fails on a drop without blocking today's PR. Jest evaluates `./src/rules/` against a stricter floor (security-surface code); the rest hits the `global` threshold. UI/React glue and runtime entry points are excluded from `collectCoverageFrom` — they need the loaded extension, not jest. CI now runs `jest --coverage --coverageReporters=text-summary` via a new `test:coverage` script that preflight delegates to.

- **License headers on `__tests__`** (deferred per discussion): removing the `__tests__/` exclusion silently disables Jest's `@jest-environment-options` docblock pragmas (the regex in `jest-docblock` requires only whitespace before the docblock), and 10 test files rely on the per-file URL setup. JSDOM's `window.location` is non-configurable at runtime, so a clean fix needs a custom Jest environment exposing `dom.reconfigure`. Not done here.

## Current coverage (`bun run test:coverage`)

```
Statements   : 69.33% ( 1083/1562 )
Branches     : 58.33% ( 385/660 )
Functions    : 66.39% ( 160/241 )
Lines        : 69.11% ( 1065/1541 )
```

`./src/rules/`: 76.49% statements / 60.60% branches / 76.47% functions / 76.21% lines.

Untested rules pulling `src/rules/` down (next ratchet candidates): `cross-origin-frame-hide` (16%), `irrelevant-sections-hide` (16%).

## Test plan

- [ ] CI passes — `Preflight (lint + typecheck + knip + test with coverage)` step runs both `tsc` configs and the coverage gate
- [ ] Local: `bun run preflight` succeeds
- [ ] Verify thresholds bite: drop a test, confirm `bun run test:coverage` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)