### PR TITLE
Cite prior art (papers + OSS) for each defense rule

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -105,9 +105,8 @@ readable by agents and can carry prompt-injection payloads. Comments inside
 `<script>`/`<style>`/`<noscript>` are preserved. Removal is not reversible
 within the current page load.
 
-Prior art: HTML comments are explicitly enumerated as a non-rendered carrier
-for indirect prompt injection in Greshake et al. (cited in the section
-preamble).
+Prior art: HTML comments are explicitly enumerated as a non-rendered carrier for
+indirect prompt injection in Greshake et al. (cited in the section preamble).
 
 ### Hide Comments
 
@@ -130,10 +129,10 @@ Hide user-generated review text so agents aren't exposed to potential prompt
 injection from reviewers. Covers schema.org microdata and supported sites
 (Amazon, Walmart); aggregate star ratings are kept visible.
 
-Detection relies on the
-[schema.org `Review`](https://schema.org/Review) microdata vocabulary where
-sites expose it; user-generated reviews as an indirect-prompt-injection vector
-are covered by the same WIPI threat model referenced above.
+Detection relies on the [schema.org `Review`](https://schema.org/Review)
+microdata vocabulary where sites expose it; user-generated reviews as an
+indirect-prompt-injection vector are covered by the same WIPI threat model
+referenced above.
 
 ### Hide Social Embeds
 
@@ -181,8 +180,8 @@ The pattern taxonomy itself traces to Harry Brignull's 2010
 darkpatterns.org) and the empirical study by Mathur et al.,
 [*Dark Patterns at Scale: Findings from a Crawl of 11K Shopping Websites*](https://webtransparency.cs.princeton.edu/dark-patterns/)
 (CSCW 2019), which enumerates *Scarcity*, *Sneaking* (sneak-into-basket),
-*Preselection*, and *Urgency* (countdown timers) — the four categories the
-rules below target. Bösch et al.,
+*Preselection*, and *Urgency* (countdown timers) — the four categories the rules
+below target. Bösch et al.,
 [*Tales from the Dark Side: Privacy Dark Strategies and Privacy Dark Patterns*](https://petsymposium.org/popets/2016/popets-2016-0038.php)
 (PoPETs 2016), gives the parallel privacy-side taxonomy.
 
@@ -242,8 +241,8 @@ donation/round-up, gift wrap, carbon offset, shipping/package protection, Route,
 Seel, Navidium, driver tips). The line item is **not** removed — the agent reads
 the annotation and decides whether to click the line's remove control.
 
-Prior art: Brignull's original 2010 *Sneak into Basket* pattern, generalized
-to the *Sneaking* family in Mathur et al. 2019 (both cited in the section
+Prior art: Brignull's original 2010 *Sneak into Basket* pattern, generalized to
+the *Sneaking* family in Mathur et al. 2019 (both cited in the section
 preamble).
 
 ## Token-saving cleanup
@@ -268,8 +267,8 @@ generic article extractor.
 Hide the page footer (legal links, sitemap, social icons, marketing copy) to
 save tokens. Per-section footers inside articles or asides are left visible.
 
-Prior art: Footers are a canonical boilerplate region in Kohlschütter et al.
-and are stripped by Readability.js (cited in the section preamble).
+Prior art: Footers are a canonical boilerplate region in Kohlschütter et al. and
+are stripped by Readability.js (cited in the section preamble).
 
 ### Remove Cookie Banners
 
@@ -311,9 +310,9 @@ Remove interstitial newsletter signup modals that cover the page. Detects
 fixed-position dialogs containing signup language and an email input. Standard
 login modals, paywalls, and small toasts are kept visible.
 
-Prior art: Interstitial signup modals are categorized as *Nagging* in Mathur
-et al. 2019 (cited in the Dark-pattern section preamble); reader-mode tools
-like Readability.js routinely strip them as non-article chrome.
+Prior art: Interstitial signup modals are categorized as *Nagging* in Mathur et
+al. 2019 (cited in the Dark-pattern section preamble); reader-mode tools like
+Readability.js routinely strip them as non-article chrome.
 
 ### Hide Ads & Sponsored Results
 
@@ -327,10 +326,9 @@ from EasyList are injected as a `display:none` stylesheet for broader coverage
 of third-party ad networks.
 
 Prior art: Selectors come directly from [EasyList](https://easylist.to/), the
-filter list that powers
-[uBlock Origin](https://github.com/gorhill/uBlock), Adblock Plus, and most
-other consumer ad blockers — over a decade of community-maintained ad and
-tracker selector patterns.
+filter list that powers [uBlock Origin](https://github.com/gorhill/uBlock),
+Adblock Plus, and most other consumer ad blockers — over a decade of
+community-maintained ad and tracker selector patterns.
 
 ### Remove Unused SVG Sprites
 
@@ -342,8 +340,8 @@ definitions) when none of their symbols are referenced by any `<use>` element on
 the page. Referenced sprites are preserved so icons keep working.
 
 Prior art: Dead-code elimination — the bundler optimization of dropping
-references that no live code reaches — applied to SVG `<symbol>` definitions
-at runtime. No direct academic prior art known.
+references that no live code reaches — applied to SVG `<symbol>` definitions at
+runtime. No direct academic prior art known.
 
 ### Hide Irrelevant Sections (AI)
 
@@ -386,9 +384,9 @@ URL instead of typing into search boxes and clicking facets. No visible
 affordance — the landmark is preserved by `hidden-text-strip` via the `sr-only`
 class allowlist.
 
-Prior art: Same goal as the [llms.txt](https://llmstxt.org/) proposal
-(Howard, Answer.AI, 2024) — give LLMs a compact, machine-readable hint about
-how to use a site — but injected client-side as a hidden landmark instead of
-relying on the site to publish a top-level file. The hidden-but-readable
-delivery mechanism reuses the long-established `sr-only` / `visually-hidden`
-convention from screen-reader accessibility practice.
+Prior art: Same goal as the [llms.txt](https://llmstxt.org/) proposal (Howard,
+Answer.AI, 2024) — give LLMs a compact, machine-readable hint about how to use a
+site — but injected client-side as a hidden landmark instead of relying on the
+site to publish a top-level file. The hidden-but-readable delivery mechanism
+reuses the long-established `sr-only` / `visually-hidden` convention from
+screen-reader accessibility practice.

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -32,6 +32,11 @@ renders normally for humans.
 
 Hide credit card numbers (Luhn-validated), phone numbers, and SSNs.
 
+Prior art: Microsoft's open-source
+[Presidio](https://github.com/microsoft/presidio) framework uses the same mix of
+regex patterns, checksum validation (e.g., Luhn for credit cards), and
+named-entity recognition to detect and redact PII in text.
+
 ### Mask Secrets
 
 - **ID:** `secrets-mask`
@@ -39,10 +44,27 @@ Hide credit card numbers (Luhn-validated), phone numbers, and SSNs.
 
 Hide API keys, tokens, JWTs, private keys, and other high-entropy credentials.
 
+Prior art: Repository secret-scanning tools —
+[gitleaks](https://github.com/gitleaks/gitleaks),
+[trufflehog](https://github.com/trufflesecurity/trufflehog), and Yelp's
+[detect-secrets](https://github.com/Yelp/detect-secrets) — use comparable regex
+and entropy heuristics to surface API keys, tokens, and private keys in source
+repositories. This rule applies the same approach to live page text instead of
+files on disk.
+
 ## Prompt-injection defense
 
 Remove or hide content that could carry attacker-controlled instructions —
 user-generated text, invisible text, and HTML comments.
+
+Background: Greshake et al.,
+[*Not what you've signed up for: Compromising Real-World LLM-Integrated Applications with Indirect Prompt Injection*](https://arxiv.org/abs/2302.12173)
+(AISec 2023), introduces the indirect prompt injection threat model — attacker
+text reaches the model via the page or document the LLM reads, not via the
+user's prompt. Wu et al.,
+[*WIPI: A New Web Threat for LLM-Driven Web Agents*](https://arxiv.org/abs/2402.16965),
+extends that model specifically to LLM-driven web agents. The rules in this
+section each target a delivery vector documented in those threat models.
 
 ### Hide Prompt Injection
 
@@ -67,6 +89,12 @@ the 1×1 + `overflow:hidden` + `position:absolute` envelope) so a11y-tree
 affordances like Amazon SERP prices stay intact. `display:none` is left alone so
 collapsed menus and tab panels keep working.
 
+Prior art: Liao et al.,
+[*EIA: Environmental Injection Attack on Generalist Web Agents for Privacy Leakage*](https://arxiv.org/abs/2409.11295)
+(ICLR 2025), demonstrates that web elements made invisible via CSS — opacity,
+off-screen positioning, zero-area clipping — are read by web agents but unseen
+by humans, the exact asymmetry this rule closes.
+
 ### Strip HTML Comments
 
 - **ID:** `html-comment-strip`
@@ -77,6 +105,10 @@ readable by agents and can carry prompt-injection payloads. Comments inside
 `<script>`/`<style>`/`<noscript>` are preserved. Removal is not reversible
 within the current page load.
 
+Prior art: HTML comments are explicitly enumerated as a non-rendered carrier
+for indirect prompt injection in Greshake et al. (cited in the section
+preamble).
+
 ### Hide Comments
 
 - **ID:** `comments-hide`
@@ -85,6 +117,9 @@ within the current page load.
 Hide user-generated comment threads so agents aren't exposed to potential prompt
 injection from commenters. Covers common platforms (Disqus, Facebook) plus
 Reddit, YouTube, and Hacker News.
+
+Prior art: User-generated text as an injection delivery vector is core to the
+WIPI threat model (Wu et al., cited in the section preamble).
 
 ### Hide Reviews
 
@@ -95,6 +130,11 @@ Hide user-generated review text so agents aren't exposed to potential prompt
 injection from reviewers. Covers schema.org microdata and supported sites
 (Amazon, Walmart); aggregate star ratings are kept visible.
 
+Detection relies on the
+[schema.org `Review`](https://schema.org/Review) microdata vocabulary where
+sites expose it; user-generated reviews as an indirect-prompt-injection vector
+are covered by the same WIPI threat model referenced above.
+
 ### Hide Social Embeds
 
 - **ID:** `social-embed-hide`
@@ -104,6 +144,9 @@ Hide embedded social-media widgets (Twitter/X, YouTube, Facebook, Instagram,
 TikTok, LinkedIn, Reddit, Spotify, SoundCloud). Replaced with a placeholder so
 the agent knows an embed lived there. Skipped on the embed providers' own
 domains, where embeds are the page content.
+
+Prior art: Same indirect-prompt-injection threat model as above; social embeds
+are a third-party content surface whose text the host page does not control.
 
 ### Hide Cross-Origin Frames (Experimental)
 
@@ -133,6 +176,16 @@ to these patterns — sometimes more so than humans — see
 [SusBench](https://arxiv.org/abs/2510.11035) (Guo et al., 2025) and
 [DECEPTICON](https://arxiv.org/abs/2512.22894) (Cuvin et al., 2025).
 
+The pattern taxonomy itself traces to Harry Brignull's 2010
+[deceptive.design](https://www.deceptive.design/) catalog (originally
+darkpatterns.org) and the empirical study by Mathur et al.,
+[*Dark Patterns at Scale: Findings from a Crawl of 11K Shopping Websites*](https://webtransparency.cs.princeton.edu/dark-patterns/)
+(CSCW 2019), which enumerates *Scarcity*, *Sneaking* (sneak-into-basket),
+*Preselection*, and *Urgency* (countdown timers) — the four categories the
+rules below target. Bösch et al.,
+[*Tales from the Dark Side: Privacy Dark Strategies and Privacy Dark Patterns*](https://petsymposium.org/popets/2016/popets-2016-0038.php)
+(PoPETs 2016), gives the parallel privacy-side taxonomy.
+
 ### Hide Countdown Timers
 
 - **ID:** `countdown-timer-hide`
@@ -158,6 +211,10 @@ fast", "12 viewing now") so agents aren't pressured by manufactured scarcity.
 Out-of-stock indicators and bestseller badges are kept visible because they
 convey real purchaseability or preference information.
 
+Prior art: Cataloged as *Scarcity* (low-stock and high-demand subtypes) in
+Mathur et al. 2019 (cited in the section preamble), which found scarcity claims
+on roughly a fifth of the 11K shopping sites they crawled.
+
 ### Clear Checkout Checkboxes
 
 - **ID:** `checkout-checkbox-clear`
@@ -169,6 +226,9 @@ selected add-ons (insurance, warranty, gift wrap, donations, marketing opt-ins).
 The agent is then expected to re-check anything it actually wants to opt into,
 including required agreements. `role="checkbox"` widgets and radio groups are
 out of scope.
+
+Prior art: Pre-checked opt-ins are *Preselection* in Mathur et al. 2019 and
+Brignull's deceptive.design catalog (both cited in the section preamble).
 
 ### Flag Cart Add-Ons (Sneak-Into-Basket)
 
@@ -182,10 +242,23 @@ donation/round-up, gift wrap, carbon offset, shipping/package protection, Route,
 Seel, Navidium, driver tips). The line item is **not** removed — the agent reads
 the annotation and decides whether to click the line's remove control.
 
+Prior art: Brignull's original 2010 *Sneak into Basket* pattern, generalized
+to the *Sneaking* family in Mathur et al. 2019 (both cited in the section
+preamble).
+
 ## Token-saving cleanup
 
 Remove page chrome that costs tokens without helping the agent complete its
 task.
+
+Background: Content-vs-boilerplate separation has a long line of prior art,
+starting with Kohlschütter et al.,
+[*Boilerplate Detection using Shallow Text Features*](https://dl.acm.org/doi/10.1145/1718487.1718542)
+(WSDM 2010) — the basis for the Boilerpipe library — and Mozilla's
+[Readability.js](https://github.com/mozilla/readability), the algorithm behind
+Firefox Reader View. Several rules below are the agent-facing analogue of those
+heuristics, targeted at specific chrome categories instead of running a single
+generic article extractor.
 
 ### Hide Page Footer
 
@@ -194,6 +267,9 @@ task.
 
 Hide the page footer (legal links, sitemap, social icons, marketing copy) to
 save tokens. Per-section footers inside articles or asides are left visible.
+
+Prior art: Footers are a canonical boilerplate region in Kohlschütter et al.
+and are stripped by Readability.js (cited in the section preamble).
 
 ### Remove Cookie Banners
 
@@ -206,6 +282,12 @@ Sourcepoint, Quantcast, Osano, Didomi, and generic patterns). These overlays
 float above the page, so they're removed entirely rather than replaced with an
 in-flow placeholder.
 
+Prior art: Aarhus University's
+[Consent-O-Matic](https://github.com/cavi-au/Consent-O-Matic) maintains the
+canonical open ruleset for matching CMPs (Consent Management Platforms) like
+OneTrust, Cookiebot, and TrustArc — the same CMP coverage this rule targets,
+though Consent-O-Matic auto-fills banners while this rule removes them outright.
+
 ### Remove Chat Widgets
 
 - **ID:** `chat-widget-hide`
@@ -216,6 +298,9 @@ Remove live-chat widgets (Intercom, Drift, Zendesk, Crisp, Tawk.to, HubSpot,
 Olark, LiveChat, Freshchat, Zopim). These bubbles float above the page, so
 they're removed entirely rather than replaced with an in-flow placeholder.
 
+Prior art: Same boilerplate-removal lineage as the section preamble; chat
+bubbles are floating chrome that Readability-style extractors discard.
+
 ### Remove Newsletter Modals
 
 - **ID:** `newsletter-modal-hide`
@@ -225,6 +310,10 @@ they're removed entirely rather than replaced with an in-flow placeholder.
 Remove interstitial newsletter signup modals that cover the page. Detects
 fixed-position dialogs containing signup language and an email input. Standard
 login modals, paywalls, and small toasts are kept visible.
+
+Prior art: Interstitial signup modals are categorized as *Nagging* in Mathur
+et al. 2019 (cited in the Dark-pattern section preamble); reader-mode tools
+like Readability.js routinely strip them as non-article chrome.
 
 ### Hide Ads & Sponsored Results
 
@@ -237,6 +326,12 @@ stripped from the DOM so the agent never sees them. ~13k additional ad selectors
 from EasyList are injected as a `display:none` stylesheet for broader coverage
 of third-party ad networks.
 
+Prior art: Selectors come directly from [EasyList](https://easylist.to/), the
+filter list that powers
+[uBlock Origin](https://github.com/gorhill/uBlock), Adblock Plus, and most
+other consumer ad blockers — over a decade of community-maintained ad and
+tracker selector patterns.
+
 ### Remove Unused SVG Sprites
 
 - **ID:** `svg-sprite-suppress`
@@ -245,6 +340,10 @@ of third-party ad networks.
 Remove hidden SVG sprite containers (those holding only `<symbol>`/`<defs>`
 definitions) when none of their symbols are referenced by any `<use>` element on
 the page. Referenced sprites are preserved so icons keep working.
+
+Prior art: Dead-code elimination — the bundler optimization of dropping
+references that no live code reaches — applied to SVG `<symbol>` definitions
+at runtime. No direct academic prior art known.
 
 ### Hide Irrelevant Sections (AI)
 
@@ -261,6 +360,12 @@ with click-to-reveal placeholders. Sends a compressed page tree with stable refs
 so the LLM can choose the right granularity; interactive elements (search, cart,
 checkout, login) are labeled as protected. Re-scans on scroll to catch
 lazy-loaded content.
+
+Prior art: This is an LLM-driven generalization of the boilerplate-detection
+heuristics in Kohlschütter et al. (cited in the section preamble) and
+Readability.js. The specific targeting of engagement and recommendation rails
+aligns with the *Nagging*/*Interface Interference* families in Mathur et al.
+2019 (cited in the Dark-pattern section preamble).
 
 ## Agent affordances
 
@@ -280,3 +385,10 @@ searches, filters, sorts, and direct lookups via URL. Lets agents navigate by
 URL instead of typing into search boxes and clicking facets. No visible
 affordance — the landmark is preserved by `hidden-text-strip` via the `sr-only`
 class allowlist.
+
+Prior art: Same goal as the [llms.txt](https://llmstxt.org/) proposal
+(Howard, Answer.AI, 2024) — give LLMs a compact, machine-readable hint about
+how to use a site — but injected client-side as a hidden landmark instead of
+relying on the site to publish a top-level file. The hidden-but-readable
+delivery mechanism reuses the long-established `sr-only` / `visually-hidden`
+convention from screen-reader accessibility practice.


### PR DESCRIPTION
## Summary
- Adds an inline **Prior art:** note to each rule entry in `docs/src/content/docs/rules.md`, citing the relevant research papers, open-source projects, and standards each defense draws from.
- Adds short category-level preambles for **Prompt-injection defense**, **Dark-pattern blocking**, and **Token-saving cleanup** so per-rule notes can reference shared citations instead of repeating them.
- Keeps existing citations (Roesner & Kohlbrenner for cross-origin frames; Mathur et al. for countdown timers; SusBench / DECEPTICON for agent susceptibility) intact.

### Notable citations added
- `pii-mask` → Microsoft [Presidio](https://github.com/microsoft/presidio)
- `secrets-mask` → [gitleaks](https://github.com/gitleaks/gitleaks), [trufflehog](https://github.com/trufflesecurity/trufflehog), [detect-secrets](https://github.com/Yelp/detect-secrets)
- Prompt-injection section → Greshake et al. [*Not what you've signed up for*](https://arxiv.org/abs/2302.12173) (AISec 2023), Wu et al. [*WIPI*](https://arxiv.org/abs/2402.16965)
- `hidden-text-strip` → Liao et al. [*EIA*](https://arxiv.org/abs/2409.11295) (ICLR 2025) — invisible CSS as a web-agent attack vector
- Dark-pattern section → Brignull's [deceptive.design](https://www.deceptive.design/) catalog, Mathur et al. [*Dark Patterns at Scale*](https://webtransparency.cs.princeton.edu/dark-patterns/) (CSCW 2019), Bösch et al. [*Tales from the Dark Side*](https://petsymposium.org/popets/2016/popets-2016-0038.php) (PoPETs 2016)
- Token-saving section → Kohlschütter et al. [*Boilerplate Detection*](https://dl.acm.org/doi/10.1145/1718487.1718542) (WSDM 2010), Mozilla [Readability.js](https://github.com/mozilla/readability)
- `cookie-banner-hide` → Aarhus [Consent-O-Matic](https://github.com/cavi-au/Consent-O-Matic)
- `ads-hide` → [EasyList](https://easylist.to/), [uBlock Origin](https://github.com/gorhill/uBlock)
- `search-url-helper` → [llms.txt](https://llmstxt.org/) proposal (Howard, Answer.AI, 2024)
- `svg-sprite-suppress` — noted as a runtime dead-code-elimination analogue with no direct academic prior art

## Test plan
- [x] `bun run build` in `docs/` succeeds and `/rules/` renders.
- [ ] Reviewer spot-checks 2–3 citations for accuracy and stable URLs.
- [ ] Reviewer confirms no rule was missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)