### PR TITLE
Fix hidden-text-strip false-positive on font-size:0 wrappers

### DIFF
--- a/extension/src/rules/__tests__/hidden-text-strip.test.ts
+++ b/extension/src/rules/__tests__/hidden-text-strip.test.ts
@@ -61,6 +61,22 @@ describe("hiddenTextStripRule", () => {
     expect(document.querySelector("#x")).toBeNull();
   });
 
+  // Amazon's #nav-belt / #nav-search and many legacy layouts set `font-size:
+  // 0` on a wrapper to collapse whitespace between inline-block children, then
+  // restore a real font-size on the children themselves. The wrapper has no
+  // direct text of its own — stripping it would wipe out the entire top nav.
+  it("preserves a font-size:0 wrapper whose children restore a real font-size", () => {
+    document.body.innerHTML = `
+      <div id="wrapper" style="font-size: 0">
+        <span id="child" style="font-size: 14px">visible nav link</span>
+      </div>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#wrapper")).not.toBeNull();
+    expect(document.querySelector("#child")).not.toBeNull();
+  });
+
   it("preserves .sr-only text", () => {
     document.body.innerHTML = `
       <span id="x" class="sr-only" style="position: absolute; left: -10000px">screen reader hint</span>

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -148,14 +148,20 @@ function hasStructuralSrOnlyPattern(style: CSSStyleDeclaration): boolean {
   return true;
 }
 
-function isHiddenByCss(style: CSSStyleDeclaration): boolean {
+function isHiddenByCss(element: Element, style: CSSStyleDeclaration): boolean {
   if (style.visibility === "hidden" || style.visibility === "collapse") {
     return true;
   }
   if (Number.parseFloat(style.opacity) === 0) {
     return true;
   }
-  if (style.fontSize === "0px") {
+  // `font-size: 0` on a wrapper is the legacy layout trick to collapse
+  // whitespace between inline-block children — children override with their
+  // own font-size and render normally (Amazon's #nav-belt, #nav-search, and
+  // similar use this idiom; matching the wrapper would wipe out the whole
+  // top nav). Only treat font-size:0 as hiding text when the element itself
+  // owns direct text nodes that would actually be invisible.
+  if (style.fontSize === "0px" && hasOwnDirectText(element)) {
     return true;
   }
   if (style.position === "absolute" || style.position === "fixed") {
@@ -180,6 +186,22 @@ function isHiddenByCss(style: CSSStyleDeclaration): boolean {
 
 function hasNonemptyText(element: Element): boolean {
   return element.textContent.trim().length > 0;
+}
+
+// True if the element itself owns nonempty text node children (not just text
+// inside descendants). Used to distinguish a leaf that hides its own text
+// from a wrapper whose descendants override the hiding property.
+function hasOwnDirectText(element: Element): boolean {
+  for (const node of element.childNodes) {
+    if (
+      node.nodeType === Node.TEXT_NODE &&
+      node.textContent !== null &&
+      node.textContent.trim().length > 0
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // sRGB Euclidean distance under which two colors are perceptually
@@ -277,7 +299,10 @@ function findCandidates(root: ParentNode): HTMLElement[] {
     if (hasStructuralSrOnlyPattern(style)) {
       continue;
     }
-    if (!isHiddenByCss(style) && !hasMatchingForeground(element, style)) {
+    if (
+      !isHiddenByCss(element, style) &&
+      !hasMatchingForeground(element, style)
+    ) {
       continue;
     }
     matches.push(element);


### PR DESCRIPTION
## Summary

- `hidden-text-strip` was removing Amazon's top nav (`#nav-belt` / `#nav-search` / surrounding wrappers) on amazon.com.
- Root cause: `isHiddenByCss` flagged any element whose computed `font-size` was `0px`. Amazon uses the legacy layout trick of setting `font-size: 0` on a wrapper to collapse whitespace between inline-block children, while children restore a real font-size. The wrapper itself has no direct text — it's not actually hiding anything — but `filterToOutermost` picked it as the outermost match and removed the entire nav.
- Fix: gate the `font-size: 0` trigger on `hasOwnDirectText(element)` — only treat font-size:0 as a hidden-text signal when the element owns text node children that would themselves be invisible. Leaf payloads with `font-size: 0` still match (existing test covers this); wrapper layout tricks no longer do.

Scope is intentionally narrow: only the `font-size: 0` heuristic gets the gate. `visibility:hidden` / `opacity:0` are unchanged because the injection patterns those defend against don't have the same benign-wrapper analogue at meaningful frequency, and broadening the gate would weaken the defense.

## Test plan

- [x] `bun run test src/rules/__tests__/hidden-text-strip.test.ts` — 21/21 pass including the new wrapper test
- [x] `bun run test` — full suite 536/536 pass
- [x] `bun run check` + `bun run typecheck` — clean
- [ ] Smoke test on live amazon.com with the built extension: top nav with search renders intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)