### PR TITLE
Fix hidden-text-strip false-positives on Amazon nav

### DIFF
--- a/extension/src/lib/dom-utils.ts
+++ b/extension/src/lib/dom-utils.ts
@@ -20,6 +20,39 @@ export function isNonContentTag(tagName: string): boolean {
   return NON_CONTENT_TAGS.has(tagName);
 }
 
+// Text that a sighted user could perceive — like `Node.textContent` but with
+// `NON_CONTENT_TAGS` subtrees (SCRIPT/STYLE/NOSCRIPT/TEMPLATE) excluded.
+// `Node.textContent` happily serializes inline script source as if it were
+// prose, which is misleading for any check keyed on "does this element show
+// text" (e.g., color-match on a wrapper whose only `textContent` is a JSON
+// blob inside a <script>).
+export function visibleTextContent(element: Element): string {
+  const walker = globalThis.document.createTreeWalker(
+    element,
+    NodeFilter.SHOW_TEXT,
+    {
+      acceptNode: (node) => {
+        let parent: Node | null = node.parentNode;
+        while (parent && parent !== element) {
+          if (
+            parent.nodeType === Node.ELEMENT_NODE &&
+            NON_CONTENT_TAGS.has((parent as Element).tagName)
+          ) {
+            return NodeFilter.FILTER_REJECT;
+          }
+          parent = parent.parentNode;
+        }
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    },
+  );
+  let out = "";
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    out += node.textContent ?? "";
+  }
+  return out;
+}
+
 // True for placeholder elements themselves and anything inside one — the
 // common "don't re-process my own replacement" check that every hide rule
 // performs before considering a candidate.

--- a/extension/src/rules/__tests__/hidden-text-strip.test.ts
+++ b/extension/src/rules/__tests__/hidden-text-strip.test.ts
@@ -196,6 +196,82 @@ describe("hiddenTextStripRule", () => {
     expect(document.querySelector("#x")).not.toBeNull();
   });
 
+  // Amazon's `<nav id="shortcut-menu">` lives at `position: fixed; left:
+  // -10000px` and slides in when the user hits a keyboard shortcut. It's
+  // prose (1,100+ chars of help text), so the 1×1 SR-only envelope doesn't
+  // apply. The semantic landmark tag is the signal: agents and a11y tools
+  // treat NAV as navigation regardless of where it's positioned.
+  it("preserves an off-screen NAV landmark (keyboard-shortcut help pattern)", () => {
+    document.body.innerHTML = `
+      <nav id="shortcuts" style="position: fixed; left: -10000px">
+        Skip to main content. Keyboard shortcuts: opt+/, shift+opt+C…
+      </nav>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#shortcuts")).not.toBeNull();
+  });
+
+  it("preserves an off-screen element with role=navigation", () => {
+    document.body.innerHTML = `
+      <div id="shortcuts" role="navigation" style="position: absolute; left: -10000px">
+        Keyboard shortcut help menu
+      </div>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#shortcuts")).not.toBeNull();
+  });
+
+  // Landmark preservation is per-element, not per-subtree — an injection
+  // shaped descendant inside a NAV is still strippable.
+  it("still strips an injection-shaped descendant inside a landmark", () => {
+    document.body.innerHTML = `
+      <nav id="nav">
+        <a href="/home">Home</a>
+        <div id="payload" style="position: absolute; left: -10000px; width: 600px; height: 200px">
+          ${FIXTURES.HIDDEN_LARGE_OFFSCREEN}
+        </div>
+      </nav>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#nav")).not.toBeNull();
+    expect(document.querySelector("#payload")).toBeNull();
+  });
+
+  // Amazon's #navbar wrapper has `color: rgb(15,17,17)` against the dark nav
+  // background — a color-match by perceptual distance — but the wrapper has
+  // no direct text of its own. The visible nav text lives in `<a>`
+  // descendants with their own white color that overrides inheritance.
+  // Stripping the wrapper would wipe out the top nav.
+  it("preserves a color-matched wrapper whose text comes from descendants", () => {
+    document.body.innerHTML = `
+      <div id="nav" style="color: rgb(15, 17, 17); background-color: rgb(19, 25, 33)">
+        <a href="/home" style="color: rgb(255, 255, 255)">Home</a>
+        <a href="/account" style="color: rgb(255, 255, 255)">Account</a>
+      </div>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#nav")).not.toBeNull();
+    expect(document.querySelector("a[href='/home']")).not.toBeNull();
+  });
+
+  // `Node.textContent` includes inline script source, which historically led
+  // us to scan wrappers whose only "text" was a JSON blob or telemetry
+  // bootstrap inside <script>. The wrapper should look text-less to the rule.
+  it("ignores text inside <script> when deciding whether a wrapper has content", () => {
+    document.body.innerHTML = `
+      <div id="nav" style="color: rgb(15, 17, 17); background-color: rgb(19, 25, 33)">
+        <script>window.navmet.push({key:'Logo',end:+new Date()});</script>
+      </div>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#nav")).not.toBeNull();
+  });
+
   // An offscreen element that's large enough to carry prose is not an
   // SR-only label — it's the injection shape we exist to strip.
   it("still removes large off-left blocks (no 1×1 envelope = not SR-only)", () => {

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -55,6 +55,7 @@ import {
   isInsidePlaceholder,
   isNonContentTag,
   NON_CONTENT_TAGS,
+  visibleTextContent,
 } from "../lib/dom-utils";
 import { log } from "../lib/log";
 import { SR_ONLY_CLASS_NAMES, SR_ONLY_MAX_SIZE_PX } from "../lib/sr-only";
@@ -86,6 +87,38 @@ function isExcludedAncestor(element: Element): boolean {
     current = current.parentElement;
   }
   return false;
+}
+
+// HTML5 landmarks + ARIA landmark roles. These elements are load-bearing for
+// page structure and accessibility, and sites routinely position them
+// off-screen as "skip to content" affordances or keyboard-shortcut help
+// menus (e.g., Amazon's `<nav id="shortcut-menu">` at `left: -10000px`).
+// Stripping a landmark wipes out a chunk of the a11y tree, and the prose
+// inside is almost never injection — agents reading the a11y tree treat the
+// content as navigation anyway. We allowlist the element itself, not the
+// subtree: an injection-shaped descendant inside a landmark is still
+// strippable.
+const LANDMARK_TAGS: ReadonlySet<string> = new Set([
+  "NAV",
+  "MAIN",
+  "HEADER",
+  "FOOTER",
+  "ASIDE",
+]);
+const LANDMARK_ROLES: ReadonlySet<string> = new Set([
+  "navigation",
+  "main",
+  "banner",
+  "contentinfo",
+  "complementary",
+]);
+
+function isLandmark(element: Element): boolean {
+  if (LANDMARK_TAGS.has(element.tagName)) {
+    return true;
+  }
+  const role = element.getAttribute("role");
+  return role !== null && LANDMARK_ROLES.has(role);
 }
 
 function parsePixelLength(value: string): number | null {
@@ -209,7 +242,7 @@ function detectHiddenByCss(
 }
 
 function hasNonemptyText(element: Element): boolean {
-  return element.textContent.trim().length > 0;
+  return visibleTextContent(element).trim().length > 0;
 }
 
 // True if the element itself owns nonempty text node children (not just text
@@ -283,10 +316,20 @@ function colorDistance(a: RGB, b: RGB): number {
 // perceptual tolerance — the classic "white text on white background"
 // LLM-trick. Element's own alpha is folded in so `opacity:0`-style cases
 // don't double-count (those are already caught by detectHiddenByCss).
+//
+// Gated on direct text nodes for the same reason font-size:0 is: `color`
+// inherits and descendants routinely override. A wrapper whose only text
+// comes from descendants doesn't render any pixel in the wrapper's own
+// color (Amazon's #navbar has color near-black against a dark bg, but the
+// visible nav text lives in `<a>` descendants with their own white color
+// — matching the wrapper would wipe out the whole top nav).
 function detectColorMatch(
   element: Element,
   style: CSSStyleDeclaration,
 ): MatchDetail | null {
+  if (!hasOwnDirectText(element)) {
+    return null;
+  }
   const fg = parseColor(style.color);
   if (!fg) {
     return null;
@@ -328,6 +371,9 @@ function findCandidates(root: ParentNode): Candidate[] {
     if (hasSrOnlyClass(element)) {
       continue;
     }
+    if (isLandmark(element)) {
+      continue;
+    }
     if (isExcludedAncestor(element)) {
       continue;
     }
@@ -350,11 +396,11 @@ function findCandidates(root: ParentNode): Candidate[] {
 
 const TEXT_PREVIEW_MAX = 80;
 
-function textPreview(element: Element): string {
-  const text = element.textContent.trim().replaceAll(/\s+/g, " ");
-  return text.length > TEXT_PREVIEW_MAX
-    ? `${text.slice(0, TEXT_PREVIEW_MAX)}…`
-    : text;
+function textPreview(text: string): string {
+  const normalized = text.trim().replaceAll(/\s+/g, " ");
+  return normalized.length > TEXT_PREVIEW_MAX
+    ? `${normalized.slice(0, TEXT_PREVIEW_MAX)}…`
+    : normalized;
 }
 
 function scanAndStrip(root: ParentNode): void {
@@ -363,6 +409,7 @@ function scanAndStrip(root: ParentNode): void {
     if (!element.isConnected) {
       continue;
     }
+    const visible = visibleTextContent(element);
     log("hidden text removed", {
       ruleId: RULE_ID,
       reason,
@@ -370,8 +417,8 @@ function scanAndStrip(root: ParentNode): void {
       tag: element.tagName,
       id: element.id || undefined,
       classes: element.className || undefined,
-      textLength: element.textContent.length,
-      textPreview: textPreview(element),
+      textLength: visible.length,
+      textPreview: textPreview(visible),
     });
     element.remove();
   }


### PR DESCRIPTION
## Summary

Three fixes for the Amazon nav false-positives surfaced by the new reason logging in #69:

- **`visibleTextContent` helper** in `extension/src/lib/dom-utils.ts` — walks text nodes and skips `NON_CONTENT_TAGS` subtrees (SCRIPT/STYLE/NOSCRIPT/TEMPLATE). `Node.textContent` happily serializes inline script source as if it were prose, which made Amazon's `#navbar` look text-bearing when its only "text" was a `window.navmet.push(...)` bootstrap inside `<script>`.

- **Gate `detectColorMatch` on `hasOwnDirectText`** — mirrors the font-size:0 fix from #68. Color is inherited-and-overridable, so a wrapper whose only text comes from descendants doesn't render any pixel in the wrapper's own color. `#navbar` has near-black color against a dark bg, but the visible nav text lives in `<a>` descendants with their own white color — matching the wrapper would wipe out the whole top nav.

- **HTML5 landmark allowlist** — preserve `<nav>`, `<main>`, `<header>`, `<footer>`, `<aside>` and ARIA landmark roles (`navigation`, `main`, `banner`, `contentinfo`, `complementary`). Amazon's `<nav id="shortcut-menu">` lives at `left: -10000px` and slides in on keyboard shortcut — a legitimate off-canvas-reveal pattern. The allowlist is per-element, not per-subtree, so an injection-shaped descendant inside a NAV is still strippable.

Log payload now also uses `visibleTextContent` for `textLength` and `textPreview`, so future diagnostics aren't polluted by script source.

## Test plan

- [x] `bun run check` — Biome + ESLint clean
- [x] `bun run typecheck` clean
- [x] `bun run test` — 541 tests pass (5 new in `hidden-text-strip.test.ts`)
- [ ] Reload extension on amazon.com and confirm `#shortcut-menu`, `#navbar`, and `#be` are no longer stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)