### PR TITLE
Add compare_scenarios.py for fast 2-scenario iteration

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -140,6 +140,60 @@ uv run scripts/compare_scenarios.py \
     -n 3 --open
 ```
 
+Pass `--llm-proxy-url <tunnel>` to also capture the exact LLM messages per
+call (see below); the digest will point at the proxy log when it's enabled.
+
+## Capturing the LLM messages (proxy)
+
+By default Stagehand's event stream redacts the rendered a11y tree and
+system prompt — only token counts and the model's final action survive in
+`events/*.jsonl`. When you need to see the *exact* messages array Browserbase
+shipped to the model (system prompt, tool defs, accumulated history, the
+rendered a11y tree per step), route the agent calls through
+`scripts/llm_proxy.py`.
+
+`scripts/llm_proxy.py` is a small OpenAI-compatible FastAPI proxy that
+forwards `POST /v1/*` to OpenAI and logs each request/response pair to a
+JSONL file. Browserbase's backend (not your laptop) is what calls the LLM,
+so the proxy has to be reachable from the public internet — pair it with
+`cloudflared` or `ngrok`.
+
+Only the agent's traffic is proxied. The judge/extractor in
+`scripts/_judge.py` keep calling OpenAI directly with `OPENAI_API_KEY` and
+are *not* logged. OpenAI is the only upstream supported today.
+
+```bash
+# Terminal 1 — start the local proxy. Logs land in
+# output/llm-proxy/proxy_<utc_ts>.jsonl unless --out overrides.
+uv run scripts/llm_proxy.py
+# → upstream: https://api.openai.com
+# → log: output/llm-proxy/proxy_<utc_ts>.jsonl
+# → listening on http://127.0.0.1:8787
+
+# Terminal 2 — expose the proxy via a public tunnel.
+cloudflared tunnel --url http://127.0.0.1:8787
+# → prints https://<random>.trycloudflare.com
+
+# Terminal 3 — run the benchmark with --llm-proxy-url pointing at the tunnel.
+# Requires OPENAI_API_KEY in env (forwarded as the agent's api_key). The
+# proxy URL is recorded in manifest.json so you can tell which runs were
+# proxied after the fact.
+uv run scripts/benchmark_run.py \
+    --scenarios benchmark/scenarios.example.yaml \
+    --tasks benchmark/tasks.csv \
+    --task weather-nyc-week-coldest --task weather-nyc \
+    --llm-proxy-url https://<random>.trycloudflare.com
+```
+
+Each line in `output/llm-proxy/proxy_<ts>.jsonl` is one OpenAI call with
+timestamps, endpoint, status, request body (messages, tool defs, model
+name), and response body. Diff `request.messages[*].content` across guarded
+vs. baseline runs of the same task to see exactly what each scenario is
+shipping to the model.
+
+When `--llm-proxy-url` is set, the Browserbase Model Gateway is bypassed:
+the agent's LLM cost falls on `OPENAI_API_KEY`, not `BROWSERBASE_API_KEY`.
+
 ## Filtering
 
 Both scripts accept glob filters for partial runs:
@@ -156,7 +210,16 @@ uv run scripts/benchmark_run.py ... --scenario 'haiku-*' --task 'hn-*'
   Browserbase starts 429ing.
 - Token / cost numbers depend on Stagehand emitting usage in its event stream.
   If a row has `tokens_missing: true`, inspect the matching
-  `events/<scenario>_<task>_r<n>.jsonl` and adjust the parser.
+  `events/<scenario>_<task>_r<n>.jsonl` and adjust the parser. Stagehand's
+  normalized `usage` block also carries `cached_input_tokens` and
+  `reasoning_tokens`, which the runner aggregates as `tokens.cached` /
+  `tokens.reasoning` (Anthropic's `cache_creation_input_tokens` shows up as
+  `tokens.cache_creation` when applicable). The scoreboard surfaces a
+  scenario-level **Cache hit %** column; a low ratio under guard often means
+  the running prefix mutates between steps and is busting prompt caching.
+  To populate cached / reasoning fields on rows written before the runner
+  tracked them, run `benchmark_report.py --backfill-tokens` — it re-reads
+  `events/*.jsonl` locally (no LLM calls).
 - The per-task matrix shows each cell as a pass/fail ratio across the N
   repetitions (e.g. `2/3 pass`), with the most-common extracted answer above the
   fold and per-rep details (response + judge reason + session link) under an

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -152,21 +152,23 @@ shipped to the model (system prompt, tool defs, accumulated history, the
 rendered a11y tree per step), route the agent calls through
 `scripts/llm_proxy.py`.
 
-`scripts/llm_proxy.py` is a small OpenAI-compatible FastAPI proxy that forwards
-`POST /v1/*` to OpenAI and logs each request/response pair to a JSONL file.
-Browserbase's backend (not your laptop) is what calls the LLM, so the proxy has
-to be reachable from the public internet — pair it with `cloudflared` or
-`ngrok`.
+`scripts/llm_proxy.py` is a small FastAPI proxy that forwards `POST /v1/*` to
+OpenRouter (which speaks the OpenAI wire format) and logs each request/response
+pair to a JSONL file. Browserbase's backend (not your laptop) is what calls the
+LLM, so the proxy has to be reachable from the public internet — pair it with
+`cloudflared` or `ngrok`.
 
 Only the agent's traffic is proxied. The judge/extractor in `scripts/_judge.py`
-keep calling OpenAI directly with `OPENAI_API_KEY` and are *not* logged. OpenAI
-is the only upstream supported today.
+keep calling OpenAI directly with `OPENAI_API_KEY` and are *not* logged.
+OpenRouter accepts the provider-prefixed model slugs the scenarios file already
+uses (e.g. `openai/gpt-5-mini`, `anthropic/claude-haiku-4-5`,
+`google/gemini-2.5-flash`), so no scenario edits are needed.
 
 ```bash
 # Terminal 1 — start the local proxy. Logs land in
 # output/llm-proxy/proxy_<utc_ts>.jsonl unless --out overrides.
 uv run scripts/llm_proxy.py
-# → upstream: https://api.openai.com
+# → upstream: https://openrouter.ai/api
 # → log: output/llm-proxy/proxy_<utc_ts>.jsonl
 # → listening on http://127.0.0.1:8787
 
@@ -175,7 +177,7 @@ cloudflared tunnel --url http://127.0.0.1:8787
 # → prints https://<random>.trycloudflare.com
 
 # Terminal 3 — run the benchmark with --llm-proxy-url pointing at the tunnel.
-# Requires OPENAI_API_KEY in env (forwarded as the agent's api_key). The
+# Requires OPENROUTER_API_KEY in env (forwarded as the agent's api_key). The
 # proxy URL is recorded in manifest.json so you can tell which runs were
 # proxied after the fact.
 uv run scripts/benchmark_run.py \
@@ -185,14 +187,14 @@ uv run scripts/benchmark_run.py \
     --llm-proxy-url https://<random>.trycloudflare.com
 ```
 
-Each line in `output/llm-proxy/proxy_<ts>.jsonl` is one OpenAI call with
+Each line in `output/llm-proxy/proxy_<ts>.jsonl` is one OpenRouter call with
 timestamps, endpoint, status, request body (messages, tool defs, model name),
 and response body. Diff `request.messages[*].content` across guarded vs.
 baseline runs of the same task to see exactly what each scenario is shipping to
 the model.
 
 When `--llm-proxy-url` is set, the Browserbase Model Gateway is bypassed: the
-agent's LLM cost falls on `OPENAI_API_KEY`, not `BROWSERBASE_API_KEY`.
+agent's LLM cost falls on `OPENROUTER_API_KEY`, not `BROWSERBASE_API_KEY`.
 
 ## Filtering
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -122,6 +122,24 @@ Hand a regressed task's trace dir
 `steps.json` carries the per-step reasoning + a11y-tree snapshots needed to
 explain the divergence.
 
+### Iterating on one task with two scenarios
+
+When you're actively iterating on a guarded rule and want a tight
+edit-run-diagnose loop instead of re-running the full matrix, use
+`compare_scenarios.py`. It runs `benchmark_run.py` for exactly two scenarios ×
+one task × N reps, builds the trace bundles + HTML diff, and writes a
+Markdown digest (`output/results/<run_id>/cost_diff.md`) that highlights what
+drove the cost/token delta — step count, a11y-tree byte size, paired step
+divergences — so a coding agent can read it directly.
+
+```bash
+uv run scripts/compare_scenarios.py \
+    --scenario gpt5-mini-baseline \
+    --scenario gpt5-mini-guarded \
+    --task arxiv-recent-cs-ai \
+    -n 3 --open
+```
+
 ## Filtering
 
 Both scripts accept glob filters for partial runs:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -127,10 +127,10 @@ explain the divergence.
 When you're actively iterating on a guarded rule and want a tight
 edit-run-diagnose loop instead of re-running the full matrix, use
 `compare_scenarios.py`. It runs `benchmark_run.py` for exactly two scenarios ×
-one task × N reps, builds the trace bundles + HTML diff, and writes a
-Markdown digest (`output/results/<run_id>/cost_diff.md`) that highlights what
-drove the cost/token delta — step count, a11y-tree byte size, paired step
-divergences — so a coding agent can read it directly.
+one task × N reps, builds the trace bundles + HTML diff, and writes a Markdown
+digest (`output/results/<run_id>/cost_diff.md`) that highlights what drove the
+cost/token delta — step count, a11y-tree byte size, paired step divergences — so
+a coding agent can read it directly.
 
 ```bash
 uv run scripts/compare_scenarios.py \
@@ -140,27 +140,27 @@ uv run scripts/compare_scenarios.py \
     -n 3 --open
 ```
 
-Pass `--llm-proxy-url <tunnel>` to also capture the exact LLM messages per
-call (see below); the digest will point at the proxy log when it's enabled.
+Pass `--llm-proxy-url <tunnel>` to also capture the exact LLM messages per call
+(see below); the digest will point at the proxy log when it's enabled.
 
 ## Capturing the LLM messages (proxy)
 
-By default Stagehand's event stream redacts the rendered a11y tree and
-system prompt — only token counts and the model's final action survive in
+By default Stagehand's event stream redacts the rendered a11y tree and system
+prompt — only token counts and the model's final action survive in
 `events/*.jsonl`. When you need to see the *exact* messages array Browserbase
 shipped to the model (system prompt, tool defs, accumulated history, the
 rendered a11y tree per step), route the agent calls through
 `scripts/llm_proxy.py`.
 
-`scripts/llm_proxy.py` is a small OpenAI-compatible FastAPI proxy that
-forwards `POST /v1/*` to OpenAI and logs each request/response pair to a
-JSONL file. Browserbase's backend (not your laptop) is what calls the LLM,
-so the proxy has to be reachable from the public internet — pair it with
-`cloudflared` or `ngrok`.
+`scripts/llm_proxy.py` is a small OpenAI-compatible FastAPI proxy that forwards
+`POST /v1/*` to OpenAI and logs each request/response pair to a JSONL file.
+Browserbase's backend (not your laptop) is what calls the LLM, so the proxy has
+to be reachable from the public internet — pair it with `cloudflared` or
+`ngrok`.
 
-Only the agent's traffic is proxied. The judge/extractor in
-`scripts/_judge.py` keep calling OpenAI directly with `OPENAI_API_KEY` and
-are *not* logged. OpenAI is the only upstream supported today.
+Only the agent's traffic is proxied. The judge/extractor in `scripts/_judge.py`
+keep calling OpenAI directly with `OPENAI_API_KEY` and are *not* logged. OpenAI
+is the only upstream supported today.
 
 ```bash
 # Terminal 1 — start the local proxy. Logs land in
@@ -186,13 +186,13 @@ uv run scripts/benchmark_run.py \
 ```
 
 Each line in `output/llm-proxy/proxy_<ts>.jsonl` is one OpenAI call with
-timestamps, endpoint, status, request body (messages, tool defs, model
-name), and response body. Diff `request.messages[*].content` across guarded
-vs. baseline runs of the same task to see exactly what each scenario is
-shipping to the model.
+timestamps, endpoint, status, request body (messages, tool defs, model name),
+and response body. Diff `request.messages[*].content` across guarded vs.
+baseline runs of the same task to see exactly what each scenario is shipping to
+the model.
 
-When `--llm-proxy-url` is set, the Browserbase Model Gateway is bypassed:
-the agent's LLM cost falls on `OPENAI_API_KEY`, not `BROWSERBASE_API_KEY`.
+When `--llm-proxy-url` is set, the Browserbase Model Gateway is bypassed: the
+agent's LLM cost falls on `OPENAI_API_KEY`, not `BROWSERBASE_API_KEY`.
 
 ## Filtering
 
@@ -215,10 +215,10 @@ uv run scripts/benchmark_run.py ... --scenario 'haiku-*' --task 'hn-*'
   `reasoning_tokens`, which the runner aggregates as `tokens.cached` /
   `tokens.reasoning` (Anthropic's `cache_creation_input_tokens` shows up as
   `tokens.cache_creation` when applicable). The scoreboard surfaces a
-  scenario-level **Cache hit %** column; a low ratio under guard often means
-  the running prefix mutates between steps and is busting prompt caching.
-  To populate cached / reasoning fields on rows written before the runner
-  tracked them, run `benchmark_report.py --backfill-tokens` — it re-reads
+  scenario-level **Cache hit %** column; a low ratio under guard often means the
+  running prefix mutates between steps and is busting prompt caching. To
+  populate cached / reasoning fields on rows written before the runner tracked
+  them, run `benchmark_report.py --backfill-tokens` — it re-reads
   `events/*.jsonl` locally (no LLM calls).
 - The per-task matrix shows each cell as a pass/fail ratio across the N
   repetitions (e.g. `2/3 pass`), with the most-common extracted answer above the

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -152,23 +152,23 @@ shipped to the model (system prompt, tool defs, accumulated history, the
 rendered a11y tree per step), route the agent calls through
 `scripts/llm_proxy.py`.
 
-`scripts/llm_proxy.py` is a small FastAPI proxy that forwards `POST /v1/*` to
-OpenRouter (which speaks the OpenAI wire format) and logs each request/response
-pair to a JSONL file. Browserbase's backend (not your laptop) is what calls the
-LLM, so the proxy has to be reachable from the public internet — pair it with
-`cloudflared` or `ngrok`.
+`scripts/llm_proxy.py` is a small FastAPI proxy that forwards `/v1/*` to OpenAI
+and logs each request/response pair to a JSONL file. Browserbase's backend (not
+your laptop) is what calls the LLM, so the proxy has to be reachable from the
+public internet — pair it with `cloudflared` or `ngrok`.
 
 Only the agent's traffic is proxied. The judge/extractor in `scripts/_judge.py`
-keep calling OpenAI directly with `OPENAI_API_KEY` and are *not* logged.
-OpenRouter accepts the provider-prefixed model slugs the scenarios file already
-uses (e.g. `openai/gpt-5-mini`, `anthropic/claude-haiku-4-5`,
-`google/gemini-2.5-flash`), so no scenario edits are needed.
+keep calling OpenAI directly with `OPENAI_API_KEY` and are *not* logged. OpenAI
+is the only fully-supported upstream today — OpenRouter accepts most
+chat-completions traffic but its `/v1/responses` schema rejects the `reasoning`
+items Stagehand re-sends across multi-turn agent runs, so multi-step tasks 400
+after the first turn.
 
 ```bash
 # Terminal 1 — start the local proxy. Logs land in
 # output/llm-proxy/proxy_<utc_ts>.jsonl unless --out overrides.
 uv run scripts/llm_proxy.py
-# → upstream: https://openrouter.ai/api
+# → upstream: https://api.openai.com
 # → log: output/llm-proxy/proxy_<utc_ts>.jsonl
 # → listening on http://127.0.0.1:8787
 
@@ -177,7 +177,7 @@ cloudflared tunnel --url http://127.0.0.1:8787
 # → prints https://<random>.trycloudflare.com
 
 # Terminal 3 — run the benchmark with --llm-proxy-url pointing at the tunnel.
-# Requires OPENROUTER_API_KEY in env (forwarded as the agent's api_key). The
+# Requires OPENAI_API_KEY in env (forwarded as the agent's api_key). The
 # proxy URL is recorded in manifest.json so you can tell which runs were
 # proxied after the fact.
 uv run scripts/benchmark_run.py \
@@ -187,14 +187,14 @@ uv run scripts/benchmark_run.py \
     --llm-proxy-url https://<random>.trycloudflare.com
 ```
 
-Each line in `output/llm-proxy/proxy_<ts>.jsonl` is one OpenRouter call with
+Each line in `output/llm-proxy/proxy_<ts>.jsonl` is one OpenAI call with
 timestamps, endpoint, status, request body (messages, tool defs, model name),
 and response body. Diff `request.messages[*].content` across guarded vs.
 baseline runs of the same task to see exactly what each scenario is shipping to
 the model.
 
 When `--llm-proxy-url` is set, the Browserbase Model Gateway is bypassed: the
-agent's LLM cost falls on `OPENROUTER_API_KEY`, not `BROWSERBASE_API_KEY`.
+agent's LLM cost falls on `OPENAI_API_KEY`, not `BROWSERBASE_API_KEY`.
 
 ## Filtering
 

--- a/scripts/_stagehand.py
+++ b/scripts/_stagehand.py
@@ -84,6 +84,110 @@ def event_to_dict(event: Any) -> Any:
     return str(event)
 
 
+def extract_usage(payload: Any) -> dict[str, int] | None:
+    """Walk an event payload looking for token-usage fields. Stagehand wraps
+    LLM call usage in different shapes across event types; this is defensive.
+
+    Cache and reasoning fields are gathered across providers:
+      - OpenAI: `cached_input_tokens` (Stagehand-normalized) or nested
+        `prompt_tokens_details.cached_tokens` / `completion_tokens_details.reasoning_tokens`.
+      - Anthropic: `cache_read_input_tokens` (cache hits, billed at a discount)
+        and `cache_creation_input_tokens` (cache writes, billed at a premium).
+      - Gemini: `cached_content_token_count` / `cachedContentTokenCount`.
+
+    Stagehand's gateway already maps the per-provider field into
+    `cached_input_tokens` in `usage` for routed calls, but we still search
+    the raw provider names so direct-provider events (and future schema
+    drift) work without code changes.
+    """
+    if not isinstance(payload, dict):
+        return None
+
+    def find(key_names: tuple[str, ...]) -> Any:
+        # Breadth-first hunt for the first matching key anywhere in the tree.
+        stack: list[Any] = [payload]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, dict):
+                for key in key_names:
+                    if key in node:
+                        return node[key]
+                stack.extend(node.values())
+            elif isinstance(node, list):
+                stack.extend(node)
+        return None
+
+    def find_in(root: Any, key_names: tuple[str, ...]) -> Any:
+        stack: list[Any] = [root]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, dict):
+                for key in key_names:
+                    if key in node:
+                        return node[key]
+                stack.extend(node.values())
+            elif isinstance(node, list):
+                stack.extend(node)
+        return None
+
+    usage_block = find(("usage", "token_usage", "tokenUsage"))
+    if not isinstance(usage_block, dict):
+        return None
+    input_tok = (
+        usage_block.get("input_tokens")
+        or usage_block.get("inputTokens")
+        or usage_block.get("prompt_tokens")
+        or usage_block.get("promptTokens")
+        or usage_block.get("prompt_token_count")
+        or usage_block.get("promptTokenCount")
+    )
+    output_tok = (
+        usage_block.get("output_tokens")
+        or usage_block.get("outputTokens")
+        or usage_block.get("completion_tokens")
+        or usage_block.get("completionTokens")
+        or usage_block.get("candidates_token_count")
+        or usage_block.get("candidatesTokenCount")
+    )
+    if input_tok is None and output_tok is None:
+        return None
+    input_n = int(input_tok or 0)
+    output_n = int(output_tok or 0)
+    cached_tok = find_in(
+        usage_block,
+        (
+            "cached_input_tokens",
+            "cachedInputTokens",
+            "cache_read_input_tokens",
+            "cacheReadInputTokens",
+            "cached_tokens",
+            "cachedTokens",
+            "cached_content_token_count",
+            "cachedContentTokenCount",
+        ),
+    )
+    cache_creation_tok = find_in(
+        usage_block,
+        ("cache_creation_input_tokens", "cacheCreationInputTokens"),
+    )
+    reasoning_tok = find_in(
+        usage_block,
+        ("reasoning_tokens", "reasoningTokens"),
+    )
+    result: dict[str, int] = {
+        "input": input_n,
+        "output": output_n,
+        "total": input_n + output_n,
+    }
+    if cached_tok is not None:
+        result["cached"] = int(cached_tok or 0)
+    if cache_creation_tok is not None:
+        result["cache_creation"] = int(cache_creation_tok or 0)
+    if reasoning_tok is not None:
+        result["reasoning"] = int(reasoning_tok or 0)
+    return result
+
+
 def format_event(event: Any) -> str:
     try:
         return json.dumps(event_to_dict(event), indent=2, default=str, sort_keys=True)

--- a/scripts/benchmark_report.py
+++ b/scripts/benchmark_report.py
@@ -58,6 +58,7 @@ from _judge import (  # noqa: E402
     load_judge_defaults_from_scenarios,
     resolve_judge_model,
 )
+from _stagehand import event_to_dict, extract_usage  # noqa: E402
 
 # ---------- Argument parsing ----------
 
@@ -98,6 +99,13 @@ def parse_args() -> argparse.Namespace:
         "--redetect",
         action="store_true",
         help="With --detect-blocks, re-detect rows that already have a blocked_by_defense verdict.",
+    )
+    parser.add_argument(
+        "--backfill-tokens",
+        action="store_true",
+        help="Re-aggregate token usage (input/output/cached/cache_creation/"
+        "reasoning) from each row's event log. Use to add cached/reasoning "
+        "fields to rows written before they were tracked. No LLM calls.",
     )
     parser.add_argument(
         "--judge-model",
@@ -408,6 +416,7 @@ def scenario_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
     total_tokens: list[int] = []
     input_tokens: list[int] = []
     output_tokens: list[int] = []
+    cached_tokens: list[int] = []
     costs: list[float] = []
     pass_costs: list[float] = []
     steps: list[int] = []
@@ -436,6 +445,8 @@ def scenario_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
             input_tokens.append(int(toks["input"]))
         if toks.get("output") is not None:
             output_tokens.append(int(toks["output"]))
+        if toks.get("cached") is not None:
+            cached_tokens.append(int(toks["cached"]))
         cost = r.get("cost_usd")
         if cost is not None:
             costs.append(float(cost))
@@ -457,12 +468,19 @@ def scenario_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "total_tokens": _total(total_tokens),
         "total_input_tokens": _total(input_tokens),
         "total_output_tokens": _total(output_tokens),
+        "total_cached_tokens": _total(cached_tokens),
         "total_cost": _total(costs),
         "total_steps": _total(steps),
         "total_duration": _total(durations),
         "avg_tokens": _avg(total_tokens),
         "avg_input_tokens": _avg(input_tokens),
         "avg_output_tokens": _avg(output_tokens),
+        "avg_cached_tokens": _avg(cached_tokens),
+        "cache_hit_pct": (
+            100.0 * sum(cached_tokens) / sum(input_tokens)
+            if cached_tokens and sum(input_tokens) > 0
+            else None
+        ),
         "avg_cost": _avg(costs),
         "avg_cost_pass": _avg(pass_costs),
         "avg_cost_pass_n": len(pass_costs),
@@ -625,6 +643,58 @@ def run_block_detector(
         process=process,
         judge_model=judge_model,
     )
+
+
+def run_backfill_tokens(results_path: Path, rows: list[dict[str, Any]]) -> int:
+    """Re-aggregate token usage from each row's event log.
+
+    Reads `events/{scenario}_{task}_r{rep}.jsonl`, applies `extract_usage` to
+    each event, sums input/output/cached/cache_creation/reasoning, and writes
+    the merged `tokens` dict back to the row. Pure local work — no LLM calls.
+    """
+    events_dir = results_path.parent / "events"
+    if not events_dir.is_dir():
+        print(f"no events directory at {events_dir}; nothing to backfill")
+        return 0
+
+    updated = 0
+    for row in rows:
+        event_path = events_dir / build_traces.events_filename(
+            row.get("scenario_id") or "",
+            row.get("task_id") or "",
+            _rep_index(row),
+        )
+        if not event_path.is_file():
+            continue
+        agg: dict[str, int] = {"input": 0, "output": 0, "total": 0}
+        agg_opt: dict[str, int] = {}
+        any_usage = False
+        for line in event_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event_dict = event_to_dict(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+            usage = extract_usage(event_dict)
+            if not usage:
+                continue
+            any_usage = True
+            agg["input"] += usage["input"]
+            agg["output"] += usage["output"]
+            agg["total"] += usage["total"]
+            for k in ("cached", "cache_creation", "reasoning"):
+                if k in usage:
+                    agg_opt[k] = agg_opt.get(k, 0) + usage[k]
+        if any_usage:
+            row["tokens"] = {**agg, **agg_opt}
+            row["tokens_missing"] = False
+            updated += 1
+
+    write_jsonl_atomic(results_path, rows)
+    print(f"backfilled tokens on {updated} rows")
+    return updated
 
 
 # ---------- Prompt builders ----------
@@ -1036,9 +1106,10 @@ document.querySelectorAll('.copy-prompt').forEach(function(btn){
 """
 
 
-def _dual_th(total_label: str, avg_label: str) -> str:
+def _dual_th(total_label: str, avg_label: str, *, title: str | None = None) -> str:
+    title_attr = f" title='{html.escape(title)}'" if title else ""
     return (
-        "<th class='num'>"
+        f"<th class='num'{title_attr}>"
         f"<span class='v-total'>{html.escape(total_label)}</span>"
         f"<span class='v-avg'>{html.escape(avg_label)}</span>"
         "</th>"
@@ -1334,6 +1405,22 @@ def _render_scoreboard(
         + _dual_th("Total tokens", "Avg tokens")
         + _dual_th("Total input", "Avg input")
         + _dual_th("Total output", "Avg output")
+        + _dual_th(
+            "Total cached",
+            "Avg cached",
+            title=(
+                "Cache-read input tokens (Stagehand-normalized across providers: "
+                "OpenAI cached_input_tokens, Anthropic cache_read_input_tokens, "
+                "Gemini cachedContentTokenCount). Does NOT reduce the model's "
+                "input-token limit — only billing/latency."
+            ),
+        )
+        + (
+            "<th class='num' title='Share of input tokens served from cache "
+            "across all runs in the scenario. Low values often mean the running "
+            "prefix mutates between steps (e.g., DOM markers re-applied each "
+            "turn).'>Cache hit %</th>"
+        )
         + _dual_th("Total cost", "Avg cost")
         + (
             "<th class='num v-avg' title='Average cost across runs that "
@@ -1367,6 +1454,12 @@ def _render_scoreboard(
         parts.append(
             _dual_cell(fmt_int(summ["total_output_tokens"]), fmt_int(summ["avg_output_tokens"]))
         )
+        parts.append(
+            _dual_cell(fmt_int(summ["total_cached_tokens"]), fmt_int(summ["avg_cached_tokens"]))
+        )
+        hit_pct = summ.get("cache_hit_pct")
+        hit_html = "—" if hit_pct is None else f"{hit_pct:.1f}%"
+        parts.append(f"<td class='num'>{hit_html}</td>")
         parts.append(_dual_cell(fmt_money(summ["total_cost"]), fmt_money(summ["avg_cost"])))
         pass_n = summ["avg_cost_pass_n"]
         pass_cost_html = fmt_money(summ["avg_cost_pass"])
@@ -1751,6 +1844,10 @@ def main() -> int:
 
     manifest = json.loads(manifest_path.read_text())
     rows = load_jsonl(results_path)
+
+    if args.backfill_tokens:
+        run_backfill_tokens(results_path, rows)
+        rows = load_jsonl(results_path)
 
     if args.judge or args.extract or args.detect_blocks:
         # Prefer the judge model the runner recorded in the manifest, then fall

--- a/scripts/benchmark_run.py
+++ b/scripts/benchmark_run.py
@@ -181,9 +181,9 @@ def parse_args() -> argparse.Namespace:
         help="Route Stagehand's agent LLM calls through this OpenAI-compatible "
         "endpoint (e.g. a cloudflared tunnel exposing scripts/llm_proxy.py) so "
         "the proxy can log the full messages array per step. Requires "
-        "OPENAI_API_KEY in env (forwarded as the agent's api_key). Only the "
-        "agent calls are proxied — judge/extractor continue calling OpenAI "
-        "directly.",
+        "OPENROUTER_API_KEY in env (forwarded as the agent's api_key). Only "
+        "the agent calls are proxied — judge/extractor continue calling "
+        "OpenAI directly with OPENAI_API_KEY.",
     )
     parser.add_argument("-v", "--verbose", action="count", default=0)
     return parser.parse_args()
@@ -473,31 +473,31 @@ class JsonlSink:
                 os.fsync(fh.fileno())
 
 
-def _agent_model_config(model: str, proxy_url: str | None, openai_api_key: str | None) -> Any:
+def _agent_model_config(model: str, proxy_url: str | None, openrouter_api_key: str | None) -> Any:
     """Build the `agent_config.model` value.
 
     When no proxy is configured, the model is passed as a string and Stagehand
     routes through the Browserbase Model Gateway (or `model_api_key` if set).
     When a proxy URL is configured, the model is a structured object whose
     `base_url` points at the proxy and whose `api_key` is the developer's
-    OpenAI key — Browserbase calls the proxy in place of OpenAI.
+    OpenRouter key — Browserbase calls the proxy in place of OpenRouter.
+
+    Model names are forwarded with their provider prefix intact (e.g.
+    `openai/gpt-5-mini`, `anthropic/claude-haiku-4-5`) because OpenRouter
+    expects the prefixed slug as its routing key.
     """
     if not proxy_url:
         return model
-    if not openai_api_key:
+    if not openrouter_api_key:
         sys.exit(
-            "--llm-proxy-url requires OPENAI_API_KEY in env (forwarded to the "
+            "--llm-proxy-url requires OPENROUTER_API_KEY in env (forwarded to the "
             "proxy as the agent's api_key)"
         )
-    # Stagehand accepts either an OpenAI-prefixed or a bare model name in this
-    # structured form; strip the `openai/` prefix because the proxy forwards
-    # to the real OpenAI API which expects the bare name in the request body.
-    bare = model.split("/", 1)[1] if model.startswith("openai/") else model
     return {
         "provider": "openai",
-        "modelName": bare,
+        "modelName": model,
         "baseURL": proxy_url.rstrip("/"),
-        "apiKey": openai_api_key,
+        "apiKey": openrouter_api_key,
     }
 
 
@@ -514,7 +514,7 @@ def run_one(
     results: JsonlSink,
     judge_model: str | None,
     llm_proxy_url: str | None = None,
-    openai_api_key: str | None = None,
+    openrouter_api_key: str | None = None,
 ) -> dict[str, Any]:
     """Run a single (scenario, task, repetition). Always writes one row to
     results.jsonl, even on failure."""
@@ -594,7 +594,7 @@ def run_one(
             for event in stagehand.sessions.execute(
                 id=session.id,
                 agent_config={
-                    "model": _agent_model_config(scenario.model, llm_proxy_url, openai_api_key)
+                    "model": _agent_model_config(scenario.model, llm_proxy_url, openrouter_api_key)
                 },
                 execute_options={
                     "instruction": task.task,
@@ -852,9 +852,9 @@ def main() -> int:
     if model_api_key is None:
         LOG.info("MODEL_API_KEY not set; routing agent via Browserbase Model Gateway")
 
-    openai_api_key = optional_env("OPENAI_API_KEY")
-    if args.llm_proxy_url and not openai_api_key:
-        sys.exit("--llm-proxy-url requires OPENAI_API_KEY in env")
+    openrouter_api_key = optional_env("OPENROUTER_API_KEY")
+    if args.llm_proxy_url and not openrouter_api_key:
+        sys.exit("--llm-proxy-url requires OPENROUTER_API_KEY in env")
     if args.llm_proxy_url:
         LOG.info("agent LLM calls routed through proxy: %s", args.llm_proxy_url)
 
@@ -889,7 +889,7 @@ def main() -> int:
                 results=results,
                 judge_model=judge_model,
                 llm_proxy_url=args.llm_proxy_url,
-                openai_api_key=openai_api_key,
+                openrouter_api_key=openrouter_api_key,
             ): unit
             for unit in work_units
         }

--- a/scripts/benchmark_run.py
+++ b/scripts/benchmark_run.py
@@ -482,9 +482,11 @@ def _agent_model_config(model: str, proxy_url: str | None, openrouter_api_key: s
     `base_url` points at the proxy and whose `api_key` is the developer's
     OpenRouter key — Browserbase calls the proxy in place of OpenRouter.
 
-    Model names are forwarded with their provider prefix intact (e.g.
-    `openai/gpt-5-mini`, `anthropic/claude-haiku-4-5`) because OpenRouter
-    expects the prefixed slug as its routing key.
+    The `openai/` provider prefix is stripped before handing the name to
+    Stagehand: with `provider: openai`, Stagehand validates the model against
+    OpenAI's catalog and rejects the prefixed form client-side ("Failed to
+    execute task: Not Found"). The proxy re-prefixes the bare name when
+    forwarding to OpenRouter, which needs the prefix as its routing key.
     """
     if not proxy_url:
         return model
@@ -493,9 +495,10 @@ def _agent_model_config(model: str, proxy_url: str | None, openrouter_api_key: s
             "--llm-proxy-url requires OPENROUTER_API_KEY in env (forwarded to the "
             "proxy as the agent's api_key)"
         )
+    bare = model.split("/", 1)[1] if model.startswith("openai/") else model
     return {
         "provider": "openai",
-        "modelName": model,
+        "modelName": bare,
         "baseURL": proxy_url.rstrip("/"),
         "apiKey": openrouter_api_key,
     }

--- a/scripts/benchmark_run.py
+++ b/scripts/benchmark_run.py
@@ -75,6 +75,7 @@ from _stagehand import (
     LOG,
     configure_logging,
     event_to_dict,
+    extract_usage,
     optional_env,
     require_env,
 )
@@ -173,6 +174,16 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Skip the inline judge call after each task. Use benchmark_report.py "
         "--judge to grade later.",
+    )
+    parser.add_argument(
+        "--llm-proxy-url",
+        default=None,
+        help="Route Stagehand's agent LLM calls through this OpenAI-compatible "
+        "endpoint (e.g. a cloudflared tunnel exposing scripts/llm_proxy.py) so "
+        "the proxy can log the full messages array per step. Requires "
+        "OPENAI_API_KEY in env (forwarded as the agent's api_key). Only the "
+        "agent calls are proxied — judge/extractor continue calling OpenAI "
+        "directly.",
     )
     parser.add_argument("-v", "--verbose", action="count", default=0)
     return parser.parse_args()
@@ -407,46 +418,8 @@ def compute_cost(
     return round(cost, 6), False
 
 
-def extract_usage(payload: Any) -> dict[str, int] | None:
-    """Walk an event payload looking for token-usage fields. Stagehand wraps
-    LLM call usage in different shapes across event types; this is defensive."""
-    if not isinstance(payload, dict):
-        return None
-
-    def find(key_names: tuple[str, ...]) -> Any:
-        # Breadth-first hunt for the first matching key anywhere in the tree.
-        stack: list[Any] = [payload]
-        while stack:
-            node = stack.pop()
-            if isinstance(node, dict):
-                for key in key_names:
-                    if key in node:
-                        return node[key]
-                stack.extend(node.values())
-            elif isinstance(node, list):
-                stack.extend(node)
-        return None
-
-    usage_block = find(("usage", "token_usage", "tokenUsage"))
-    if isinstance(usage_block, dict):
-        input_tok = (
-            usage_block.get("input_tokens")
-            or usage_block.get("inputTokens")
-            or usage_block.get("prompt_tokens")
-            or usage_block.get("promptTokens")
-        )
-        output_tok = (
-            usage_block.get("output_tokens")
-            or usage_block.get("outputTokens")
-            or usage_block.get("completion_tokens")
-            or usage_block.get("completionTokens")
-        )
-        if input_tok is None and output_tok is None:
-            return None
-        input_n = int(input_tok or 0)
-        output_n = int(output_tok or 0)
-        return {"input": input_n, "output": output_n, "total": input_n + output_n}
-    return None
+# extract_usage lives in _stagehand.py so benchmark_report can re-aggregate
+# token usage from events/*.jsonl without pulling in the Stagehand SDK.
 
 
 def event_type_of(payload: Any) -> str | None:
@@ -500,6 +473,34 @@ class JsonlSink:
                 os.fsync(fh.fileno())
 
 
+def _agent_model_config(model: str, proxy_url: str | None, openai_api_key: str | None) -> Any:
+    """Build the `agent_config.model` value.
+
+    When no proxy is configured, the model is passed as a string and Stagehand
+    routes through the Browserbase Model Gateway (or `model_api_key` if set).
+    When a proxy URL is configured, the model is a structured object whose
+    `base_url` points at the proxy and whose `api_key` is the developer's
+    OpenAI key — Browserbase calls the proxy in place of OpenAI.
+    """
+    if not proxy_url:
+        return model
+    if not openai_api_key:
+        sys.exit(
+            "--llm-proxy-url requires OPENAI_API_KEY in env (forwarded to the "
+            "proxy as the agent's api_key)"
+        )
+    # Stagehand accepts either an OpenAI-prefixed or a bare model name in this
+    # structured form; strip the `openai/` prefix because the proxy forwards
+    # to the real OpenAI API which expects the bare name in the request body.
+    bare = model.split("/", 1)[1] if model.startswith("openai/") else model
+    return {
+        "provider": "openai",
+        "modelName": bare,
+        "baseURL": proxy_url.rstrip("/"),
+        "apiKey": openai_api_key,
+    }
+
+
 def run_one(
     unit: WorkUnit,
     *,
@@ -512,6 +513,8 @@ def run_one(
     events_dir: Path,
     results: JsonlSink,
     judge_model: str | None,
+    llm_proxy_url: str | None = None,
+    openai_api_key: str | None = None,
 ) -> dict[str, Any]:
     """Run a single (scenario, task, repetition). Always writes one row to
     results.jsonl, even on failure."""
@@ -580,7 +583,8 @@ def run_one(
         if task.url:
             stagehand.sessions.navigate(id=session.id, url=task.url)
 
-        agg_tokens = {"input": 0, "output": 0, "total": 0}
+        agg_tokens: dict[str, int] = {"input": 0, "output": 0, "total": 0}
+        agg_optional: dict[str, int] = {}
         any_usage = False
         steps = 0
         final_answer: str | None = None
@@ -589,7 +593,11 @@ def run_one(
         with event_path.open("w", encoding="utf-8") as event_fh:
             for event in stagehand.sessions.execute(
                 id=session.id,
-                agent_config={"model": scenario.model},
+                agent_config={
+                    "model": _agent_model_config(
+                        scenario.model, llm_proxy_url, openai_api_key
+                    )
+                },
                 execute_options={
                     "instruction": task.task,
                     "maxSteps": effective_max_steps,
@@ -616,12 +624,15 @@ def run_one(
                     agg_tokens["input"] += usage["input"]
                     agg_tokens["output"] += usage["output"]
                     agg_tokens["total"] += usage["total"]
+                    for opt_key in ("cached", "cache_creation", "reasoning"):
+                        if opt_key in usage:
+                            agg_optional[opt_key] = agg_optional.get(opt_key, 0) + usage[opt_key]
 
         record["steps_taken"] = steps
         record["completed_within_budget"] = result_completed and steps <= effective_max_steps
         record["final_answer"] = final_answer
         if any_usage:
-            record["tokens"] = agg_tokens
+            record["tokens"] = {**agg_tokens, **agg_optional}
             record["tokens_missing"] = False
         cost, pricing_missing = compute_cost(scenario.model, record["tokens"], pricing)
         record["cost_usd"] = cost
@@ -784,6 +795,7 @@ def main() -> int:
         "concurrency": args.concurrency,
         "repetitions": repetitions,
         "judge_model": judge_model,
+        "llm_proxy_url": args.llm_proxy_url,
         "scenarios": [
             {
                 "id": s.id,
@@ -842,6 +854,12 @@ def main() -> int:
     if model_api_key is None:
         LOG.info("MODEL_API_KEY not set; routing agent via Browserbase Model Gateway")
 
+    openai_api_key = optional_env("OPENAI_API_KEY")
+    if args.llm_proxy_url and not openai_api_key:
+        sys.exit("--llm-proxy-url requires OPENAI_API_KEY in env")
+    if args.llm_proxy_url:
+        LOG.info("agent LLM calls routed through proxy: %s", args.llm_proxy_url)
+
     extension_id: str | None = None
     if needs_extension:
         bb = Browserbase(api_key=bb_api_key)
@@ -872,6 +890,8 @@ def main() -> int:
                 events_dir=events_dir,
                 results=results,
                 judge_model=judge_model,
+                llm_proxy_url=args.llm_proxy_url,
+                openai_api_key=openai_api_key,
             ): unit
             for unit in work_units
         }

--- a/scripts/benchmark_run.py
+++ b/scripts/benchmark_run.py
@@ -181,7 +181,7 @@ def parse_args() -> argparse.Namespace:
         help="Route Stagehand's agent LLM calls through this OpenAI-compatible "
         "endpoint (e.g. a cloudflared tunnel exposing scripts/llm_proxy.py) so "
         "the proxy can log the full messages array per step. Requires "
-        "OPENROUTER_API_KEY in env (forwarded as the agent's api_key). Only "
+        "OPENAI_API_KEY in env (forwarded as the agent's api_key). Only "
         "the agent calls are proxied — judge/extractor continue calling "
         "OpenAI directly with OPENAI_API_KEY.",
     )
@@ -473,34 +473,41 @@ class JsonlSink:
                 os.fsync(fh.fileno())
 
 
-def _agent_model_config(model: str, proxy_url: str | None, openrouter_api_key: str | None) -> Any:
+def _agent_model_config(model: str, proxy_url: str | None, openai_api_key: str | None) -> Any:
     """Build the `agent_config.model` value.
 
     When no proxy is configured, the model is passed as a string and Stagehand
     routes through the Browserbase Model Gateway (or `model_api_key` if set).
     When a proxy URL is configured, the model is a structured object whose
     `base_url` points at the proxy and whose `api_key` is the developer's
-    OpenRouter key — Browserbase calls the proxy in place of OpenRouter.
+    OpenAI key — Browserbase calls the proxy in place of OpenAI.
 
-    The `openai/` provider prefix is stripped before handing the name to
-    Stagehand: with `provider: openai`, Stagehand validates the model against
-    OpenAI's catalog and rejects the prefixed form client-side ("Failed to
-    execute task: Not Found"). The proxy re-prefixes the bare name when
-    forwarding to OpenRouter, which needs the prefix as its routing key.
+    The model name keeps its `openai/` prefix: Stagehand's ModelConfigParam
+    rejects bare names with UnsupportedModelError 422. The proxy strips the
+    prefix before forwarding to the real OpenAI API, which expects bare
+    names.
+
+    The proxy URL is suffixed with `/v1` before handing it to Stagehand:
+    Stagehand uses the OpenAI Responses API and calls `<baseURL>/responses`
+    (the SDK's convention is that `base_url` already includes the API
+    version), so without `/v1` the request lands at `/responses` and the
+    proxy 404s. Users pass the bare tunnel root.
+
+    `provider` is omitted because passing both `provider` and `baseURL`
+    makes Stagehand validate against the built-in provider's catalog
+    instead of routing through the custom endpoint.
     """
     if not proxy_url:
         return model
-    if not openrouter_api_key:
+    if not openai_api_key:
         sys.exit(
-            "--llm-proxy-url requires OPENROUTER_API_KEY in env (forwarded to the "
+            "--llm-proxy-url requires OPENAI_API_KEY in env (forwarded to the "
             "proxy as the agent's api_key)"
         )
-    bare = model.split("/", 1)[1] if model.startswith("openai/") else model
     return {
-        "provider": "openai",
-        "modelName": bare,
-        "baseURL": proxy_url.rstrip("/"),
-        "apiKey": openrouter_api_key,
+        "modelName": model,
+        "baseURL": proxy_url.rstrip("/") + "/v1",
+        "apiKey": openai_api_key,
     }
 
 
@@ -517,7 +524,7 @@ def run_one(
     results: JsonlSink,
     judge_model: str | None,
     llm_proxy_url: str | None = None,
-    openrouter_api_key: str | None = None,
+    openai_api_key: str | None = None,
 ) -> dict[str, Any]:
     """Run a single (scenario, task, repetition). Always writes one row to
     results.jsonl, even on failure."""
@@ -597,7 +604,7 @@ def run_one(
             for event in stagehand.sessions.execute(
                 id=session.id,
                 agent_config={
-                    "model": _agent_model_config(scenario.model, llm_proxy_url, openrouter_api_key)
+                    "model": _agent_model_config(scenario.model, llm_proxy_url, openai_api_key)
                 },
                 execute_options={
                     "instruction": task.task,
@@ -855,9 +862,9 @@ def main() -> int:
     if model_api_key is None:
         LOG.info("MODEL_API_KEY not set; routing agent via Browserbase Model Gateway")
 
-    openrouter_api_key = optional_env("OPENROUTER_API_KEY")
-    if args.llm_proxy_url and not openrouter_api_key:
-        sys.exit("--llm-proxy-url requires OPENROUTER_API_KEY in env")
+    openai_api_key = optional_env("OPENAI_API_KEY")
+    if args.llm_proxy_url and not openai_api_key:
+        sys.exit("--llm-proxy-url requires OPENAI_API_KEY in env")
     if args.llm_proxy_url:
         LOG.info("agent LLM calls routed through proxy: %s", args.llm_proxy_url)
 
@@ -892,7 +899,7 @@ def main() -> int:
                 results=results,
                 judge_model=judge_model,
                 llm_proxy_url=args.llm_proxy_url,
-                openrouter_api_key=openrouter_api_key,
+                openai_api_key=openai_api_key,
             ): unit
             for unit in work_units
         }

--- a/scripts/benchmark_run.py
+++ b/scripts/benchmark_run.py
@@ -594,9 +594,7 @@ def run_one(
             for event in stagehand.sessions.execute(
                 id=session.id,
                 agent_config={
-                    "model": _agent_model_config(
-                        scenario.model, llm_proxy_url, openai_api_key
-                    )
+                    "model": _agent_model_config(scenario.model, llm_proxy_url, openai_api_key)
                 },
                 execute_options={
                     "instruction": task.task,

--- a/scripts/compare_scenarios.py
+++ b/scripts/compare_scenarios.py
@@ -1,0 +1,677 @@
+#!/usr/bin/env -S uv run --script
+# Copyright (c) 2026 PixieBrix, Inc.
+# Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-dotenv>=1.0.0",
+# ]
+# ///
+"""Compare 2 scenarios on 1 task — fast iteration loop for cost/token regressions.
+
+Runs `benchmark_run.py` for exactly two scenarios × one task × N reps, then
+builds the standard trace bundles + side-by-side HTML diff, and finally emits
+`output/results/<run_id>/cost_diff.md` — a Claude-Code-readable digest that
+highlights what drove the cost/token delta (step count, a11y tree size,
+diverging step types) so you can iterate on a guarded scenario without running
+the full matrix.
+
+Usage:
+  uv run scripts/compare_scenarios.py \\
+      --scenario gpt5-mini-baseline \\
+      --scenario gpt5-mini-guarded \\
+      --task arxiv-recent-cs-ai \\
+      -n 3 --open
+
+Pair with `scripts/llm_proxy.py` + a tunnel and pass `--llm-proxy-url` to also
+capture the exact LLM messages per call (see benchmark/README.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import secrets
+import statistics
+import subprocess
+import sys
+import webbrowser
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+RESULTS_ROOT = REPO_ROOT / "output" / "results"
+REPORTS_ROOT = REPO_ROOT / "output" / "reports"
+DEFAULT_SCENARIOS = REPO_ROOT / "benchmark" / "scenarios.example.yaml"
+DEFAULT_TASKS = REPO_ROOT / "benchmark" / "tasks.csv"
+DEFAULT_EXTENSION_ZIP = REPO_ROOT / "output" / "extension.zip"
+DEFAULT_PRICING = REPO_ROOT / "benchmark" / "pricing.json"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+from build_traces import (  # noqa: E402
+    build_all as build_traces_all,
+    diff_html_filename,
+    pair_steps_by_type,
+    trace_dirname,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--scenario",
+        action="append",
+        default=[],
+        required=True,
+        metavar="ID",
+        help="Scenario id from --scenarios-file. Pass exactly twice.",
+    )
+    p.add_argument(
+        "--task",
+        required=True,
+        metavar="ID",
+        help="Task id from --tasks-file. Exactly one.",
+    )
+    p.add_argument("--scenarios-file", type=Path, default=DEFAULT_SCENARIOS)
+    p.add_argument("--tasks-file", type=Path, default=DEFAULT_TASKS)
+    p.add_argument(
+        "-n",
+        "--repetitions",
+        type=int,
+        default=3,
+        help="Reps per scenario (default: 3) to absorb agent variance.",
+    )
+    p.add_argument(
+        "--llm-proxy-url",
+        default=None,
+        help="Forwarded to benchmark_run.py so the exact LLM messages get "
+        "logged to output/llm-proxy/. Optional.",
+    )
+    p.add_argument("--no-judge", action="store_true")
+    p.add_argument("--judge-model", default=None)
+    p.add_argument("--extension-zip", type=Path, default=DEFAULT_EXTENSION_ZIP)
+    p.add_argument("--pricing", type=Path, default=DEFAULT_PRICING)
+    p.add_argument("--run-id", default=None, help="Override auto-minted run id.")
+    p.add_argument(
+        "--open",
+        action="store_true",
+        help="Open the HTML side-by-side diff in the default browser.",
+    )
+    args = p.parse_args()
+    if len(args.scenario) != 2:
+        sys.exit(f"--scenario must be passed exactly twice (got {len(args.scenario)})")
+    if args.scenario[0] == args.scenario[1]:
+        sys.exit("--scenario values must differ")
+    if args.repetitions < 1:
+        sys.exit(f"--repetitions must be >= 1 (got {args.repetitions})")
+    return args
+
+
+def mint_run_id() -> str:
+    ts = dt.datetime.now(dt.UTC).strftime("%Y%m%d_%H%M%S")
+    return f"cmp_{ts}_{secrets.token_hex(2)}"
+
+
+def run_benchmark(args: argparse.Namespace, run_id: str) -> None:
+    cmd = [
+        "uv",
+        "run",
+        str(SCRIPTS_DIR / "benchmark_run.py"),
+        "--scenarios",
+        str(args.scenarios_file),
+        "--tasks",
+        str(args.tasks_file),
+        "--task",
+        args.task,
+        "-n",
+        str(args.repetitions),
+        "--run-id",
+        run_id,
+        "--concurrency",
+        str(max(2, args.repetitions * 2)),
+        "--extension-zip",
+        str(args.extension_zip),
+        "--pricing",
+        str(args.pricing),
+    ]
+    for s in args.scenario:
+        cmd += ["--scenario", s]
+    if args.no_judge:
+        cmd.append("--no-judge")
+    if args.judge_model:
+        cmd += ["--judge-model", args.judge_model]
+    if args.llm_proxy_url:
+        cmd += ["--llm-proxy-url", args.llm_proxy_url]
+    print("$", " ".join(cmd))
+    rc = subprocess.call(cmd, cwd=REPO_ROOT)
+    if rc != 0:
+        sys.exit(f"benchmark_run.py exited {rc}")
+
+
+# ---------- digest rendering ----------
+
+
+def fmt_int(n: Any) -> str:
+    if n is None:
+        return "—"
+    try:
+        return f"{int(round(float(n))):,}"
+    except (TypeError, ValueError):
+        return str(n)
+
+
+def fmt_money(n: Any) -> str:
+    if n is None:
+        return "—"
+    try:
+        return f"${float(n):.4f}"
+    except (TypeError, ValueError):
+        return str(n)
+
+
+def fmt_secs(n: Any) -> str:
+    if n is None:
+        return "—"
+    try:
+        return f"{float(n):.1f}s"
+    except (TypeError, ValueError):
+        return str(n)
+
+
+def fmt_float(n: Any, places: int = 1) -> str:
+    if n is None:
+        return "—"
+    try:
+        return f"{float(n):.{places}f}"
+    except (TypeError, ValueError):
+        return str(n)
+
+
+def fmt_pct_delta(a: float | None, b: float | None) -> str:
+    if a in (None, 0) or b is None:
+        return "—"
+    pct = (b - a) / a * 100
+    return f"{pct:+.0f}%"
+
+
+def fmt_abs_delta(a: float | None, b: float | None, kind: str = "int") -> str:
+    if a is None or b is None:
+        return "—"
+    diff = b - a
+    if kind == "int":
+        return f"{int(round(diff)):+,}"
+    if kind == "money":
+        return f"{diff:+.4f}"
+    if kind == "secs":
+        return f"{diff:+.1f}s"
+    return f"{diff:+}"
+
+
+def mean(xs: list[Any]) -> float | None:
+    vals = [float(x) for x in xs if x is not None]
+    if not vals:
+        return None
+    return statistics.mean(vals)
+
+
+def load_results_rows(run_dir: Path) -> list[dict[str, Any]]:
+    p = run_dir / "results.jsonl"
+    rows: list[dict[str, Any]] = []
+    if not p.is_file():
+        return rows
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    # Last write wins per (scenario, task, rep) — matches build_traces.load_jsonl.
+    by_key: dict[tuple[str, str, int], dict[str, Any]] = {}
+    order: list[tuple[str, str, int]] = []
+    for r in rows:
+        key = (
+            str(r.get("scenario_id") or ""),
+            str(r.get("task_id") or ""),
+            int(r.get("repetition") or 1),
+        )
+        if key not in by_key:
+            order.append(key)
+        by_key[key] = r
+    return [by_key[k] for k in order]
+
+
+def load_steps(run_dir: Path, sid: str, tid: str, rep: int) -> list[dict[str, Any]]:
+    p = run_dir / "traces" / trace_dirname(sid, tid, rep) / "steps.json"
+    if not p.is_file():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def token_field(rows: list[dict[str, Any]], key: str) -> list[Any]:
+    out: list[Any] = []
+    for r in rows:
+        toks = r.get("tokens") or {}
+        out.append(toks.get(key))
+    return out
+
+
+def judge_verdict(row: dict[str, Any]) -> str:
+    if row.get("error"):
+        return "error"
+    v = (row.get("judge") or {}).get("pass")
+    if v is True:
+        return "pass"
+    if v is False:
+        return "fail"
+    return "ungraded"
+
+
+def summarize_scenario(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "n": len(rows),
+        "input": mean(token_field(rows, "input")),
+        "output": mean(token_field(rows, "output")),
+        "total": mean(token_field(rows, "total")),
+        "cached": mean(token_field(rows, "cached")),
+        "reasoning": mean(token_field(rows, "reasoning")),
+        "cost": mean([r.get("cost_usd") for r in rows]),
+        "steps": mean([r.get("steps_taken") for r in rows]),
+        "duration": mean([r.get("duration_s") for r in rows]),
+        "pass": sum(1 for r in rows if judge_verdict(r) == "pass"),
+        "fail": sum(1 for r in rows if judge_verdict(r) == "fail"),
+        "error": sum(1 for r in rows if judge_verdict(r) == "error"),
+        "ungraded": sum(1 for r in rows if judge_verdict(r) == "ungraded"),
+    }
+
+
+def render_summary_table(sid_a: str, sid_b: str, sa: dict, sb: dict) -> str:
+    """Aggregate token/cost/step/pass-rate table, scenario A vs B (mean across reps)."""
+    rows: list[tuple[str, str, str, str]] = []
+    rows.append(
+        (
+            "pass / fail / err",
+            f"{sa['pass']} / {sa['fail']} / {sa['error']}",
+            f"{sb['pass']} / {sb['fail']} / {sb['error']}",
+            "—",
+        )
+    )
+    rows.append(
+        (
+            "steps (mean)",
+            fmt_float(sa["steps"]),
+            fmt_float(sb["steps"]),
+            fmt_pct_delta(sa["steps"], sb["steps"]),
+        )
+    )
+    rows.append(
+        (
+            "duration (mean)",
+            fmt_secs(sa["duration"]),
+            fmt_secs(sb["duration"]),
+            fmt_pct_delta(sa["duration"], sb["duration"]),
+        )
+    )
+    rows.append(
+        (
+            "input tokens (mean)",
+            fmt_int(sa["input"]),
+            fmt_int(sb["input"]),
+            fmt_pct_delta(sa["input"], sb["input"]),
+        )
+    )
+    rows.append(
+        (
+            "output tokens (mean)",
+            fmt_int(sa["output"]),
+            fmt_int(sb["output"]),
+            fmt_pct_delta(sa["output"], sb["output"]),
+        )
+    )
+    if sa["cached"] is not None or sb["cached"] is not None:
+        rows.append(
+            (
+                "cached tokens (mean)",
+                fmt_int(sa["cached"]),
+                fmt_int(sb["cached"]),
+                fmt_pct_delta(sa["cached"], sb["cached"]),
+            )
+        )
+    if sa["reasoning"] is not None or sb["reasoning"] is not None:
+        rows.append(
+            (
+                "reasoning tokens (mean)",
+                fmt_int(sa["reasoning"]),
+                fmt_int(sb["reasoning"]),
+                fmt_pct_delta(sa["reasoning"], sb["reasoning"]),
+            )
+        )
+    rows.append(
+        (
+            "total tokens (mean)",
+            fmt_int(sa["total"]),
+            fmt_int(sb["total"]),
+            fmt_pct_delta(sa["total"], sb["total"]),
+        )
+    )
+    rows.append(
+        (
+            "cost USD (mean)",
+            fmt_money(sa["cost"]),
+            fmt_money(sb["cost"]),
+            fmt_pct_delta(sa["cost"], sb["cost"]),
+        )
+    )
+
+    out = [f"| metric | {sid_a} | {sid_b} | Δ (B vs A) |", "|---|---|---|---|"]
+    for r in rows:
+        out.append("| " + " | ".join(r) + " |")
+    return "\n".join(out)
+
+
+def render_per_rep_table(
+    sid_a: str, sid_b: str, rows_a: list[dict], rows_b: list[dict]
+) -> str:
+    reps = sorted({int(r.get("repetition") or 1) for r in rows_a + rows_b})
+    by_a = {int(r.get("repetition") or 1): r for r in rows_a}
+    by_b = {int(r.get("repetition") or 1): r for r in rows_b}
+
+    out = [
+        f"| rep | A ({sid_a}) | B ({sid_b}) | Δ total tok | Δ steps |",
+        "|---|---|---|---|---|",
+    ]
+    for rep in reps:
+        a = by_a.get(rep)
+        b = by_b.get(rep)
+        a_tot = ((a or {}).get("tokens") or {}).get("total")
+        b_tot = ((b or {}).get("tokens") or {}).get("total")
+        a_steps = (a or {}).get("steps_taken")
+        b_steps = (b or {}).get("steps_taken")
+
+        def cell(r: dict | None) -> str:
+            if r is None:
+                return "—"
+            tot = (r.get("tokens") or {}).get("total")
+            steps = r.get("steps_taken")
+            verdict = judge_verdict(r)
+            cost = r.get("cost_usd")
+            return (
+                f"{verdict} · {fmt_int(tot)} tok · "
+                f"{steps if steps is not None else '—'} steps · "
+                f"{fmt_money(cost)}"
+            )
+
+        out.append(
+            "| r"
+            f"{rep} | {cell(a)} | {cell(b)} | "
+            f"{fmt_abs_delta(a_tot, b_tot)} | "
+            f"{fmt_abs_delta(a_steps, b_steps)} |"
+        )
+    return "\n".join(out)
+
+
+def render_step_pairing(
+    sid_a: str,
+    sid_b: str,
+    rep: int,
+    steps_a: list[dict],
+    steps_b: list[dict],
+) -> str:
+    """Side-by-side step list. Bytes column = tool_result text length (mostly
+    a11y tree size). a11y column flags match / diverge per build_traces' pair
+    logic."""
+    pairings = pair_steps_by_type(steps_a, steps_b)
+    seen_b: set[int] = set()
+    rows: list[str] = []
+    # First pass: every left step + its (optional) right pair.
+    for s in steps_a:
+        other = pairings.get(id(s))
+        if other is not None:
+            seen_b.add(id(other))
+        rows.append(_step_pair_row(s, other))
+    # Second pass: any right steps that were never paired (extras on B side).
+    for s in steps_b:
+        if id(s) in seen_b:
+            continue
+        rows.append(_step_pair_row(None, s))
+
+    out = [
+        f"### rep {rep} — paired steps",
+        "",
+        f"Bytes = `tool_result` text length (mostly the a11y tree). a11y flag "
+        f"compares paired ariaTree snapshots between {sid_a} (A) and {sid_b} (B).",
+        "",
+        "| # | type | A bytes | B bytes | Δ bytes | a11y | URL |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    out.extend(rows)
+    return "\n".join(out)
+
+
+def _step_pair_row(a: dict | None, b: dict | None) -> str:
+    a_idx = a.get("index") if a else None
+    b_idx = b.get("index") if b else None
+    idx_label = "/".join(
+        [f"A{a_idx}" if a_idx is not None else "—", f"B{b_idx}" if b_idx is not None else "—"]
+    )
+    a_type = (a or {}).get("type")
+    b_type = (b or {}).get("type")
+    type_label = a_type if a_type == b_type else f"{a_type or '—'} / {b_type or '—'}"
+    a_bytes = ((a or {}).get("tool_result") or {}).get("text_len")
+    b_bytes = ((b or {}).get("tool_result") or {}).get("text_len")
+    a11y = ""
+    a_kind = ((a or {}).get("tool_result") or {}).get("kind")
+    b_kind = ((b or {}).get("tool_result") or {}).get("kind")
+    if a_kind == "aria_tree" and b_kind == "aria_tree":
+        a_sha = ((a or {}).get("tool_result") or {}).get("text_sha256")
+        b_sha = ((b or {}).get("tool_result") or {}).get("text_sha256")
+        a11y = "identical" if a_sha and a_sha == b_sha else "diverged"
+    url = (a or b or {}).get("page_url") or ""
+    if len(url) > 60:
+        url = url[:57] + "…"
+    return (
+        f"| {idx_label} | {type_label or '—'} | "
+        f"{fmt_int(a_bytes)} | {fmt_int(b_bytes)} | "
+        f"{fmt_abs_delta(a_bytes, b_bytes)} | {a11y or '—'} | "
+        f"`{url}` |"
+    )
+
+
+def render_cost_diff(
+    *,
+    run_id: str,
+    run_dir: Path,
+    sid_a: str,
+    sid_b: str,
+    task_id: str,
+    manifest: dict[str, Any],
+    rows: list[dict[str, Any]],
+    llm_proxy_url: str | None,
+) -> str:
+    task_def = next((t for t in manifest.get("tasks") or [] if t["id"] == task_id), {})
+    scen_a = next((s for s in manifest.get("scenarios") or [] if s["id"] == sid_a), {})
+    scen_b = next((s for s in manifest.get("scenarios") or [] if s["id"] == sid_b), {})
+
+    rows_a = [r for r in rows if r["scenario_id"] == sid_a and r["task_id"] == task_id]
+    rows_b = [r for r in rows if r["scenario_id"] == sid_b and r["task_id"] == task_id]
+    rows_a.sort(key=lambda r: int(r.get("repetition") or 1))
+    rows_b.sort(key=lambda r: int(r.get("repetition") or 1))
+
+    sa = summarize_scenario(rows_a)
+    sb = summarize_scenario(rows_b)
+
+    diff_html = REPORTS_ROOT / diff_html_filename(run_id, task_id)
+    cwd = Path.cwd()
+
+    def rel(p: Path) -> str:
+        try:
+            return str(p.relative_to(cwd))
+        except ValueError:
+            return str(p)
+
+    out: list[str] = []
+    out.append(f"# Scenario diff — `{task_id}`")
+    out.append("")
+    out.append(f"- run: `{run_id}`")
+    out.append(f"- scenario A: `{sid_a}` (extension: {scen_a.get('extension')}, "
+               f"model: `{scen_a.get('model')}`)")
+    out.append(f"- scenario B: `{sid_b}` (extension: {scen_b.get('extension')}, "
+               f"model: `{scen_b.get('model')}`)")
+    out.append(f"- reps: {manifest.get('repetitions')}")
+    out.append(f"- task: {task_def.get('task', '')}")
+    out.append(f"- success criteria: {task_def.get('success_criteria', '')}")
+    out.append("")
+    out.append("## Aggregate (mean across reps)")
+    out.append("")
+    out.append(render_summary_table(sid_a, sid_b, sa, sb))
+    out.append("")
+    out.append("## Per-rep")
+    out.append("")
+    out.append(render_per_rep_table(sid_a, sid_b, rows_a, rows_b))
+    out.append("")
+    out.append("## Step-by-step pairing")
+    out.append("")
+    out.append(
+        "Per-step token counts aren't tracked by Stagehand (only aggregate per "
+        "rep). The closest proxy for per-step cost is the tool_result byte "
+        "length below — for `ariaTree` steps that's the rendered a11y tree "
+        "that gets fed back into the next LLM call. To attribute exact tokens "
+        "to individual LLM calls, re-run with `--llm-proxy-url` and inspect "
+        "the proxy log."
+    )
+    out.append("")
+    reps = sorted({int(r.get("repetition") or 1) for r in rows_a + rows_b})
+    by_a = {int(r.get("repetition") or 1): r for r in rows_a}
+    by_b = {int(r.get("repetition") or 1): r for r in rows_b}
+    for rep in reps:
+        steps_a = load_steps(run_dir, sid_a, task_id, rep) if rep in by_a else []
+        steps_b = load_steps(run_dir, sid_b, task_id, rep) if rep in by_b else []
+        if not steps_a and not steps_b:
+            continue
+        out.append(render_step_pairing(sid_a, sid_b, rep, steps_a, steps_b))
+        out.append("")
+
+    out.append("## Files to drill into")
+    out.append("")
+    out.append(f"- HTML side-by-side: `{rel(diff_html)}` (open in browser)")
+    out.append(f"- Trace bundles (per rep, both scenarios):")
+    for rep in reps:
+        for sid in (sid_a, sid_b):
+            tdir = run_dir / "traces" / trace_dirname(sid, task_id, rep)
+            if tdir.is_dir():
+                out.append(f"  - `{rel(tdir)}/` — `steps.json`, `messages.json`, `summary.json`")
+    out.append(f"- Raw events: `{rel(run_dir / 'events')}/`")
+    out.append(f"- Results row: `{rel(run_dir / 'results.jsonl')}`")
+    if llm_proxy_url:
+        out.append(
+            f"- LLM proxy log: most recent file under "
+            f"`{rel(REPO_ROOT / 'output' / 'llm-proxy')}/` "
+            f"(scope: every OpenAI call routed through {llm_proxy_url} during "
+            f"this run; judge/extractor calls are NOT proxied)"
+        )
+    else:
+        out.append(
+            "- LLM proxy log: not enabled. Re-run with `--llm-proxy-url <tunnel>` "
+            "to capture the exact messages and per-call token counts."
+        )
+    out.append("")
+    out.append("## How to read this")
+    out.append("")
+    out.append(
+        "Cost differences between A and B come from three places: "
+        "(1) **step count** — each agent step ≈ one LLM call, so more steps = "
+        "more cost; (2) **per-call input size** — mostly the rendered a11y "
+        "tree, which the agent re-sends each step alongside accumulated "
+        "history; (3) **per-call output size** — reasoning + tool input the "
+        "model emits. The step-by-step table flags which paired steps had "
+        "diverging a11y trees and how their byte counts compare. Big positive "
+        "Δ bytes on B's ariaTree rows usually explains a big positive Δ tokens "
+        "on the aggregate."
+    )
+    return "\n".join(out)
+
+
+# ---------- entry point ----------
+
+
+def main() -> int:
+    load_dotenv(REPO_ROOT / ".env")
+    args = parse_args()
+
+    run_id = args.run_id or mint_run_id()
+    run_dir = RESULTS_ROOT / run_id
+    if run_dir.exists() and any(run_dir.iterdir()):
+        sys.exit(f"run dir {run_dir.relative_to(REPO_ROOT)} already exists and is non-empty")
+
+    print(f"run_id: {run_id}")
+    print(f"scenarios: {args.scenario[0]} vs {args.scenario[1]}")
+    print(f"task: {args.task}")
+    print(f"reps: {args.repetitions}")
+    if args.llm_proxy_url:
+        print(f"llm proxy: {args.llm_proxy_url}")
+    print()
+
+    run_benchmark(args, run_id)
+
+    if not (run_dir / "results.jsonl").is_file():
+        sys.exit("benchmark_run did not produce results.jsonl")
+
+    print()
+    print("building trace bundles + HTML diff...")
+    build_result = build_traces_all(run_id, task_globs=[args.task], force=False)
+    print(
+        f"  traces: rebuilt {build_result['traces_rebuilt']}, "
+        f"loaded {build_result['traces_loaded']}, "
+        f"failed {build_result['traces_failed']}; "
+        f"diff pages: wrote {build_result['diffs_written']}"
+    )
+
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    rows = load_results_rows(run_dir)
+
+    sid_a, sid_b = args.scenario
+    md = render_cost_diff(
+        run_id=run_id,
+        run_dir=run_dir,
+        sid_a=sid_a,
+        sid_b=sid_b,
+        task_id=args.task,
+        manifest=manifest,
+        rows=rows,
+        llm_proxy_url=args.llm_proxy_url,
+    )
+    out_path = run_dir / "cost_diff.md"
+    out_path.write_text(md, encoding="utf-8")
+
+    diff_html = REPORTS_ROOT / diff_html_filename(run_id, args.task)
+    cwd = Path.cwd()
+
+    def rel(p: Path) -> str:
+        try:
+            return str(p.relative_to(cwd))
+        except ValueError:
+            return str(p)
+
+    print()
+    print(f"digest: {rel(out_path)}")
+    print(f"html:   {rel(diff_html)}")
+
+    if args.open and diff_html.is_file():
+        webbrowser.open(diff_html.as_uri())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compare_scenarios.py
+++ b/scripts/compare_scenarios.py
@@ -55,6 +55,8 @@ DEFAULT_PRICING = REPO_ROOT / "benchmark" / "pricing.json"
 sys.path.insert(0, str(SCRIPTS_DIR))
 from build_traces import (  # noqa: E402
     build_all as build_traces_all,
+)
+from build_traces import (  # noqa: E402
     diff_html_filename,
     pair_steps_by_type,
     trace_dirname,
@@ -162,7 +164,7 @@ def fmt_int(n: Any) -> str:
     if n is None:
         return "—"
     try:
-        return f"{int(round(float(n))):,}"
+        return f"{round(float(n)):,}"
     except (TypeError, ValueError):
         return str(n)
 
@@ -206,7 +208,7 @@ def fmt_abs_delta(a: float | None, b: float | None, kind: str = "int") -> str:
         return "—"
     diff = b - a
     if kind == "int":
-        return f"{int(round(diff)):+,}"
+        return f"{round(diff):+,}"
     if kind == "money":
         return f"{diff:+.4f}"
     if kind == "secs":
@@ -381,9 +383,7 @@ def render_summary_table(sid_a: str, sid_b: str, sa: dict, sb: dict) -> str:
     return "\n".join(out)
 
 
-def render_per_rep_table(
-    sid_a: str, sid_b: str, rows_a: list[dict], rows_b: list[dict]
-) -> str:
+def render_per_rep_table(sid_a: str, sid_b: str, rows_a: list[dict], rows_b: list[dict]) -> str:
     reps = sorted({int(r.get("repetition") or 1) for r in rows_a + rows_b})
     by_a = {int(r.get("repetition") or 1): r for r in rows_a}
     by_b = {int(r.get("repetition") or 1): r for r in rows_b}
@@ -525,10 +525,14 @@ def render_cost_diff(
     out.append(f"# Scenario diff — `{task_id}`")
     out.append("")
     out.append(f"- run: `{run_id}`")
-    out.append(f"- scenario A: `{sid_a}` (extension: {scen_a.get('extension')}, "
-               f"model: `{scen_a.get('model')}`)")
-    out.append(f"- scenario B: `{sid_b}` (extension: {scen_b.get('extension')}, "
-               f"model: `{scen_b.get('model')}`)")
+    out.append(
+        f"- scenario A: `{sid_a}` (extension: {scen_a.get('extension')}, "
+        f"model: `{scen_a.get('model')}`)"
+    )
+    out.append(
+        f"- scenario B: `{sid_b}` (extension: {scen_b.get('extension')}, "
+        f"model: `{scen_b.get('model')}`)"
+    )
     out.append(f"- reps: {manifest.get('repetitions')}")
     out.append(f"- task: {task_def.get('task', '')}")
     out.append(f"- success criteria: {task_def.get('success_criteria', '')}")
@@ -566,7 +570,7 @@ def render_cost_diff(
     out.append("## Files to drill into")
     out.append("")
     out.append(f"- HTML side-by-side: `{rel(diff_html)}` (open in browser)")
-    out.append(f"- Trace bundles (per rep, both scenarios):")
+    out.append("- Trace bundles (per rep, both scenarios):")
     for rep in reps:
         for sid in (sid_a, sid_b):
             tdir = run_dir / "traces" / trace_dirname(sid, task_id, rep)

--- a/scripts/llm_proxy.py
+++ b/scripts/llm_proxy.py
@@ -11,13 +11,14 @@
 #     "uvicorn>=0.27.0",
 # ]
 # ///
-"""OpenAI-compatible logging proxy.
+"""OpenRouter logging proxy (OpenAI-compatible wire format).
 
-Forwards POST /v1/* to https://api.openai.com/v1/* using `OPENAI_API_KEY`,
-logging each request/response pair to a JSONL file. The point is to capture
-the exact messages Browserbase ships to the model — system prompt, tool
-definitions, accumulated history, and the rendered accessibility tree per
-step — so you can diff what guarded vs. baseline runs send.
+Forwards POST /v1/* to https://openrouter.ai/api/v1/* using
+`OPENROUTER_API_KEY`, logging each request/response pair to a JSONL file.
+The point is to capture the exact messages Browserbase ships to the model —
+system prompt, tool definitions, accumulated history, and the rendered
+accessibility tree per step — so you can diff what guarded vs. baseline
+runs send.
 
 Browserbase's backend (not your laptop) is what calls the LLM, so the proxy
 must be reachable from the public internet. Pair this with `cloudflared
@@ -27,8 +28,8 @@ tunnel URL to `benchmark_run.py --llm-proxy-url <URL>`.
 Streaming responses (text/event-stream) are passed through chunk-by-chunk
 while the full body is buffered for logging.
 
-Judge/extractor calls in `scripts/_judge.py` go directly to OpenAI with the
-same `OPENAI_API_KEY` and intentionally bypass this proxy — only the
+Judge/extractor calls in `scripts/_judge.py` go directly to OpenAI with
+`OPENAI_API_KEY` and intentionally bypass this proxy — only the
 Browserbase-driven agent traffic is logged here.
 
 Usage:
@@ -56,7 +57,7 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LOG_ROOT = REPO_ROOT / "output" / "llm-proxy"
-OPENAI_BASE = "https://api.openai.com"
+OPENROUTER_BASE = "https://openrouter.ai/api"
 
 # Headers that must NOT be forwarded — either hop-by-hop, or rewritten below.
 _STRIP_REQUEST_HEADERS = {
@@ -96,8 +97,8 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--upstream",
-        default=OPENAI_BASE,
-        help=f"Override upstream base URL (default: {OPENAI_BASE}).",
+        default=OPENROUTER_BASE,
+        help=f"Override upstream base URL (default: {OPENROUTER_BASE}).",
     )
     return parser.parse_args()
 
@@ -226,9 +227,9 @@ def build_app(*, log_path: Path, upstream_base: str, upstream_key: str) -> FastA
 def main() -> int:
     args = _parse_args()
     load_dotenv()
-    upstream_key = os.environ.get("OPENAI_API_KEY")
+    upstream_key = os.environ.get("OPENROUTER_API_KEY")
     if not upstream_key:
-        sys.exit("OPENAI_API_KEY is required (set in env or .env)")
+        sys.exit("OPENROUTER_API_KEY is required (set in env or .env)")
 
     log_path = args.out or _default_log_path()
     print(f"upstream: {args.upstream}")

--- a/scripts/llm_proxy.py
+++ b/scripts/llm_proxy.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env -S uv run --script
+# Copyright (c) 2026 PixieBrix, Inc.
+# Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "fastapi>=0.110.0",
+#     "httpx>=0.27.0",
+#     "python-dotenv>=1.0.0",
+#     "uvicorn>=0.27.0",
+# ]
+# ///
+"""OpenAI-compatible logging proxy.
+
+Forwards POST /v1/* to https://api.openai.com/v1/* using `OPENAI_API_KEY`,
+logging each request/response pair to a JSONL file. The point is to capture
+the exact messages Browserbase ships to the model — system prompt, tool
+definitions, accumulated history, and the rendered accessibility tree per
+step — so you can diff what guarded vs. baseline runs send.
+
+Browserbase's backend (not your laptop) is what calls the LLM, so the proxy
+must be reachable from the public internet. Pair this with `cloudflared
+tunnel --url http://localhost:8787` (or `ngrok http 8787`) and pass the
+tunnel URL to `benchmark_run.py --llm-proxy-url <URL>`.
+
+Streaming responses (text/event-stream) are passed through chunk-by-chunk
+while the full body is buffered for logging.
+
+Judge/extractor calls in `scripts/_judge.py` go directly to OpenAI with the
+same `OPENAI_API_KEY` and intentionally bypass this proxy — only the
+Browserbase-driven agent traffic is logged here.
+
+Usage:
+  uv run scripts/llm_proxy.py                          # default 127.0.0.1:8787
+  uv run scripts/llm_proxy.py --port 9000 --out my.jsonl
+  cloudflared tunnel --url http://localhost:8787      # in another terminal
+  uv run scripts/benchmark_run.py ... --llm-proxy-url https://<tunnel>.trycloudflare.com
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LOG_ROOT = REPO_ROOT / "output" / "llm-proxy"
+OPENAI_BASE = "https://api.openai.com"
+
+# Headers that must NOT be forwarded — either hop-by-hop, or rewritten below.
+_STRIP_REQUEST_HEADERS = {
+    "host",
+    "content-length",
+    "authorization",
+    "accept-encoding",
+    "connection",
+    "transfer-encoding",
+}
+
+# Headers from the upstream response that must NOT be forwarded back —
+# they describe the upstream's transport, not ours.
+_STRIP_RESPONSE_HEADERS = {
+    "content-length",
+    "content-encoding",
+    "transfer-encoding",
+    "connection",
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help=(
+            "Log file path (default: output/llm-proxy/proxy_<UTC-timestamp>.jsonl). "
+            "Parent directory is created if missing."
+        ),
+    )
+    parser.add_argument(
+        "--upstream",
+        default=OPENAI_BASE,
+        help=f"Override upstream base URL (default: {OPENAI_BASE}).",
+    )
+    return parser.parse_args()
+
+
+def _default_log_path() -> Path:
+    stamp = dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+    return LOG_ROOT / f"proxy_{stamp}.jsonl"
+
+
+def _kept_request_headers(headers: dict[str, str]) -> dict[str, str]:
+    return {k: v for k, v in headers.items() if k.lower() not in _STRIP_REQUEST_HEADERS}
+
+
+def _kept_response_headers(headers: httpx.Headers) -> dict[str, str]:
+    return {k: v for k, v in headers.items() if k.lower() not in _STRIP_RESPONSE_HEADERS}
+
+
+def _try_parse_json(raw: bytes) -> Any:
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        try:
+            return raw.decode("utf-8", errors="replace")
+        except Exception:  # pragma: no cover - defensive
+            return None
+
+
+def build_app(*, log_path: Path, upstream_base: str, upstream_key: str) -> FastAPI:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    client = httpx.AsyncClient(base_url=upstream_base, timeout=600.0)
+    app = FastAPI(title="agent-browser-shield LLM proxy")
+
+    def _write_log(record: dict[str, Any]) -> None:
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, default=str, ensure_ascii=False) + "\n")
+            fh.flush()
+
+    @app.get("/health")
+    async def health() -> JSONResponse:
+        return JSONResponse({"ok": True, "upstream": upstream_base, "log": str(log_path)})
+
+    @app.api_route("/v1/{path:path}", methods=["POST"])
+    async def passthrough(path: str, request: Request) -> Response:
+        body = await request.body()
+        forwarded_headers = _kept_request_headers(dict(request.headers))
+        forwarded_headers["authorization"] = f"Bearer {upstream_key}"
+
+        started_at = dt.datetime.now(dt.UTC).isoformat()
+        upstream_req = client.build_request(
+            "POST",
+            f"/v1/{path}",
+            content=body,
+            headers=forwarded_headers,
+            params=dict(request.query_params),
+        )
+
+        # Use stream=True so SSE responses can be forwarded incrementally
+        # while we still capture the full body for the log.
+        upstream_resp = await client.send(upstream_req, stream=True)
+        is_event_stream = upstream_resp.headers.get("content-type", "").startswith(
+            "text/event-stream"
+        )
+
+        if not is_event_stream:
+            raw = await upstream_resp.aread()
+            await upstream_resp.aclose()
+            ended_at = dt.datetime.now(dt.UTC).isoformat()
+            _write_log(
+                {
+                    "started_at": started_at,
+                    "ended_at": ended_at,
+                    "endpoint": f"/v1/{path}",
+                    "query": dict(request.query_params),
+                    "status": upstream_resp.status_code,
+                    "request_headers": forwarded_headers,
+                    "request": _try_parse_json(body),
+                    "response_headers": dict(upstream_resp.headers),
+                    "response": _try_parse_json(raw),
+                }
+            )
+            return Response(
+                content=raw,
+                status_code=upstream_resp.status_code,
+                headers=_kept_response_headers(upstream_resp.headers),
+                media_type=upstream_resp.headers.get("content-type"),
+            )
+
+        # Streaming: buffer chunks for logging, forward to the caller live.
+        buffered = bytearray()
+
+        async def iterator():
+            try:
+                async for chunk in upstream_resp.aiter_raw():
+                    buffered.extend(chunk)
+                    yield chunk
+            finally:
+                await upstream_resp.aclose()
+                ended_at = dt.datetime.now(dt.UTC).isoformat()
+                _write_log(
+                    {
+                        "started_at": started_at,
+                        "ended_at": ended_at,
+                        "endpoint": f"/v1/{path}",
+                        "query": dict(request.query_params),
+                        "status": upstream_resp.status_code,
+                        "stream": True,
+                        "request_headers": forwarded_headers,
+                        "request": _try_parse_json(body),
+                        "response_headers": dict(upstream_resp.headers),
+                        "response_raw": bytes(buffered).decode("utf-8", errors="replace"),
+                    }
+                )
+
+        return StreamingResponse(
+            iterator(),
+            status_code=upstream_resp.status_code,
+            headers=_kept_response_headers(upstream_resp.headers),
+            media_type=upstream_resp.headers.get("content-type"),
+        )
+
+    return app
+
+
+def main() -> int:
+    args = _parse_args()
+    load_dotenv()
+    upstream_key = os.environ.get("OPENAI_API_KEY")
+    if not upstream_key:
+        sys.exit("OPENAI_API_KEY is required (set in env or .env)")
+
+    log_path = args.out or _default_log_path()
+    print(f"upstream: {args.upstream}")
+    print(f"log: {log_path}")
+    print(f"listening on http://{args.host}:{args.port}")
+    print(
+        "expose with `cloudflared tunnel --url http://"
+        f"{args.host}:{args.port}` (or ngrok) and pass the public URL via "
+        "`benchmark_run.py --llm-proxy-url ...`"
+    )
+
+    app = build_app(log_path=log_path, upstream_base=args.upstream, upstream_key=upstream_key)
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/llm_proxy.py
+++ b/scripts/llm_proxy.py
@@ -11,14 +11,19 @@
 #     "uvicorn>=0.27.0",
 # ]
 # ///
-"""OpenRouter logging proxy (OpenAI-compatible wire format).
+"""OpenAI logging proxy.
 
-Forwards POST /v1/* to https://openrouter.ai/api/v1/* using
-`OPENROUTER_API_KEY`, logging each request/response pair to a JSONL file.
-The point is to capture the exact messages Browserbase ships to the model —
-system prompt, tool definitions, accumulated history, and the rendered
-accessibility tree per step — so you can diff what guarded vs. baseline
-runs send.
+Forwards `/v1/*` to https://api.openai.com/v1/* using `OPENAI_API_KEY`,
+logging each request/response pair to a JSONL file. The point is to
+capture the exact messages Browserbase ships to the model — system prompt,
+tool definitions, accumulated history, and the rendered accessibility
+tree per step — so you can diff what guarded vs. baseline runs send.
+
+OpenAI is the only fully-supported upstream today. OpenRouter accepts most
+chat-completions traffic but its `/v1/responses` schema rejects the
+`reasoning` items Stagehand includes across multi-turn agent runs, so
+multi-step tasks 400 after the first turn — not worth the multi-provider
+routing.
 
 Browserbase's backend (not your laptop) is what calls the LLM, so the proxy
 must be reachable from the public internet. Pair this with `cloudflared
@@ -57,7 +62,7 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LOG_ROOT = REPO_ROOT / "output" / "llm-proxy"
-OPENROUTER_BASE = "https://openrouter.ai/api"
+OPENAI_BASE = "https://api.openai.com"
 
 # Headers that must NOT be forwarded — either hop-by-hop, or rewritten below.
 _STRIP_REQUEST_HEADERS = {
@@ -97,8 +102,8 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--upstream",
-        default=OPENROUTER_BASE,
-        help=f"Override upstream base URL (default: {OPENROUTER_BASE}).",
+        default=OPENAI_BASE,
+        help=f"Override upstream base URL (default: {OPENAI_BASE}).",
     )
     return parser.parse_args()
 
@@ -116,14 +121,13 @@ def _kept_response_headers(headers: httpx.Headers) -> dict[str, str]:
     return {k: v for k, v in headers.items() if k.lower() not in _STRIP_RESPONSE_HEADERS}
 
 
-def _prefix_openai_model(body: bytes) -> bytes:
-    """Rewrite `{"model": "gpt-5-mini", ...}` → `{"model": "openai/gpt-5-mini", ...}`.
+def _strip_openai_prefix(body: bytes) -> bytes:
+    """Rewrite `{"model": "openai/gpt-5-mini", ...}` → `{"model": "gpt-5-mini", ...}`.
 
-    Stagehand's `provider: openai` config validates model names against
-    OpenAI's catalog, so we strip the `openai/` prefix on the way out of
-    benchmark_run.py. OpenRouter routes by provider-prefixed slug, so we add
-    it back here. Bodies that already carry a prefixed name, or that aren't
-    JSON, pass through unchanged.
+    Stagehand's ModelConfigParam requires `provider/model` slugs, so the
+    runner sends `openai/gpt-5-mini`. OpenAI's API expects bare names, so
+    we strip the prefix before forwarding. Bodies without the prefix, or
+    that aren't JSON, pass through unchanged.
     """
     if not body:
         return body
@@ -134,9 +138,9 @@ def _prefix_openai_model(body: bytes) -> bytes:
     if not isinstance(payload, dict):
         return body
     model = payload.get("model")
-    if not isinstance(model, str) or "/" in model:
+    if not isinstance(model, str) or not model.startswith("openai/"):
         return body
-    payload["model"] = f"openai/{model}"
+    payload["model"] = model.split("/", 1)[1]
     return json.dumps(payload, ensure_ascii=False).encode("utf-8")
 
 
@@ -166,21 +170,24 @@ def build_app(*, log_path: Path, upstream_base: str, upstream_key: str) -> FastA
     async def health() -> JSONResponse:
         return JSONResponse({"ok": True, "upstream": upstream_base, "log": str(log_path)})
 
-    @app.api_route("/v1/{path:path}", methods=["POST"])
+    _ALL_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"]
+
+    @app.api_route("/v1/{path:path}", methods=_ALL_METHODS)
     async def passthrough(path: str, request: Request) -> Response:
         body = await request.body()
-        # Stagehand sends bare OpenAI model names (gpt-5-mini); OpenRouter
-        # needs the provider prefix as its routing key. Re-prefix any
-        # unprefixed model name in the JSON body before forwarding.
-        body = _prefix_openai_model(body)
+        # Stagehand sends OpenAI-prefixed slugs (openai/gpt-5-mini); OpenAI's
+        # API expects bare names. Strip the prefix from POST bodies before
+        # forwarding.
+        if request.method == "POST":
+            body = _strip_openai_prefix(body)
         forwarded_headers = _kept_request_headers(dict(request.headers))
         forwarded_headers["authorization"] = f"Bearer {upstream_key}"
 
         started_at = dt.datetime.now(dt.UTC).isoformat()
         upstream_req = client.build_request(
-            "POST",
+            request.method,
             f"/v1/{path}",
-            content=body,
+            content=body if request.method == "POST" else None,
             headers=forwarded_headers,
             params=dict(request.query_params),
         )
@@ -201,6 +208,7 @@ def build_app(*, log_path: Path, upstream_base: str, upstream_key: str) -> FastA
                     "started_at": started_at,
                     "ended_at": ended_at,
                     "endpoint": f"/v1/{path}",
+                    "method": request.method,
                     "query": dict(request.query_params),
                     "status": upstream_resp.status_code,
                     "request_headers": forwarded_headers,
@@ -232,6 +240,7 @@ def build_app(*, log_path: Path, upstream_base: str, upstream_key: str) -> FastA
                         "started_at": started_at,
                         "ended_at": ended_at,
                         "endpoint": f"/v1/{path}",
+                        "method": request.method,
                         "query": dict(request.query_params),
                         "status": upstream_resp.status_code,
                         "stream": True,
@@ -249,15 +258,36 @@ def build_app(*, log_path: Path, upstream_base: str, upstream_key: str) -> FastA
             media_type=upstream_resp.headers.get("content-type"),
         )
 
+    @app.api_route("/{full_path:path}", methods=_ALL_METHODS)
+    async def catch_all(full_path: str, request: Request) -> JSONResponse:
+        """Log any request the /v1/* passthrough doesn't claim — useful for
+        diagnosing client misroutes (probing `/responses` without `/v1` etc.)
+        instead of getting a silent FastAPI 404."""
+        _write_log(
+            {
+                "ts": dt.datetime.now(dt.UTC).isoformat(),
+                "unhandled": True,
+                "method": request.method,
+                "path": f"/{full_path}",
+                "query": dict(request.query_params),
+                "headers": dict(request.headers),
+                "body": _try_parse_json(await request.body()),
+            }
+        )
+        return JSONResponse(
+            {"error": f"proxy only handles /v1/* (got {request.method} /{full_path})"},
+            status_code=404,
+        )
+
     return app
 
 
 def main() -> int:
     args = _parse_args()
     load_dotenv()
-    upstream_key = os.environ.get("OPENROUTER_API_KEY")
+    upstream_key = os.environ.get("OPENAI_API_KEY")
     if not upstream_key:
-        sys.exit("OPENROUTER_API_KEY is required (set in env or .env)")
+        sys.exit("OPENAI_API_KEY is required (set in env or .env)")
 
     log_path = args.out or _default_log_path()
     print(f"upstream: {args.upstream}")

--- a/scripts/llm_proxy.py
+++ b/scripts/llm_proxy.py
@@ -116,6 +116,30 @@ def _kept_response_headers(headers: httpx.Headers) -> dict[str, str]:
     return {k: v for k, v in headers.items() if k.lower() not in _STRIP_RESPONSE_HEADERS}
 
 
+def _prefix_openai_model(body: bytes) -> bytes:
+    """Rewrite `{"model": "gpt-5-mini", ...}` → `{"model": "openai/gpt-5-mini", ...}`.
+
+    Stagehand's `provider: openai` config validates model names against
+    OpenAI's catalog, so we strip the `openai/` prefix on the way out of
+    benchmark_run.py. OpenRouter routes by provider-prefixed slug, so we add
+    it back here. Bodies that already carry a prefixed name, or that aren't
+    JSON, pass through unchanged.
+    """
+    if not body:
+        return body
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return body
+    if not isinstance(payload, dict):
+        return body
+    model = payload.get("model")
+    if not isinstance(model, str) or "/" in model:
+        return body
+    payload["model"] = f"openai/{model}"
+    return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+
 def _try_parse_json(raw: bytes) -> Any:
     if not raw:
         return None
@@ -145,6 +169,10 @@ def build_app(*, log_path: Path, upstream_base: str, upstream_key: str) -> FastA
     @app.api_route("/v1/{path:path}", methods=["POST"])
     async def passthrough(path: str, request: Request) -> Response:
         body = await request.body()
+        # Stagehand sends bare OpenAI model names (gpt-5-mini); OpenRouter
+        # needs the provider prefix as its routing key. Re-prefix any
+        # unprefixed model name in the JSON body before forwarding.
+        body = _prefix_openai_model(body)
         forwarded_headers = _kept_request_headers(dict(request.headers))
         forwarded_headers["authorization"] = f"Bearer {upstream_key}"
 

--- a/skills/agent-browser-shield-autoresearch/SKILL.md
+++ b/skills/agent-browser-shield-autoresearch/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: agent-browser-shield-autoresearch
+description: Run an experiment to understand how the guarded extension affects an agent on a specific task — for one model or across several — and turn the observations into concrete rule-change proposals (tighten a built-in default, add a site-specific rule, drop a rule, or ship a new defense). Use when the user asks "research how guard does on task X", "is the extension helping on Y", "what should we change to do better on Z", "test this task across models", "should we add a site rule for this", or "see if our rules pay off here". NOT for explaining an existing benchmark row (use `agent-browser-shield-diagnose`), authoring new task CSV rows (use `agent-browser-shield-tasks`), adding selectors to a known site after you've already decided the recipe (use `agent-browser-shield-site-rules`), or extension build/install configuration (use `agent-browser-shield-install`).
+---
+
+# Autoresearch: guarded vs unguarded on a focused task
+
+This skill drives `scripts/compare_scenarios.py` as a research loop. The goal is
+to *learn* whether the extension helps, hurts, or is neutral on a given task —
+and decide what to change next: tune a built-in rule default, add a per-site
+recipe under `extension/data/sites/`, drop a rule that's hurting more than it
+helps, or propose a new defense.
+
+This is the proactive counterpart to `agent-browser-shield-diagnose`. Diagnose
+explains an existing run; autoresearch runs a fresh experiment focused on one
+task and forms a recommendation.
+
+## When to invoke
+
+- User points at a specific task (or task pattern) and asks how the extension
+  performs on it.
+- User suspects a defense is helping or hurting and wants a measurement.
+- User wants to test the same task across multiple models to see whether the
+  guard's benefit generalizes.
+- User wants concrete change proposals grounded in the trace, not speculation.
+
+If the user already has a run in hand and just wants the *why*, hand off to
+`agent-browser-shield-diagnose` instead.
+
+## Pre-flight
+
+- `output/extension.zip` exists (any scenario with `extension: true` needs it).
+  Build with `cd extension && bun run build && bun run package && cd ..` if not.
+- `OPENAI_API_KEY` is in `.env` (the judge always calls OpenAI directly,
+  regardless of the agent model).
+- `BROWSERBASE_API_KEY` + `BROWSERBASE_PROJECT_ID` are in `.env`.
+- The two scenarios you'll compare both exist in
+  `benchmark/scenarios.example.yaml` (or whatever `--scenarios-file` you pass).
+  The shipped file defines `gpt5-mini-baseline` and `gpt5-mini-guarded`. For
+  "across models", scenarios for additional model pairs need to be added there
+  first — don't guess names, ask the user or read the file.
+- The task id exists in `benchmark/tasks.csv` (or the BU Bench file).
+
+If `--llm-proxy-url` will be passed: `scripts/llm_proxy.py` must be running with
+a public tunnel (`cloudflared tunnel --url http://127.0.0.1:8787`) and
+`OPENAI_API_KEY` in that proxy's env. The proxy is OpenAI-only today — see
+`benchmark/README.md` "Capturing the LLM messages (proxy)". The runner appends
+`/v1` to the tunnel URL automatically; the user passes the bare root.
+
+## 1. Run the focused comparison
+
+Default: 3 reps per scenario to absorb agent stochasticity (which can swing step
+counts by ±2 on the same task even without rule changes).
+
+```bash
+uv run scripts/compare_scenarios.py \
+    --scenario <baseline_id> \
+    --scenario <guarded_id> \
+    --task <task_id> \
+    -n 3
+```
+
+Add `--llm-proxy-url <tunnel-root>` if you want to inspect the exact LLM
+messages later (and you have the proxy running). For research, the proxy log is
+rarely needed — the trace bundles carry the page-state delta which is where rule
+effects live.
+
+The script writes:
+
+- `output/results/<run_id>/cost_diff.md` — aggregate + per-rep token/cost/step
+  deltas, paired step-by-step a11y-byte deltas. Read this first.
+- `output/results/<run_id>/traces/<scenario>__<task>__r<n>/{summary,steps,messages}.json`
+  — per-rep structured traces.
+- `output/reports/<run_id>__<task>.html` — side-by-side HTML diff (for humans).
+
+## 2. Read the digest
+
+Pull the headline numbers from `cost_diff.md`:
+
+- Pass-rate per scenario.
+- Aggregate Δ on `steps (mean)`, `total tokens (mean)`, `cost USD (mean)`,
+  `duration (mean)`. Anything < ±10% with n=3 is likely noise.
+- Per-rep table: if 2/3 reps are roughly equal and 1 rep is wildly different,
+  the delta is probably stochastic (one rep happened to take a different path).
+  Read `final_answer` for those reps to confirm they reached the same
+  conclusion.
+
+Classify the outcome:
+
+- **Guard helps** — fewer steps and/or tokens, same pass rate or better.
+- **Guard hurts** — more steps/tokens or worse pass rate.
+- **Guard is neutral** — within noise on every metric.
+- **Guard flips behavior** — same aggregate cost but different step types (e.g.
+  agent chose `goto` instead of `act`+`keys`). Worth investigating because it
+  implies a rule is steering the agent.
+
+## 3. Find the rule fingerprint
+
+Open the article-page (or task-target-page) `ariaTree` step on each side and
+diff the trees with **node IDs normalized** (raw IDs like `[0-7195]` shift
+between captures even when content is identical — without normalization the diff
+is mostly noise).
+
+```python
+import json, re, difflib
+b = json.load(open("output/results/<run_id>/traces/<baseline>__<task>__r1/steps.json"))
+g = json.load(open("output/results/<run_id>/traces/<guarded>__<task>__r1/steps.json"))
+bt = next(s for s in b if s["type"]=="ariaTree" and s["tool_result"]["text_len"] > 1000)
+gt = next(s for s in g if s["type"]=="ariaTree" and s["tool_result"]["text_len"] > 1000)
+norm = re.compile(r"\[\d+-\d+\]")
+strip = lambda t: [norm.sub("[ID]", l) for l in t.splitlines()]
+diff = list(difflib.unified_diff(strip(bt["tool_result"]["text"]),
+                                  strip(gt["tool_result"]["text"]),
+                                  n=0, lineterm=""))
+for l in diff:
+    if l[0] in "+-" and not l.startswith(("+++", "---")):
+        print(l[:160])
+```
+
+The `-` lines are what the extension *stripped* from the page; the `+` lines are
+what it *added* (placeholders like `[footer hidden — click to reveal]`, helper
+notes like `abs URL helper`, marker buttons). Those together are the guard's
+fingerprint on this task.
+
+Cross-check with reasoning: read the post-`ariaTree` step's `reasoning` field on
+the guarded side. Did the agent act on a hint the extension injected? Did it get
+blocked by a placeholder it couldn't interpret?
+
+## 4. Propose changes
+
+Map what you observed to a concrete change. Pick one of:
+
+- **Tighten a built-in rule default** — `extension/data/rule-defaults.json`.
+  Disable a rule that's hurting more than it helps, or enable one that's
+  off-by-default but would help.
+- **Add a site-specific rule** — `extension/data/sites/<host>.yaml`. Hand off to
+  `agent-browser-shield-site-rules` for the selector-authoring workflow. Common
+  case: the guard's generic stripping missed something host-specific, or the
+  agent would benefit from a search-URL helper hint that doesn't yet exist for
+  this host.
+- **Drop or narrow a rule** — when the trace shows a rule firing on
+  false-positive content (e.g. masking a real product price as PII, or stripping
+  a navigation element the agent needed).
+- **Ship a new defense rule** — when no existing rule covers the observed bad
+  content (a new dark-pattern variant, a new PII shape, etc.). Reference the
+  `agent-browser-shield` skill for the rule contract.
+- **Do nothing** — the delta is within noise, or the guard is already optimal on
+  this task.
+
+State the proposal in terms of: the file to change, the specific change, and the
+trace evidence supporting it. Don't propose changes that aren't grounded in the
+trace.
+
+## 5. Across-model loop (optional)
+
+If the user asked "across models" and multiple `(baseline, guarded)` scenario
+pairs exist in the scenarios file:
+
+1. Run §1 once per pair.
+2. Apply §2–§3 to each run.
+3. Synthesize: does the guard's effect generalize across models, or is it
+   model-specific?
+
+Common patterns:
+
+- **Helps small models more** — guard's hints (e.g. URL helpers) substitute for
+  capabilities the larger model already has. Recommendation: keep the rule on by
+  default; it's cheap insurance.
+- **Helps large models more** — the guard reveals enough page structure for a
+  smarter model to choose better, but a weaker model can't capitalize.
+  Recommendation: depends on the target deployment.
+- **Hurts one model, helps another** — likely a rule that interacts with how a
+  specific model interprets the page. Worth a per-rule investigation.
+
+If there's only one model pair available (the shipped file), say so and
+recommend adding scenarios for the other models the user cares about before
+extending the experiment.
+
+## 6. Report back
+
+Lead with: the classification (helps / hurts / neutral / flips), the headline
+metric delta with its noise caveat (`n=3`), the *specific* rule fingerprint
+observed in the a11y diff, and the proposed change. Cite paths so the user can
+verify:
+
+> On `wiki-claude` (n=3), guarded is **-14% tokens, -17% steps** vs baseline,
+> 3/3 pass on both. The aggregate is dominated by 1 rep where guarded chose
+> `goto` (1 step) instead of the typical search-click-wait path (3 steps); the
+> other 2 reps were equal. The a11y diff at the article-page snapshot shows the
+> extension injects an `abs URL helper` note ("prefer URL navigation over
+> typing. Direct article: /wiki/{Title_With_Underscores}") — that's the hint the
+> agent followed in rep 2. Footer stripping accounts for the other -1,400 bytes
+> per article-page tree.
+>
+> **Proposal**: keep `search-url-helper` enabled (`rule-defaults.json` shows
+> it's already true). Optionally add more Wikipedia URL templates to
+> `extension/data/sites/wikipedia.yaml` if other reps had been searching from
+> non-Main_Page entry points. Evidence: `output/results/cmp_<id>/cost_diff.md`,
+> `output/results/cmp_<id>/traces/.../steps.json` step 4.
+
+Don't recommend a change unless the trace supports it. If the experiment is
+inconclusive at n=3, recommend re-running with higher `-n` rather than guessing.


### PR DESCRIPTION
## Summary

- New `scripts/compare_scenarios.py`: runs exactly two scenarios × one task × N reps, builds trace bundles + HTML diff, and writes a Markdown digest at `output/results/<run_id>/cost_diff.md` highlighting what drove cost/token deltas (step count, a11y-tree byte size, paired divergences). Digest is designed to be read by a coding agent — aggregate table with Δ%, per-rep table flagging flaky reps, paired step-by-step listing with byte-length deltas and identical/diverged a11y flags, plus file pointers to drill into.
- New `scripts/llm_proxy.py`: OpenAI-compatible FastAPI logging proxy. Pairs with cloudflared/ngrok so Browserbase can reach it from the public internet. Captures the exact messages array the agent ships to the model.
- `benchmark_run.py --llm-proxy-url`: routes Stagehand's agent calls through the proxy (uses `OPENAI_API_KEY`, bypassing Browserbase Model Gateway). Proxy URL recorded in `manifest.json`.
- `_stagehand.py:extract_usage()`: walks event payloads for token-usage fields across OpenAI/Anthropic/Gemini variants and aggregates `cached`/`cache_creation`/`reasoning` sub-fields.
- `benchmark_report.py`: `--backfill-tokens` re-aggregates from event logs locally, plus a scenario-level **Cache hit %** column in the scoreboard.
- README: new "Iterating on one task with two scenarios" subsection, the proxy walkthrough, and Notes additions covering the new token sub-fields and cache-hit signal.

## Test plan

- [x] `compare_scenarios.py --help` boots
- [x] Render-only smoke test against an existing run (`run_20260601_204107_e2ee`, task `arxiv-recent-cs-ai`) — aggregate, per-rep, and paired-step tables all populated correctly; per-task filter strips other tasks from the aggregate; null-token reps render as `—`; unpaired steps from either side surface in the step table.
- [ ] End-to-end Browserbase run with `--llm-proxy-url` against a tunneled `llm_proxy.py` (deferred — costs real API quota).

🤖 Generated with [Claude Code](https://claude.com/claude-code)