### PR TITLE
Apply weather.gov URL helper at the home page

### DIFF
--- a/extension/data/sites/weather-gov.yaml
+++ b/extension/data/sites/weather-gov.yaml
@@ -1,4 +1,5 @@
 hostnames:
+  - "www.weather.gov"
   - "forecast.weather.gov"
 
 rules:

--- a/extension/src/rules/site-data.generated.ts
+++ b/extension/src/rules/site-data.generated.ts
@@ -1485,6 +1485,7 @@ Idea boards (signed-in only): /myideaboards (out of scope without auth).
   {
     // from data/sites/weather-gov.yaml
     patterns: [
+      new URLPattern({ hostname: "www.weather.gov" }),
       new URLPattern({ hostname: "forecast.weather.gov" }),
     ],
     recipe: `abs URL helper for forecast.weather.gov — prefer URL navigation over typing.


### PR DESCRIPTION
## Summary

- `extension/data/sites/weather-gov.yaml` only covered `forecast.weather.gov` — the URL-recipe note landed on the destination, not the entry point. By the time the agent saw it, the search form had already been submitted and the agent was deep in the WFO map interstitial.
- Add `www.weather.gov` to the file-level `hostnames` so the recipe fires at body-top on the home page, where it can steer the agent to direct `goto /MapClick.php?lat={lat}&lon={lon}` instead of typing into the location form. Existing recipe wording reads correctly from the home page; no recipe rewrite.
- Regenerated `extension/src/rules/site-data.generated.ts` via `bun run build-site-data` — 1-line URLPattern addition.

This is a productivity tweak, **not** a regression fix. At n=3 on `weather-nyc-week-coldest` the guarded vs baseline gap was dominated by one outlier rep where gpt-5-mini happened to pick a slow path through the post-search interstitial; the other reps were within noise (homepage tree diff between scenarios is one line: the options-badge button). The helper on the home page should push both scenarios toward the direct-goto path and squeeze out that variance.

## Test plan

- [ ] `bun run check` clean (Biome + ESLint).
- [ ] Re-run `uv run scripts/compare_scenarios.py --scenario gpt5-mini-baseline --scenario gpt5-mini-guarded --task weather-nyc-week-coldest -n 5 --llm-proxy-url <tunnel>` and confirm the URL helper appears in the home-page `function_call_output` tree on the guarded side.
- [ ] Confirm guarded reps now prefer `goto /MapClick.php?lat=...&lon=...` over `act` against the location textbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)