### PR TITLE
Auto-rebuild extension in compare_scenarios.py

### DIFF
--- a/scripts/compare_scenarios.py
+++ b/scripts/compare_scenarios.py
@@ -102,6 +102,14 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--pricing", type=Path, default=DEFAULT_PRICING)
     p.add_argument("--run-id", default=None, help="Override auto-minted run id.")
     p.add_argument(
+        "--no-rebuild-extension",
+        action="store_true",
+        help="Skip the pre-run `bun run build && bun run package`. By default "
+        "the script rebuilds output/extension.zip so source edits (rule code, "
+        "site YAMLs, defaults JSON) take effect this run. Pass this when the "
+        "zip path is pinned to a release artifact you don't want clobbered.",
+    )
+    p.add_argument(
         "--open",
         action="store_true",
         help="Open the HTML side-by-side diff in the default browser.",
@@ -119,6 +127,21 @@ def parse_args() -> argparse.Namespace:
 def mint_run_id() -> str:
     ts = dt.datetime.now(dt.UTC).strftime("%Y%m%d_%H%M%S")
     return f"cmp_{ts}_{secrets.token_hex(2)}"
+
+
+def rebuild_extension() -> None:
+    # Codegen + bundle + zip together take <2s on a clean tree; cheap enough
+    # to do every run so source edits in rules/, data/sites/, or
+    # data/rule-defaults.json can't silently miss this comparison the way
+    # they would with a stale zip on disk.
+    ext_dir = REPO_ROOT / "extension"
+    print("rebuilding extension (bun run build && bun run package)...")
+    rc = subprocess.call(["bun", "run", "build"], cwd=ext_dir)
+    if rc != 0:
+        sys.exit(f"`bun run build` exited {rc}")
+    rc = subprocess.call(["bun", "run", "package"], cwd=ext_dir)
+    if rc != 0:
+        sys.exit(f"`bun run package` exited {rc}")
 
 
 def run_benchmark(args: argparse.Namespace, run_id: str) -> None:
@@ -626,6 +649,16 @@ def main() -> int:
     if args.llm_proxy_url:
         print(f"llm proxy: {args.llm_proxy_url}")
     print()
+
+    if not args.no_rebuild_extension and args.extension_zip == DEFAULT_EXTENSION_ZIP:
+        rebuild_extension()
+        print()
+    elif args.extension_zip != DEFAULT_EXTENSION_ZIP and not args.no_rebuild_extension:
+        print(
+            f"skipping rebuild — --extension-zip overridden to "
+            f"{args.extension_zip.relative_to(REPO_ROOT) if args.extension_zip.is_relative_to(REPO_ROOT) else args.extension_zip}"
+        )
+        print()
 
     run_benchmark(args, run_id)
 

--- a/skills/agent-browser-shield-autoresearch/SKILL.md
+++ b/skills/agent-browser-shield-autoresearch/SKILL.md
@@ -29,8 +29,12 @@ If the user already has a run in hand and just wants the *why*, hand off to
 
 ## Pre-flight
 
-- `output/extension.zip` exists (any scenario with `extension: true` needs it).
-  Build with `cd extension && bun run build && bun run package && cd ..` if not.
+- `output/extension.zip` is auto-rebuilt by `compare_scenarios.py` before each
+  run (codegen + bundle + zip, \<2s on a clean tree), so source edits in
+  `extension/src/rules/`, `extension/data/sites/`, or
+  `extension/data/rule-defaults.json` take effect on the next comparison. Pass
+  `--no-rebuild-extension` to opt out (useful when `--extension-zip` is pinned
+  to a release artifact).
 - `OPENAI_API_KEY` is in `.env` (the judge always calls OpenAI directly,
   regardless of the agent model).
 - `BROWSERBASE_API_KEY` + `BROWSERBASE_PROJECT_ID` are in `.env`.
@@ -191,14 +195,100 @@ State the proposal in terms of: the file to change, the specific change, and the
 trace evidence supporting it. Don't propose changes that aren't grounded in the
 trace.
 
-## 5. Across-model loop (optional)
+## 5. Apply the change and re-test
+
+`scripts/compare_scenarios.py` auto-rebuilds `output/extension.zip` (codegen +
+bundle + zip, \<2s) before each run, so source edits below take effect on the
+next §1 invocation with no manual rebuild step. Pass `--no-rebuild-extension`
+only when `--extension-zip` is pinned to a release artifact you don't want
+clobbered.
+
+### Where each change lives
+
+- **Default rule toggles** — `extension/data/rule-defaults.json`. Flat map of
+  `<rule-id>` to boolean. The codegen
+  (`extension/scripts/build-rule-defaults.ts`) validates that every registered
+  id has a default and rejects unknown ids; do not edit the generated
+  `extension/src/rules/rule-defaults.generated.ts`. To flip
+  `irrelevant-sections-hide` on for one experiment, change `false` to `true`
+  here and rebuild.
+- **Site-specific rules** — `extension/data/sites/<host>.yaml`. Codegen
+  (`extension/scripts/build-site-data.ts`) validates each YAML against
+  `extension/data/site-rules.schema.ts` and emits
+  `extension/src/rules/site-data.generated.ts`. For selector-authoring workflow
+  (probing the live site, validating against the schema), hand off to
+  `agent-browser-shield-site-rules`. For the YAML edit alone, do it inline.
+- **Built-in JS rule behavior** — `extension/src/rules/<rule-id>.ts`. Edit when
+  the trace shows a rule firing on false-positives (e.g. masking a real price as
+  PII, stripping nav the agent needed) or missing content it should catch. Each
+  rule exports a `Rule` object from `./types`; see existing rules for the shape.
+  Unit tests live next to each rule at
+  `extension/src/rules/__tests__/<rule-id>.test.ts` — add a failing fixture
+  reproducing the trace observation before changing the rule, so the refinement
+  is anchored.
+- **New defense rule** — create `extension/src/rules/<new-id>.ts`, import + add
+  it to the tuple in `extension/src/rules/index.ts`, add a default to
+  `extension/data/rule-defaults.json`. See the `agent-browser-shield` skill for
+  the rule contract.
+- **Injection regex patterns** — `extension/data/injection-patterns.yaml`
+  (base64-encoded sources). Codegen emits the plaintext RegExp file. Do not edit
+  the generated file. Be aware of the project rule that the regex source
+  phrasing should not leak into docs (see auto-memory).
+
+### Re-run §1
+
+After editing, re-run §1 with the same task and scenarios. The script handles
+the rebuild itself; no `bun` commands needed from you. If you want a manual
+rebuild for some reason (e.g. inspecting the generated files before running the
+comparison): `cd extension && bun run build && bun run package`. `bun run build`
+invokes all three codegens automatically.
+
+### Verify the change shipped
+
+Before drawing conclusions from the re-run, confirm the change is actually in
+the bundle:
+
+- For default toggles or new rules: grep the rebuilt
+  `extension/src/rules/rule-defaults.generated.ts` for the id.
+- For site rules: grep `extension/src/rules/site-data.generated.ts` for the host
+  or selector.
+- For built-in rule code edits: `bun run test -- <rule-id>` (or
+  `jest <rule-id>`) and make sure the new fixture passes. Then check `mtime` on
+  `output/extension.zip` is newer than your edit.
+
+If the rebuild fails (typo in YAML, schema rejection, unknown rule id), the
+codegen error message names the offending file and line — fix and retry. Do not
+work around codegen by editing the `*.generated.ts` files directly.
+
+### Debugging a built-in rule from the trace
+
+When the divergence-turn diff (§3) implicates a specific built-in rule but the
+*why* isn't obvious from the rule's source, the fast loop is:
+
+1. Pull the exact pre-rule HTML for the divergence page — the proxy log only has
+   the post-rule a11y tree, so reproduce locally: load the page in a real
+   Chromium with the extension loaded (see `agent-browser-shield-install` Path
+   A), open DevTools, snapshot the relevant subtree, then load the same page
+   with the rule disabled via the Options page to compare.
+2. Distill into a Jest fixture under
+   `extension/src/rules/__tests__/<rule-id>.test.ts`. The existing tests use
+   `jsdom`-style DOM construction; mirror the pattern.
+3. Iterate the rule until the fixture matches expected behavior, then rebuild
+   and re-run §1 to confirm the trace-level effect.
+
+This is faster than the Browserbase round-trip for narrowing-down work — but the
+§1 re-run is still required to confirm the agent-level outcome actually moved.
+
+## 6. Across-model loop (optional)
 
 If the user asked "across models" and multiple `(baseline, guarded)` scenario
 pairs exist in the scenarios file:
 
 1. Run §1 once per pair.
 2. Apply §2–§3 to each run.
-3. Synthesize: does the guard's effect generalize across models, or is it
+3. If a refinement looks promising on one model, apply it once via §5 and re-run
+   all pairs — measuring the same edit across models is the point.
+4. Synthesize: does the guard's effect generalize across models, or is it
    model-specific?
 
 Common patterns:
@@ -216,7 +306,7 @@ If there's only one model pair available (the shipped file), say so and
 recommend adding scenarios for the other models the user cares about before
 extending the experiment.
 
-## 6. Report back
+## 7. Report back
 
 Lead with: the classification (helps / hurts / neutral / flips), the headline
 metric delta with its noise caveat (`n=3`), the *specific* rule fingerprint


### PR DESCRIPTION
## Summary

- `scripts/compare_scenarios.py` now runs `bun run build && bun run package` before each comparison (codegen + bundle + zip, <2s on a clean tree). Source edits in `extension/src/rules/`, `extension/data/sites/`, or `extension/data/rule-defaults.json` take effect on the next run with no manual rebuild step.
- Pass `--no-rebuild-extension` to opt out; auto-skipped when `--extension-zip` is overridden to a non-default path (so release-artifact comparisons aren't clobbered).
- `skills/agent-browser-shield-autoresearch/SKILL.md` adds a §5 "Apply the change and re-test" covering where each kind of change lives (defaults JSON, site YAML, built-in JS rule body, new rule, injection patterns), how to verify the change shipped, and a debugging loop for built-in JS rules. Reflects the auto-rebuild so the skill no longer instructs a manual `bun run build` step.

## Motivation

Discovered while autoresearching `weather-nyc`: the `output/extension.zip` on disk predated commit 5f48684 (which added `www.weather.gov` to the search-url-helper YAML), so the comparison measured an extension without the recipe's primary hostname pattern. The shipped `content.js` only had `forecast.weather.gov` in the bundle. With a fresh build, guarded steps drop from 14 → 4 (mean), tokens −79%, cost −77%, duration −70% — all 3 guarded reps now use `goto https://forecast.weather.gov/MapClick.php?lat=40.7142&lon=-74.0064` (the recipe's verbatim NYC coords).

The stale-zip gotcha is now structurally prevented for autoresearch runs.

## Test plan

- [ ] `uv run scripts/compare_scenarios.py --scenario gpt5-mini-baseline --scenario gpt5-mini-guarded --task weather-nyc -n 3 --llm-proxy-url <tunnel>` — prints "rebuilding extension..." before the benchmark, and the proxy log shows the URL helper landmark in the agent's www.weather.gov a11y tree.
- [ ] Same command with `--no-rebuild-extension` — skips the rebuild step.
- [ ] Same command with `--extension-zip /abs/path/to/release.zip` — auto-skips rebuild and prints a "skipping rebuild" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)