### PR TITLE
Drop S3 publish + rename release zip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,10 @@ jobs:
       - name: Upload extension zip
         uses: actions/upload-artifact@v7
         with:
-          path: output/extension.zip
+          path: output/agent-browser-shield-extension.zip
           archive: false
           if-no-files-found: error
+          retention-days: 30
 
       # CWS rejects manifests containing a "key" field. Emit a sibling zip with
       # "key" stripped so the initial CWS listing (and any manual re-uploads)

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -3,10 +3,6 @@ name: Release extension
 on:
   workflow_dispatch:
     inputs:
-      publish_s3:
-        description: "Upload to S3 (versioned + latest)"
-        type: boolean
-        default: true
       publish_chrome_web_store:
         description: "Submit to Chrome Web Store for publication"
         type: boolean
@@ -14,7 +10,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 concurrency:
   group: release-extension
@@ -76,40 +71,15 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: extension-zip-${{ steps.version.outputs.tag }}
-          path: output/extension.zip
+          path: output/agent-browser-shield-extension.zip
           archive: false
           if-no-files-found: error
-
-      - uses: aws-actions/configure-aws-credentials@v4
-        if: ${{ inputs.publish_s3 }}
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Upload versioned ZIP
-        if: ${{ inputs.publish_s3 }}
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          aws s3 cp output/extension.zip \
-            "s3://agent-browser-shield/${TAG}/extension.zip" \
-            --content-type application/zip \
-            --content-disposition 'attachment; filename="extension.zip"' \
-            --cache-control 'public, max-age=31536000, immutable'
-
-      - name: Upload latest pointer
-        if: ${{ inputs.publish_s3 }}
-        run: |
-          aws s3 cp output/extension.zip \
-            s3://agent-browser-shield/latest/extension.zip \
-            --content-type application/zip \
-            --content-disposition 'attachment; filename="extension.zip"' \
-            --cache-control 'public, max-age=300'
+          retention-days: 30
 
       # CWS rejects manifests containing a "key" field; produce a sibling zip
-      # with it stripped. The S3 zip still includes "key" if/when one is added,
-      # so consumers wanting a stable extension ID (e.g., Browserbase) aren't
-      # affected.
+      # with it stripped. The GitHub Release zip still includes "key" if/when
+      # one is added, so consumers wanting a stable extension ID (e.g.,
+      # Browserbase) aren't affected.
       - name: Package CWS-ready zip
         if: ${{ inputs.publish_chrome_web_store }}
         working-directory: extension
@@ -141,7 +111,7 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           gh release create "$TAG" \
-            output/extension.zip \
+            output/agent-browser-shield-extension.zip \
             --title "$TAG" \
             --generate-notes \
             --target "$GITHUB_SHA"

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Bundle `extension/dist/` into a ZIP suitable for uploading via the
 ```sh
 cd extension
 bun run build
-bun run package           # writes output/extension.zip at the repo root
+bun run package           # writes output/agent-browser-shield-extension.zip at the repo root
 # or specify an output path / directory:
 bun run package -- ~/Downloads/agent-browser-shield.zip
 ```

--- a/benchmark/scenarios.example.yaml
+++ b/benchmark/scenarios.example.yaml
@@ -6,7 +6,7 @@
 #
 # Fields:
 #   id          - stable slug used in result rows + report columns (required)
-#   extension   - true to load output/extension.zip; false to skip it (required)
+#   extension   - true to load output/agent-browser-shield-extension.zip; false to skip it (required)
 #   model       - Stagehand model name, e.g. openai/gpt-5-mini, anthropic/claude-haiku-4-5 (required)
 #   max_steps   - per-task step budget handed to the agent (default: 15)
 #

--- a/clawhub/agent-browser-shield/SKILL.md
+++ b/clawhub/agent-browser-shield/SKILL.md
@@ -12,15 +12,15 @@ engagement noise (ads, scarcity cues, social embeds).
 
 ## Install
 
-Release artifact (used by both paths):
-`https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/extension.zip`
+Hosted ZIP (used by both paths):
+`https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`
 — `manifest.json` is at the archive root; do not re-zip.
 
 ### Path 1 — Local Chrome via remote CDP (OpenClaw `remote` driver)
 
 Use when OpenClaw is connecting to a Chromium you launch yourself.
 
-1. Unzip `extension.zip` to a stable directory (e.g.
+1. Unzip `agent-browser-shield-extension.zip` to a stable directory (e.g.
    `~/.cache/agent-browser-shield/extension/`).
 
 2. Launch Chromium **headed** with a dedicated profile and the extension loaded:
@@ -53,7 +53,7 @@ Use when OpenClaw is connecting to a Chromium you launch yourself.
    openclaw browserbase status       # confirm
    ```
 
-2. Download `extension.zip` from the release URL above, then upload it to
+2. Download `agent-browser-shield-extension.zip` from the URL above, then upload it to
    Browserbase using the
    [`browse` CLI](https://docs.browserbase.com/integrations/skills/browse-cli)
    (npm `browse`):
@@ -61,7 +61,7 @@ Use when OpenClaw is connecting to a Chromium you launch yourself.
    ```sh
    npm install -g browse
    export BROWSERBASE_API_KEY="…"   # same key used by openclaw browserbase setup
-   browse cloud extensions upload ./extension.zip
+   browse cloud extensions upload ./agent-browser-shield-extension.zip
    ```
 
    The command prints an extension ID. **Claw: persist that ID in memory for

--- a/clawhub/agent-browser-shield/SKILL.md
+++ b/clawhub/agent-browser-shield/SKILL.md
@@ -53,8 +53,8 @@ Use when OpenClaw is connecting to a Chromium you launch yourself.
    openclaw browserbase status       # confirm
    ```
 
-2. Download `agent-browser-shield-extension.zip` from the URL above, then upload it to
-   Browserbase using the
+2. Download `agent-browser-shield-extension.zip` from the URL above, then upload
+   it to Browserbase using the
    [`browse` CLI](https://docs.browserbase.com/integrations/skills/browse-cli)
    (npm `browse`):
 

--- a/docs/src/content/docs/browser-use.md
+++ b/docs/src/content/docs/browser-use.md
@@ -124,7 +124,7 @@ from browser_use.llm import ChatOpenAI
 
 async def main():
     bb = Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
-    with open("output/extension.zip", "rb") as fh:
+    with open("output/agent-browser-shield-extension.zip", "rb") as fh:
         extension = bb.extensions.create(file=fh)
 
     session = bb.sessions.create(

--- a/docs/src/content/docs/browserbase-python.md
+++ b/docs/src/content/docs/browserbase-python.md
@@ -48,7 +48,7 @@ attach Playwright to the same `connect_url` for surgical interventions.
 - A packaged extension zip — download the
   [prebuilt ZIP](/agent-browser-shield/install/#download-a-prebuilt-zip), or
   follow [Install](/agent-browser-shield/install/) through `bun run package` to
-  produce `output/extension.zip` from source.
+  produce `output/agent-browser-shield-extension.zip` from source.
 - `BROWSERBASE_API_KEY` and `BROWSERBASE_PROJECT_ID` from *Settings → API Keys*
   at <https://www.browserbase.com>.
 - Python ≥ 3.11 with the [`browserbase`](https://pypi.org/project/browserbase/)
@@ -68,7 +68,7 @@ from browserbase import Browserbase
 
 bb = Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
 
-with open("output/extension.zip", "rb") as fh:
+with open("output/agent-browser-shield-extension.zip", "rb") as fh:
     extension = bb.extensions.create(file=fh)
 
 print(extension.id)  # ext_...
@@ -93,7 +93,7 @@ from browserbase import Browserbase
 from stagehand import Stagehand
 
 bb = Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
-with open("output/extension.zip", "rb") as fh:
+with open("output/agent-browser-shield-extension.zip", "rb") as fh:
     extension = bb.extensions.create(file=fh)
 
 stagehand = Stagehand(
@@ -127,7 +127,7 @@ drive.
 
 For a fully wired runner with logging, skill briefing, and CLI flags, see
 `scripts/agent_task.py` in the repo — pass `--with-extension` to upload and
-attach `output/extension.zip` automatically.
+attach `output/agent-browser-shield-extension.zip` automatically.
 
 ## Path B: Pure CDP (Playwright)
 
@@ -140,7 +140,7 @@ from browserbase import Browserbase
 from playwright.sync_api import sync_playwright
 
 bb = Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
-with open("output/extension.zip", "rb") as fh:
+with open("output/agent-browser-shield-extension.zip", "rb") as fh:
     extension = bb.extensions.create(file=fh)
 
 session = bb.sessions.create(

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -10,11 +10,11 @@ description: Build the agent-browser-shield extension and load it into Chromium.
 
 ## Download a prebuilt ZIP
 
-Each release publishes the packaged extension to S3. The `latest/` pointer
-follows the most recent release:
+Every release attaches the packaged extension to the GitHub Release. The
+`latest` redirect follows the most recent release:
 
 ```text
-https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip
+https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip
 ```
 
 `manifest.json` is at the archive root, so the ZIP can be uploaded straight to
@@ -101,7 +101,7 @@ After each rebuild, click the reload icon for the extension at
 The
 [Browserbase extensions API](https://docs.browserbase.com/platform/browser/core-features/browser-extensions#browser-extensions)
 accepts the prebuilt ZIP directly — download it from
-`https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip`
+`https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`
 and upload as-is.
 
 To build the ZIP from source instead:
@@ -109,7 +109,7 @@ To build the ZIP from source instead:
 ```sh
 cd extension
 bun run build
-bun run package   # writes output/extension.zip at the repo root
+bun run package   # writes output/agent-browser-shield-extension.zip at the repo root
 ```
 
 ## Contributing

--- a/docs/src/content/docs/openclaw.md
+++ b/docs/src/content/docs/openclaw.md
@@ -126,8 +126,8 @@ The flow:
 Download the
 [prebuilt ZIP](/agent-browser-shield/install/#download-a-prebuilt-zip), or
 follow [Install](/agent-browser-shield/install/) through `bun run package` to
-build one yourself at `output/agent-browser-shield-extension.zip`. Either way, `manifest.json` sits
-at the archive root — do not re-zip it.
+build one yourself at `output/agent-browser-shield-extension.zip`. Either way,
+`manifest.json` sits at the archive root — do not re-zip it.
 
 ### 2. Upload to Browserbase
 

--- a/docs/src/content/docs/openclaw.md
+++ b/docs/src/content/docs/openclaw.md
@@ -126,7 +126,7 @@ The flow:
 Download the
 [prebuilt ZIP](/agent-browser-shield/install/#download-a-prebuilt-zip), or
 follow [Install](/agent-browser-shield/install/) through `bun run package` to
-build one yourself at `output/extension.zip`. Either way, `manifest.json` sits
+build one yourself at `output/agent-browser-shield-extension.zip`. Either way, `manifest.json` sits
 at the archive root — do not re-zip it.
 
 ### 2. Upload to Browserbase
@@ -142,7 +142,7 @@ npm install -g browse
 export BROWSERBASE_API_KEY=bb_live_...
 export BROWSERBASE_PROJECT_ID=...
 
-browse cloud extensions upload ./output/extension.zip
+browse cloud extensions upload ./output/agent-browser-shield-extension.zip
 ```
 
 Stash the printed extension `id` — it's reusable across sessions until you

--- a/scripts/agent_task.py
+++ b/scripts/agent_task.py
@@ -45,7 +45,7 @@ from _stagehand import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-DEFAULT_EXTENSION_ZIP = REPO_ROOT / "output" / "extension.zip"
+DEFAULT_EXTENSION_ZIP = REPO_ROOT / "output" / "agent-browser-shield-extension.zip"
 DEFAULT_SKILL = REPO_ROOT / "skills" / "agent-browser-shield" / "SKILL.md"
 
 
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--with-extension",
         action="store_true",
-        help="Upload extension/extension.zip and load it into the session.",
+        help="Upload the packaged agent-browser-shield-extension.zip and load it into the session.",
     )
     parser.add_argument(
         "--extension-zip",

--- a/scripts/benchmark_run.py
+++ b/scripts/benchmark_run.py
@@ -81,7 +81,7 @@ from _stagehand import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-DEFAULT_EXTENSION_ZIP = REPO_ROOT / "output" / "extension.zip"
+DEFAULT_EXTENSION_ZIP = REPO_ROOT / "output" / "agent-browser-shield-extension.zip"
 DEFAULT_PRICING = REPO_ROOT / "benchmark" / "pricing.json"
 RESULTS_ROOT = REPO_ROOT / "output" / "results"
 

--- a/scripts/compare_scenarios.py
+++ b/scripts/compare_scenarios.py
@@ -49,7 +49,7 @@ RESULTS_ROOT = REPO_ROOT / "output" / "results"
 REPORTS_ROOT = REPO_ROOT / "output" / "reports"
 DEFAULT_SCENARIOS = REPO_ROOT / "benchmark" / "scenarios.example.yaml"
 DEFAULT_TASKS = REPO_ROOT / "benchmark" / "tasks.csv"
-DEFAULT_EXTENSION_ZIP = REPO_ROOT / "output" / "extension.zip"
+DEFAULT_EXTENSION_ZIP = REPO_ROOT / "output" / "agent-browser-shield-extension.zip"
 DEFAULT_PRICING = REPO_ROOT / "benchmark" / "pricing.json"
 
 sys.path.insert(0, str(SCRIPTS_DIR))
@@ -105,7 +105,7 @@ def parse_args() -> argparse.Namespace:
         "--no-rebuild-extension",
         action="store_true",
         help="Skip the pre-run `bun run build && bun run package`. By default "
-        "the script rebuilds output/extension.zip so source edits (rule code, "
+        "the script rebuilds output/agent-browser-shield-extension.zip so source edits (rule code, "
         "site YAMLs, defaults JSON) take effect this run. Pass this when the "
         "zip path is pinned to a release artifact you don't want clobbered.",
     )

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -3,7 +3,7 @@
 #
 # Triggers .github/workflows/release-extension.yml on main. The workflow
 # computes the version (YYYY.M.D.<run_number>), patches the manifest, builds,
-# uploads to S3, and creates the GitHub Release.
+# and creates the GitHub Release with the extension zip attached.
 #
 # Usage:
 #   scripts/cut-release.sh           # dispatch and print the run URL

--- a/scripts/package-extension.ts
+++ b/scripts/package-extension.ts
@@ -9,7 +9,7 @@ import { parseArgs } from "node:util";
 
 const REPO_ROOT = resolve(import.meta.dir, "..");
 const DIST = join(REPO_ROOT, "extension", "dist");
-const DEFAULT_OUTPUT = join(REPO_ROOT, "output", "extension.zip");
+const DEFAULT_OUTPUT = join(REPO_ROOT, "output", "agent-browser-shield-extension.zip");
 
 const { values, positionals } = parseArgs({
   args: process.argv.slice(2),
@@ -26,7 +26,7 @@ if (values.help) {
     `Usage: bun run scripts/package-extension.ts [output]\n\n` +
       `Zips extension/dist/ for upload to Browserbase or the Chrome Web Store.\n\n` +
       `Arguments:\n` +
-      `  output            Output path. If it's a directory, writes extension.zip inside.\n` +
+      `  output            Output path. If it's a directory, writes agent-browser-shield-extension.zip inside.\n` +
       `                    Defaults to ${relative(REPO_ROOT, DEFAULT_OUTPUT)}.\n\n` +
       `Options:\n` +
       `  -o, --output      Same as the positional argument.\n` +
@@ -57,7 +57,7 @@ async function resolveOutput(): Promise<string> {
   const abs = resolve(process.cwd(), raw);
   const existing = await stat(abs).catch(() => null);
   if (existing?.isDirectory() || raw.endsWith("/")) {
-    return join(abs, "extension.zip");
+    return join(abs, "agent-browser-shield-extension.zip");
   }
   return abs.endsWith(".zip") ? abs : `${abs}.zip`;
 }

--- a/skills/agent-browser-shield-autoresearch/SKILL.md
+++ b/skills/agent-browser-shield-autoresearch/SKILL.md
@@ -29,12 +29,12 @@ If the user already has a run in hand and just wants the *why*, hand off to
 
 ## Pre-flight
 
-- `output/agent-browser-shield-extension.zip` is auto-rebuilt by `compare_scenarios.py` before each
-  run (codegen + bundle + zip, \<2s on a clean tree), so source edits in
-  `extension/src/rules/`, `extension/data/sites/`, or
-  `extension/data/rule-defaults.json` take effect on the next comparison. Pass
-  `--no-rebuild-extension` to opt out (useful when `--extension-zip` is pinned
-  to a release artifact).
+- `output/agent-browser-shield-extension.zip` is auto-rebuilt by
+  `compare_scenarios.py` before each run (codegen + bundle + zip, \<2s on a
+  clean tree), so source edits in `extension/src/rules/`,
+  `extension/data/sites/`, or `extension/data/rule-defaults.json` take effect on
+  the next comparison. Pass `--no-rebuild-extension` to opt out (useful when
+  `--extension-zip` is pinned to a release artifact).
 - `OPENAI_API_KEY` is in `.env` (the judge always calls OpenAI directly,
   regardless of the agent model).
 - `BROWSERBASE_API_KEY` + `BROWSERBASE_PROJECT_ID` are in `.env`.
@@ -197,11 +197,11 @@ trace.
 
 ## 5. Apply the change and re-test
 
-`scripts/compare_scenarios.py` auto-rebuilds `output/agent-browser-shield-extension.zip` (codegen +
-bundle + zip, \<2s) before each run, so source edits below take effect on the
-next §1 invocation with no manual rebuild step. Pass `--no-rebuild-extension`
-only when `--extension-zip` is pinned to a release artifact you don't want
-clobbered.
+`scripts/compare_scenarios.py` auto-rebuilds
+`output/agent-browser-shield-extension.zip` (codegen + bundle + zip, \<2s)
+before each run, so source edits below take effect on the next §1 invocation
+with no manual rebuild step. Pass `--no-rebuild-extension` only when
+`--extension-zip` is pinned to a release artifact you don't want clobbered.
 
 ### Where each change lives
 

--- a/skills/agent-browser-shield-autoresearch/SKILL.md
+++ b/skills/agent-browser-shield-autoresearch/SKILL.md
@@ -29,7 +29,7 @@ If the user already has a run in hand and just wants the *why*, hand off to
 
 ## Pre-flight
 
-- `output/extension.zip` is auto-rebuilt by `compare_scenarios.py` before each
+- `output/agent-browser-shield-extension.zip` is auto-rebuilt by `compare_scenarios.py` before each
   run (codegen + bundle + zip, \<2s on a clean tree), so source edits in
   `extension/src/rules/`, `extension/data/sites/`, or
   `extension/data/rule-defaults.json` take effect on the next comparison. Pass
@@ -197,7 +197,7 @@ trace.
 
 ## 5. Apply the change and re-test
 
-`scripts/compare_scenarios.py` auto-rebuilds `output/extension.zip` (codegen +
+`scripts/compare_scenarios.py` auto-rebuilds `output/agent-browser-shield-extension.zip` (codegen +
 bundle + zip, \<2s) before each run, so source edits below take effect on the
 next §1 invocation with no manual rebuild step. Pass `--no-rebuild-extension`
 only when `--extension-zip` is pinned to a release artifact you don't want
@@ -254,7 +254,7 @@ the bundle:
   or selector.
 - For built-in rule code edits: `bun run test -- <rule-id>` (or
   `jest <rule-id>`) and make sure the new fixture passes. Then check `mtime` on
-  `output/extension.zip` is newer than your edit.
+  `output/agent-browser-shield-extension.zip` is newer than your edit.
 
 If the rebuild fails (typo in YAML, schema rejection, unknown rule id), the
 codegen error message names the offending file and line — fix and retry. Do not

--- a/skills/agent-browser-shield-install/SKILL.md
+++ b/skills/agent-browser-shield-install/SKILL.md
@@ -21,13 +21,13 @@ only covers getting the extension loaded.
 | Attaching via CDP / MCP to a Chrome the user already controls | **Path C** |
 
 The hosted ZIP is at
-`https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip`
+`https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`
 and has `manifest.json` at the archive root. Do not re-zip it.
 
 ## Path A — Local headed Chromium, unpacked load
 
 1. Download
-   `https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip`
+   `https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`
    and unzip to a stable directory, e.g.
    `~/.cache/agent-browser-shield/extension/`. The unzipped directory must
    contain `manifest.json` directly (no nested folder).
@@ -62,7 +62,7 @@ and has `manifest.json` at the archive root. Do not re-zip it.
    ```
 
 2. **Download** the ZIP from
-   `https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip`.
+   `https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`.
    Do not unzip.
 
 3. **Upload** the ZIP and capture the returned `id`. Pick one of the four
@@ -73,7 +73,7 @@ and has `manifest.json` at the archive root. Do not re-zip it.
 
    ```sh
    npm install -g browse
-   browse cloud extensions upload ./agent-browser-shield.zip
+   browse cloud extensions upload ./agent-browser-shield-extension.zip
    ```
 
    **b. Legacy Browserbase CLI** (`@browserbasehq/cli`, command `bb`). Still
@@ -82,7 +82,7 @@ and has `manifest.json` at the archive root. Do not re-zip it.
 
    ```sh
    npm install -g @browserbasehq/cli
-   bb extensions upload ./agent-browser-shield.zip
+   bb extensions upload ./agent-browser-shield-extension.zip
    ```
 
    **c. SDK:**
@@ -92,7 +92,7 @@ and has `manifest.json` at the archive root. Do not re-zip it.
    ```
 
    ```py
-   ext = bb.extensions.create(file=open("agent-browser-shield.zip", "rb"))  # Python
+   ext = bb.extensions.create(file=open("agent-browser-shield-extension.zip", "rb"))  # Python
    ```
 
    **d. REST:**
@@ -100,7 +100,7 @@ and has `manifest.json` at the archive root. Do not re-zip it.
    ```sh
    curl -X POST https://api.browserbase.com/v1/extensions \
      -H "X-BB-API-Key: $BROWSERBASE_API_KEY" \
-     -F "file=@agent-browser-shield.zip"
+     -F "file=@agent-browser-shield-extension.zip"
    ```
 
 4. Pass the returned id when creating the session: `extensionId` (Node SDK) or
@@ -122,7 +122,7 @@ and has `manifest.json` at the archive root. Do not re-zip it.
 6. The most common upload failure is `manifest.json` not at the archive root.
    The hosted ZIP is already correctly shaped; if you build your own, zip from
    inside the dist directory
-   (`cd dist && zip -r ../agent-browser-shield.zip .`), never the parent.
+   (`cd dist && zip -r ../agent-browser-shield-extension.zip .`), never the parent.
 
 ## Path C — CDP / MCP attach to user-controlled Chrome
 
@@ -131,7 +131,7 @@ attaches.
 
 1. Tell the user (once, then remember it's done):
    1. Download
-      `https://agent-browser-shield.s3.us-east-2.amazonaws.com/latest/extension.zip`
+      `https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`
       and unzip somewhere stable.
    2. Open `chrome://extensions`, enable **Developer mode**, click **Load
       unpacked**, select the unzipped directory.

--- a/skills/agent-browser-shield-install/SKILL.md
+++ b/skills/agent-browser-shield-install/SKILL.md
@@ -122,7 +122,8 @@ and has `manifest.json` at the archive root. Do not re-zip it.
 6. The most common upload failure is `manifest.json` not at the archive root.
    The hosted ZIP is already correctly shaped; if you build your own, zip from
    inside the dist directory
-   (`cd dist && zip -r ../agent-browser-shield-extension.zip .`), never the parent.
+   (`cd dist && zip -r ../agent-browser-shield-extension.zip .`), never the
+   parent.
 
 ## Path C — CDP / MCP attach to user-controlled Chrome
 

--- a/skills/agent-browser-shield-release/SKILL.md
+++ b/skills/agent-browser-shield-release/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: agent-browser-shield-release
-description: Cut a release of the agent-browser-shield Chromium extension. CalVer YYYY.M.D.<github.run_number> versioning, workflow-driven — .github/workflows/release-extension.yml computes the version, patches the manifest, builds the ZIP, creates the GitHub Release, and uploads to S3. Use when the user asks to ship, release, publish, or push a new build of the extension. NOT for editing rule code, running benchmarks, or local-only testing.
+description: Cut a release of the agent-browser-shield Chromium extension. CalVer YYYY.M.D.<github.run_number> versioning, workflow-driven — .github/workflows/release-extension.yml computes the version, patches the manifest, builds the ZIP, and creates the GitHub Release with the ZIP attached. Use when the user asks to ship, release, publish, or push a new build of the extension. NOT for editing rule code, running benchmarks, or local-only testing.
 ---
 
 # Releasing agent-browser-shield
 
 Releases are produced by `.github/workflows/release-extension.yml`. The workflow
-computes the version, builds the extension, creates the GitHub Release with the
-ZIP attached, and uploads the ZIP to S3 (both a versioned path and the `latest/`
-pointer that the install skill points consumers at).
+computes the version, builds the extension, and creates the GitHub Release with
+the ZIP attached. Consumers download from
+`https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`
+— the `latest` redirect follows the most recent release.
 
 Nothing is tagged or version-bumped in the source tree. The tag, the manifest
 `version` field in the shipped ZIP, and the GitHub Release are all created by CI
@@ -61,12 +62,9 @@ gh workflow run release-extension.yml --ref main
 2. `jq`-patches `extension/src/manifest.json` `version` in the runner's
    checkout. Never committed back.
 3. `bun install --frozen-lockfile`, `bun run build`, `bun run package` →
-   `output/extension.zip`.
-4. Uploads to:
-   - `s3://agent-browser-shield/${tag}/extension.zip` (immutable, cached 1y)
-   - `s3://agent-browser-shield/latest/extension.zip` (5-minute cache)
-5. Creates the GitHub Release at `$GITHUB_SHA` with auto-generated notes and the
-   ZIP attached.
+   `output/agent-browser-shield-extension.zip`.
+4. Creates the GitHub Release at `$GITHUB_SHA` with auto-generated notes and the
+   ZIP attached as a release asset.
 
 ## Rolling back / re-releasing
 
@@ -78,8 +76,8 @@ gh workflow run release-extension.yml --ref <sha-or-branch>
 ```
 
 The new release will have a higher `run_number` than anything before it, so
-Chrome will auto-update to it. The previous "bad" S3 versioned URL is left in
-place (immutable); only `latest/` moves.
+Chrome will auto-update to it. The previous release's tag and assets stay
+published at their versioned URLs; only the `latest` redirect moves.
 
 The script `scripts/cut-release.sh` refuses to run off `main`. To release from a
 SHA or branch, invoke `gh workflow run` directly — be sure you know what you're


### PR DESCRIPTION
## Summary

- Drop the S3 publish path from `release-extension.yml` (the `publish_s3`
  workflow input, the `aws-actions/configure-aws-credentials` step, and the
  two `aws s3 cp` steps for the versioned + `latest/` paths). Since the repo
  is public, GitHub Release assets are downloadable without auth, and the
  S3 mirror was redundant.
- Rename the packaged ZIP from `extension.zip` to
  `agent-browser-shield-extension.zip` everywhere it surfaces — package
  script default, CI artifact path, GH release asset name, benchmark
  scripts, docs, and skills — so the downloaded filename is descriptive.
- Set explicit `retention-days: 30` on the `actions/upload-artifact` calls
  in both CI and the release workflow.
- Switch the canonical download URL referenced in docs and skills
  (install, release, autoresearch, clawhub) to
  `https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`.

## Test plan

- [x] `bun install --frozen-lockfile && bun run build && bun run package`
      produces `output/agent-browser-shield-extension.zip`.
- [x] `bun run package:cws` still produces `output/extension-cws.zip`
      (unchanged — only the consumer-facing ZIP was renamed).
- [x] `bun run check` clean.
- [ ] On merge: dispatch `release-extension.yml` to confirm the GitHub
      Release attaches the renamed asset and the `latest` redirect resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)