### PR TITLE
Add preamble A/B-test infrastructure for autoresearch

### DIFF
--- a/scripts/_aggregate_expand.py
+++ b/scripts/_aggregate_expand.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env -S uv run --script
+# Copyright (c) 2026 PixieBrix, Inc.
+# Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Aggregate the expand_v{0..3}_<task> run directories produced by
+_run_expand_autoresearch.sh into one markdown digest.
+
+Emits output/results/expand_summary.md with three layers:
+
+1. Per-task aggregate table — for each of the 6 tasks, the 4 preamble
+   variants vs baseline scenario (extension off), showing mean tokens,
+   steps, pass count, and (most importantly) the "direct goto" rate
+   for the guarded scenario: how often the agent jumped straight to a
+   constructed URL instead of using the on-page search UI.
+
+2. Cross-task variant rollup — the same metrics averaged across all 6
+   tasks, one row per variant.
+
+3. Recommendation block — a few-line read of whether any variant
+   improves on baseline once you control for task-to-task noise.
+
+Direct-goto detection looks at the FIRST agent action after the initial
+page load: if it's a `goto` to a URL whose path is not the start URL's
+path, that rep "used the URL helper". This is the load-bearing signal
+because suppressing it without improving correctness means the variant
+is paying a cost (slower / more steps) for no gain.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RESULTS_ROOT = REPO_ROOT / "output" / "results"
+
+VARIANTS = ["v0", "v1", "v2", "v3"]
+VARIANT_LABELS = {
+    "v0": "baseline",
+    "v1": "no-guess",
+    "v2": "terse-no-guess",
+    "v3": "search-default",
+}
+TASKS = [
+    "wiki-claude",
+    "wikipedia-einstein-advisor",
+    "amazon-headphones",
+    "npm-react-version",
+    "mdn-array-map",
+    "ikea-billy-cheapest-white",
+]
+START_URLS = {
+    "wiki-claude": "https://en.wikipedia.org",
+    "wikipedia-einstein-advisor": "https://en.wikipedia.org",
+    "amazon-headphones": "https://www.amazon.com",
+    "npm-react-version": "https://www.npmjs.com",
+    "mdn-array-map": "https://developer.mozilla.org",
+    "ikea-billy-cheapest-white": "https://www.ikea.com/us/en/",
+}
+SCENARIOS = ("gpt5-mini-baseline", "gpt5-mini-guarded")
+
+
+def run_dir(variant: str, task: str) -> Path:
+    return RESULTS_ROOT / f"expand_{variant}_{task}"
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    rows: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return rows
+
+
+def trace_steps(rdir: Path, scenario: str, task: str, rep: int) -> list[dict]:
+    p = rdir / "traces" / f"{scenario}__{task}__r{rep}" / "steps.json"
+    if not p.is_file():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    return data if isinstance(data, list) else []
+
+
+def used_direct_goto(steps: list[dict], task: str) -> bool:
+    """True if the first non-trivial agent action is a `goto` to a path
+    other than the task's start URL path. We skip leading screenshot/
+    ariaTree probes which Stagehand sometimes prepends without LLM input."""
+    start_path = urlparse(START_URLS[task]).path or "/"
+    start_path = start_path.rstrip("/")
+    for s in steps:
+        t = s.get("type")
+        if t in ("ariaTree", "screenshot"):
+            continue
+        if t == "goto":
+            url = s.get("page_url") or ""
+            path = urlparse(url).path or "/"
+            path = path.rstrip("/")
+            return path != start_path and path != ""
+        return False
+    return False
+
+
+def judge_verdict(row: dict) -> str:
+    if row.get("error"):
+        return "error"
+    v = (row.get("judge") or {}).get("pass")
+    if v is True:
+        return "pass"
+    if v is False:
+        return "fail"
+    return "ungraded"
+
+
+def mean(xs: list) -> float | None:
+    vals = [float(x) for x in xs if x is not None]
+    if not vals:
+        return None
+    return statistics.mean(vals)
+
+
+def cell(variant: str, task: str) -> dict:
+    rdir = run_dir(variant, task)
+    rows = load_jsonl(rdir / "results.jsonl")
+    by_scen = {s: [] for s in SCENARIOS}
+    for r in rows:
+        sid = str(r.get("scenario_id") or "")
+        if sid in by_scen:
+            by_scen[sid].append(r)
+    out: dict = {"variant": variant, "task": task, "scenarios": {}}
+    for sid in SCENARIOS:
+        srows = by_scen[sid]
+        if not srows:
+            out["scenarios"][sid] = None
+            continue
+        total = [(r.get("tokens") or {}).get("total") for r in srows]
+        cached = [(r.get("tokens") or {}).get("cached") for r in srows]
+        steps = [r.get("steps_taken") for r in srows]
+        cost = [r.get("cost_usd") for r in srows]
+        verdicts = [judge_verdict(r) for r in srows]
+        # direct goto from trace
+        direct = 0
+        for r in srows:
+            rep = int(r.get("repetition") or 1)
+            sts = trace_steps(rdir, sid, task, rep)
+            if used_direct_goto(sts, task):
+                direct += 1
+        out["scenarios"][sid] = {
+            "n": len(srows),
+            "total_tokens": mean(total),
+            "cached_tokens": mean(cached),
+            "steps": mean(steps),
+            "cost": mean(cost),
+            "pass": verdicts.count("pass"),
+            "fail": verdicts.count("fail"),
+            "error": verdicts.count("error"),
+            "direct_goto": direct,
+        }
+    return out
+
+
+def fmt_int(n) -> str:
+    if n is None:
+        return "—"
+    return f"{round(float(n)):,}"
+
+
+def fmt_pct_delta(a, b) -> str:
+    if a in (None, 0) or b is None:
+        return "—"
+    return f"{(b - a) / a * 100:+.0f}%"
+
+
+def fmt_money(n) -> str:
+    if n is None:
+        return "—"
+    return f"${float(n):.4f}"
+
+
+def fmt_steps(n) -> str:
+    if n is None:
+        return "—"
+    return f"{float(n):.1f}"
+
+
+def render() -> str:
+    cells: dict[tuple[str, str], dict] = {}
+    for v in VARIANTS:
+        for t in TASKS:
+            cells[(v, t)] = cell(v, t)
+
+    out: list[str] = []
+    out.append("# Expanded autoresearch summary — preamble variants")
+    out.append("")
+    out.append(
+        "Comparison: `gpt5-mini-baseline` (extension off, scenario A) vs "
+        "`gpt5-mini-guarded` (extension on, scenario B) across 4 preamble "
+        "variants and 6 tasks, n=3 reps each. 24 (variant, task) cells, "
+        "144 reps total."
+    )
+    out.append("")
+    out.append("Variants:")
+    for v in VARIANTS:
+        out.append(f"- **{v}** — `{VARIANT_LABELS[v]}`")
+    out.append("")
+    out.append(
+        "**Direct goto** = the agent's first non-trivial action was a `goto` "
+        "to a URL whose path differs from the task's start URL — i.e. the URL "
+        "helper template fired. Counted out of n=3 reps per (variant, task, "
+        "scenario=B) cell. Lower B-side direct-goto with same pass rate ⇒ "
+        "variant suppressed safe URL-helper use; higher with same pass rate ⇒ "
+        "variant enabled more direct lookups."
+    )
+    out.append("")
+
+    # Per-task table
+    out.append("## Per-task: guarded (B) vs baseline (A) per variant")
+    out.append("")
+    for task in TASKS:
+        out.append(f"### `{task}`")
+        out.append("")
+        out.append(
+            "| variant | A pass | B pass | A tok | B tok | Δ tok | A steps | B steps | B direct-goto | B cost |"
+        )
+        out.append("|---|---|---|---|---|---|---|---|---|---|")
+        for v in VARIANTS:
+            c = cells[(v, task)]["scenarios"]
+            a = c.get("gpt5-mini-baseline")
+            b = c.get("gpt5-mini-guarded")
+            if a is None or b is None:
+                out.append(f"| `{v}` ({VARIANT_LABELS[v]}) | — | — | — | — | — | — | — | — | — |")
+                continue
+            out.append(
+                f"| `{v}` ({VARIANT_LABELS[v]}) "
+                f"| {a['pass']}/{a['n']} "
+                f"| {b['pass']}/{b['n']} "
+                f"| {fmt_int(a['total_tokens'])} "
+                f"| {fmt_int(b['total_tokens'])} "
+                f"| {fmt_pct_delta(a['total_tokens'], b['total_tokens'])} "
+                f"| {fmt_steps(a['steps'])} "
+                f"| {fmt_steps(b['steps'])} "
+                f"| {b['direct_goto']}/{b['n']} "
+                f"| {fmt_money(b['cost'])} |"
+            )
+        out.append("")
+
+    # Cross-task rollup per variant
+    out.append("## Cross-task rollup — average across all 6 tasks")
+    out.append("")
+    out.append(
+        "Each metric averaged across the 6 tasks (per-task n=3, so each "
+        "averaged cell rolls 18 reps). `B direct-goto` and `B pass` "
+        "summed across tasks then expressed as count / 18."
+    )
+    out.append("")
+    out.append(
+        "| variant | A pass | B pass | A tok (mean) | B tok (mean) | Δ tok | A steps | B steps | B direct-goto | B cost |"
+    )
+    out.append("|---|---|---|---|---|---|---|---|---|---|")
+    for v in VARIANTS:
+        a_pass = 0
+        b_pass = 0
+        a_n = 0
+        b_n = 0
+        a_tok = []
+        b_tok = []
+        a_steps = []
+        b_steps = []
+        b_cost = []
+        b_direct = 0
+        for t in TASKS:
+            c = cells[(v, t)]["scenarios"]
+            a = c.get("gpt5-mini-baseline")
+            b = c.get("gpt5-mini-guarded")
+            if a is None or b is None:
+                continue
+            a_pass += a["pass"]
+            b_pass += b["pass"]
+            a_n += a["n"]
+            b_n += b["n"]
+            if a["total_tokens"] is not None:
+                a_tok.append(a["total_tokens"])
+            if b["total_tokens"] is not None:
+                b_tok.append(b["total_tokens"])
+            if a["steps"] is not None:
+                a_steps.append(a["steps"])
+            if b["steps"] is not None:
+                b_steps.append(b["steps"])
+            if b["cost"] is not None:
+                b_cost.append(b["cost"])
+            b_direct += b["direct_goto"]
+        out.append(
+            f"| `{v}` ({VARIANT_LABELS[v]}) "
+            f"| {a_pass}/{a_n} "
+            f"| {b_pass}/{b_n} "
+            f"| {fmt_int(mean(a_tok))} "
+            f"| {fmt_int(mean(b_tok))} "
+            f"| {fmt_pct_delta(mean(a_tok), mean(b_tok))} "
+            f"| {fmt_steps(mean(a_steps))} "
+            f"| {fmt_steps(mean(b_steps))} "
+            f"| {b_direct}/{b_n} "
+            f"| {fmt_money(mean(b_cost))} |"
+        )
+    out.append("")
+
+    # Per-task direct-goto matrix for quick visual scan
+    out.append("## Direct-goto matrix (B side)")
+    out.append("")
+    out.append("Rows = task, columns = variant. Cells = `direct-goto / n reps`.")
+    out.append("")
+    header = "| task | " + " | ".join(f"`{v}` ({VARIANT_LABELS[v]})" for v in VARIANTS) + " |"
+    out.append(header)
+    out.append("|" + "---|" * (len(VARIANTS) + 1))
+    for task in TASKS:
+        row = [f"`{task}`"]
+        for v in VARIANTS:
+            b = cells[(v, task)]["scenarios"].get("gpt5-mini-guarded")
+            if b is None:
+                row.append("—")
+            else:
+                row.append(f"{b['direct_goto']}/{b['n']}")
+        out.append("| " + " | ".join(row) + " |")
+    out.append("")
+
+    return "\n".join(out)
+
+
+def main() -> int:
+    md = render()
+    out_path = RESULTS_ROOT / "expand_summary.md"
+    out_path.write_text(md, encoding="utf-8")
+    print(f"wrote {out_path.relative_to(REPO_ROOT)}")
+    print()
+    print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/_run_expand_autoresearch.sh
+++ b/scripts/_run_expand_autoresearch.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# One-shot autoresearch loop: 4 preamble variants × 6 tasks × 3 reps,
+# routed through the cloudflared LLM proxy. Drops cost_diff.md per
+# (variant, task) under output/results/expand_v{N}_{task}/.
+#
+# trap restores baseline preambles even if a single compare_scenarios.py
+# invocation fails, so the working tree never ends up holding a variant.
+
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+PROXY="https://chapel-delivering-dos-revised.trycloudflare.com"
+TASKS=(
+  wiki-claude
+  wikipedia-einstein-advisor
+  amazon-headphones
+  npm-react-version
+  mdn-array-map
+  ikea-billy-cheapest-white
+)
+
+trap './scripts/_swap_recipe_preamble.py --restore || true' EXIT
+
+run_phase() {
+  local idx="$1"; shift
+  local label="$1"; shift
+  echo
+  echo "=================================================================="
+  echo "PHASE v${idx} — ${label}"
+  echo "=================================================================="
+  for task in "${TASKS[@]}"; do
+    local run_id="expand_v${idx}_${task}"
+    if [ -d "output/results/${run_id}" ] && [ -n "$(ls -A "output/results/${run_id}" 2>/dev/null)" ]; then
+      echo "[v${idx}/${task}] SKIP — output/results/${run_id} already populated"
+      continue
+    fi
+    echo
+    echo "[v${idx}/${task}] START"
+    if uv run scripts/compare_scenarios.py \
+        --scenario gpt5-mini-baseline \
+        --scenario gpt5-mini-guarded \
+        --task "${task}" \
+        -n 3 \
+        --run-id "${run_id}" \
+        --llm-proxy-url "${PROXY}"; then
+      echo "[v${idx}/${task}] DONE"
+    else
+      echo "[v${idx}/${task}] FAILED — continuing to next task"
+    fi
+  done
+}
+
+# v0: baseline (no swap; assumes working tree is clean / matches trunk)
+run_phase 0 "baseline (no swap)"
+
+# v1: no-guess
+./scripts/_swap_recipe_preamble.py --variant no-guess
+run_phase 1 "no-guess"
+./scripts/_swap_recipe_preamble.py --restore
+
+# v2: terse-no-guess
+./scripts/_swap_recipe_preamble.py --variant terse-no-guess
+run_phase 2 "terse-no-guess"
+./scripts/_swap_recipe_preamble.py --restore
+
+# v3: search-default
+./scripts/_swap_recipe_preamble.py --variant search-default
+run_phase 3 "search-default"
+./scripts/_swap_recipe_preamble.py --restore
+
+echo
+echo "ALL PHASES COMPLETE"

--- a/scripts/_swap_recipe_preamble.py
+++ b/scripts/_swap_recipe_preamble.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env -S uv run --script
+# Copyright (c) 2026 PixieBrix, Inc.
+# Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Rewrite the leading line of every `search-url-helper` recipe across all
+extension/data/sites/*.yaml files so we can A/B-test different preamble
+wording in autoresearch experiments without committing one variant per
+branch.
+
+Matches the canonical line shape used by ~60 recipes today:
+
+    abs URL helper for {host} — prefer URL navigation over typing.
+
+Replaces it with the chosen variant text, substituting `{host}` in the new
+line with whatever host the original line carried. A `.preamble-bak` file
+is written alongside each modified yaml so `--restore` can put the original
+back without git knowing anything happened.
+
+Recipes whose first line doesn't match the canonical shape (e.g.
+google-flights, which has its own preamble) are skipped — those preambles
+encode site-specific guidance and shouldn't be flattened.
+
+Usage:
+  ./scripts/_swap_recipe_preamble.py --variant baseline
+  ./scripts/_swap_recipe_preamble.py --variant no-guess
+  ./scripts/_swap_recipe_preamble.py --variant terse
+  ./scripts/_swap_recipe_preamble.py --restore
+  ./scripts/_swap_recipe_preamble.py --list
+
+Variants are inlined below so they live with the script. Edit VARIANTS to
+add or refine. `{host}` in the template is substituted with the captured
+host from the original line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SITES_DIR = REPO_ROOT / "extension" / "data" / "sites"
+BAK_SUFFIX = ".preamble-bak"
+
+# Captures `abs URL helper for <host> — prefer URL navigation over typing.`
+# anywhere in the file. The host can contain `.`, `/`, `-`, and parenthesized
+# clarifiers (e.g. `hn.algolia.com (Hacker News search)`); the trailing em-dash
+# and exact suffix anchor the match so we don't accidentally rewrite hand-
+# written preambles like google-flights'.
+CANONICAL = re.compile(
+    r"abs URL helper for ([^—\n]+?) — prefer URL navigation over typing\.",
+)
+
+VARIANTS: dict[str, str] = {
+    # Current shipped wording — kept here so `--variant baseline` is the
+    # explicit "restore to current trunk" knob alongside `--restore`.
+    "baseline": "abs URL helper for {host} — prefer URL navigation over typing.",
+    # Explicit no-guess clause: warns the agent off inventing host-internal
+    # identifiers, points it at the search template / on-page UI as the
+    # fallback. The hypothesis under test is that this reduces wasted
+    # steps on recipes that include `Direct {entity}: /…/{ID}` templates
+    # (Amazon ASINs, IKEA category codes, IMDb tt-ids, etc.).
+    "no-guess": (
+        "abs URL helper for {host} — prefer URL navigation over typing "
+        "when you can fill every {placeholder} in the template from the "
+        "user's request or the current page. Do not guess host-internal "
+        "IDs, slugs, or codes — fall back to the Search: template or the "
+        "on-page search box instead."
+    ),
+    # Tighter restatement of no-guess: front-loads the rule, drops the
+    # softening. Useful for telling whether verbosity or the rule itself
+    # is doing the work.
+    "terse-no-guess": (
+        "abs URL helper for {host}. Use a template only when every "
+        "{value} is already known (user intent or this page's DOM). "
+        "Never invent IDs / slugs / codes — use Search: or the on-page UI."
+    ),
+    # Same no-guess rule but front-loads the Search: template as the
+    # default URL move, with direct-lookup templates only when fully
+    # known. Tests whether emphasising the Search: fallback (vs. just
+    # warning off guessing) is the load-bearing piece.
+    "search-default": (
+        "abs URL helper for {host} — search-by-URL is the default move. "
+        "Use the Search: template for any query the user gave you. Use "
+        "Direct/{entity}: templates only when every {value} is already "
+        "known from intent or this page; never guess IDs, slugs, or codes."
+    ),
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument(
+        "--variant",
+        choices=sorted(VARIANTS.keys()),
+        help="Replace the canonical preamble with the named variant. "
+        "Writes a .preamble-bak alongside each modified file.",
+    )
+    g.add_argument(
+        "--restore",
+        action="store_true",
+        help="Restore every .preamble-bak back over the modified yaml.",
+    )
+    g.add_argument(
+        "--list",
+        action="store_true",
+        help="Print the variant catalog and exit.",
+    )
+    return p.parse_args()
+
+
+def apply_variant(template: str) -> tuple[int, int]:
+    """Rewrite the canonical preamble line to `template` (with {host} filled
+    in) across every yaml in SITES_DIR. Returns (changed, total)."""
+    changed = 0
+    total = 0
+    for path in sorted(SITES_DIR.glob("*.yaml")):
+        total += 1
+        text = path.read_text(encoding="utf-8")
+        match = CANONICAL.search(text)
+        if match is None:
+            continue
+        host = match.group(1).strip()
+        # Don't use str.format — variant templates legitimately contain
+        # `{placeholder}` and `{value}` tokens we want to ship verbatim.
+        new_line = template.replace("{host}", host)
+        # Lambda (instead of passing `new_line` directly) so backrefs like
+        # `\1` in the variant text aren't expanded by re.sub.
+        new_text = CANONICAL.sub(lambda _match: new_line, text, count=1)
+        if new_text == text:
+            continue
+        bak = path.with_suffix(path.suffix + BAK_SUFFIX)
+        if not bak.exists():
+            bak.write_text(text, encoding="utf-8")
+        path.write_text(new_text, encoding="utf-8")
+        changed += 1
+    return changed, total
+
+
+def restore() -> int:
+    restored = 0
+    for bak in sorted(SITES_DIR.glob(f"*.yaml{BAK_SUFFIX}")):
+        target = bak.with_suffix("")  # strip .preamble-bak → leaves .yaml
+        target.write_text(bak.read_text(encoding="utf-8"), encoding="utf-8")
+        bak.unlink()
+        restored += 1
+    return restored
+
+
+def main() -> int:
+    args = parse_args()
+    if args.list:
+        for name, template in VARIANTS.items():
+            print(f"## {name}\n{template}\n")
+        return 0
+    if args.restore:
+        restored = restore()
+        print(f"Restored {restored} yaml file(s) from .preamble-bak.")
+        return 0
+    template = VARIANTS[args.variant]
+    changed, total = apply_variant(template)
+    print(
+        f"Variant '{args.variant}': rewrote canonical preamble in "
+        f"{changed}/{total} yaml file(s). "
+        f"Run `bun run build-site-data` (or `compare_scenarios.py`, which "
+        f"rebuilds automatically) to pick up the change."
+    )
+    if changed == 0:
+        print(
+            "WARNING: no files changed. Either already-applied or canonical "
+            "line is missing.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/_swap_recipe_preamble.py
+++ b/scripts/_swap_recipe_preamble.py
@@ -132,9 +132,9 @@ def apply_variant(template: str) -> tuple[int, int]:
         # Don't use str.format — variant templates legitimately contain
         # `{placeholder}` and `{value}` tokens we want to ship verbatim.
         new_line = template.replace("{host}", host)
-        # Lambda (instead of passing `new_line` directly) so backrefs like
-        # `\1` in the variant text aren't expanded by re.sub.
-        new_text = CANONICAL.sub(lambda _match: new_line, text, count=1)
+        # Escape backslashes so re.sub doesn't expand `\1`-style backrefs
+        # if a future variant text happens to contain one.
+        new_text = CANONICAL.sub(new_line.replace("\\", "\\\\"), text, count=1)
         if new_text == text:
             continue
         bak = path.with_suffix(path.suffix + BAK_SUFFIX)
@@ -175,8 +175,7 @@ def main() -> int:
     )
     if changed == 0:
         print(
-            "WARNING: no files changed. Either already-applied or canonical "
-            "line is missing.",
+            "WARNING: no files changed. Either already-applied or canonical line is missing.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/compare_scenarios.py
+++ b/scripts/compare_scenarios.py
@@ -31,12 +31,14 @@ capture the exact LLM messages per call (see benchmark/README.md).
 from __future__ import annotations
 
 import argparse
+import csv
 import datetime as dt
 import json
 import secrets
 import statistics
 import subprocess
 import sys
+import tempfile
 import webbrowser
 from pathlib import Path
 from typing import Any
@@ -77,12 +79,44 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument(
         "--task",
-        required=True,
+        default=None,
         metavar="ID",
-        help="Task id from --tasks-file. Exactly one.",
+        help="Task id from --tasks-file. Exactly one. Required unless "
+        "--task-prompt is supplied (in which case --task acts as the id of "
+        "the inline task and defaults to 'adhoc').",
     )
     p.add_argument("--scenarios-file", type=Path, default=DEFAULT_SCENARIOS)
     p.add_argument("--tasks-file", type=Path, default=DEFAULT_TASKS)
+    p.add_argument(
+        "--task-prompt",
+        default=None,
+        help="Inline task prompt for one-shot experiments. When set, the "
+        "script writes a temporary one-row CSV and uses it as --tasks-file, "
+        "so you can run autoresearch experiments without committing rows to "
+        "benchmark/tasks.csv. Requires --task-url; --task-success and "
+        "--task-max-steps are optional.",
+    )
+    p.add_argument(
+        "--task-url",
+        default=None,
+        help="Starting URL for the inline task (paired with --task-prompt).",
+    )
+    p.add_argument(
+        "--task-success",
+        default=None,
+        help="Success criteria fed to the judge for the inline task. "
+        "Defaults to a permissive 'agent produced a coherent answer to the "
+        "task' check when omitted, which is enough for cost/step research "
+        "but not for pass/fail signal — supply real criteria when you care "
+        "about the verdict.",
+    )
+    p.add_argument(
+        "--task-max-steps",
+        type=int,
+        default=None,
+        help="Per-task step budget for the inline task. Leave unset to "
+        "inherit the scenario default.",
+    )
     p.add_argument(
         "-n",
         "--repetitions",
@@ -121,7 +155,46 @@ def parse_args() -> argparse.Namespace:
         sys.exit("--scenario values must differ")
     if args.repetitions < 1:
         sys.exit(f"--repetitions must be >= 1 (got {args.repetitions})")
+    if args.task_prompt is not None:
+        if not args.task_url:
+            sys.exit("--task-prompt requires --task-url")
+        if args.task is None:
+            args.task = "adhoc"
+    elif args.task is None:
+        sys.exit("--task is required unless --task-prompt is supplied")
+    if args.task_prompt is None and (
+        args.task_url or args.task_success or args.task_max_steps is not None
+    ):
+        sys.exit(
+            "--task-url / --task-success / --task-max-steps only apply with --task-prompt"
+        )
     return args
+
+
+def write_inline_tasks_csv(
+    *, task_id: str, url: str, prompt: str, success: str | None, max_steps: int | None
+) -> Path:
+    """Write a one-row tasks.csv for inline-task runs. Returned path is in
+    the system temp dir so it doesn't leak into the repo."""
+    fd, raw = tempfile.mkstemp(prefix="compare_inline_tasks_", suffix=".csv")
+    path = Path(raw)
+    with open(fd, "w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["id", "enabled", "max_steps", "disabled_reason", "url", "task", "success_criteria"])
+        writer.writerow(
+            [
+                task_id,
+                "true",
+                str(max_steps) if max_steps is not None else "",
+                "",
+                url,
+                prompt,
+                success
+                or "Final answer is coherent and on-topic for the task; "
+                "any plausible response counts as pass (no ground-truth check).",
+            ]
+        )
+    return path
 
 
 def mint_run_id() -> str:
@@ -637,6 +710,17 @@ def main() -> int:
     load_dotenv(REPO_ROOT / ".env")
     args = parse_args()
 
+    inline_tasks_path: Path | None = None
+    if args.task_prompt is not None:
+        inline_tasks_path = write_inline_tasks_csv(
+            task_id=args.task,
+            url=args.task_url,
+            prompt=args.task_prompt,
+            success=args.task_success,
+            max_steps=args.task_max_steps,
+        )
+        args.tasks_file = inline_tasks_path
+
     run_id = args.run_id or mint_run_id()
     run_dir = RESULTS_ROOT / run_id
     if run_dir.exists() and any(run_dir.iterdir()):
@@ -645,6 +729,8 @@ def main() -> int:
     print(f"run_id: {run_id}")
     print(f"scenarios: {args.scenario[0]} vs {args.scenario[1]}")
     print(f"task: {args.task}")
+    if inline_tasks_path is not None:
+        print(f"inline task csv: {inline_tasks_path}")
     print(f"reps: {args.repetitions}")
     if args.llm_proxy_url:
         print(f"llm proxy: {args.llm_proxy_url}")

--- a/scripts/compare_scenarios.py
+++ b/scripts/compare_scenarios.py
@@ -165,9 +165,7 @@ def parse_args() -> argparse.Namespace:
     if args.task_prompt is None and (
         args.task_url or args.task_success or args.task_max_steps is not None
     ):
-        sys.exit(
-            "--task-url / --task-success / --task-max-steps only apply with --task-prompt"
-        )
+        sys.exit("--task-url / --task-success / --task-max-steps only apply with --task-prompt")
     return args
 
 
@@ -180,7 +178,9 @@ def write_inline_tasks_csv(
     path = Path(raw)
     with open(fd, "w", encoding="utf-8", newline="") as fh:
         writer = csv.writer(fh)
-        writer.writerow(["id", "enabled", "max_steps", "disabled_reason", "url", "task", "success_criteria"])
+        writer.writerow(
+            ["id", "enabled", "max_steps", "disabled_reason", "url", "task", "success_criteria"]
+        )
         writer.writerow(
             [
                 task_id,


### PR DESCRIPTION
## Summary

Adds tooling that lets us A/B-test the canonical `abs URL helper for {host} — prefer URL navigation over typing.` preamble (used in ~63 of the 70 site YAMLs) across many tasks without committing per-variant branches.

- `scripts/_swap_recipe_preamble.py` — rewrite the canonical preamble line across every site YAML to one of four named variants (`baseline`, `no-guess`, `terse-no-guess`, `search-default`). Writes `.preamble-bak` so `--restore` puts trunk back without git noticing. `--list` prints the variant catalog. Edit `VARIANTS` to add more.
- `scripts/compare_scenarios.py` — gains `--task-prompt` / `--task-url` / `--task-success` / `--task-max-steps`. When `--task-prompt` is set, the script writes a temp one-row CSV and uses it as `--tasks-file`, so inline-task autoresearch experiments don't pollute `benchmark/tasks.csv`. Existing `--task <id>` workflow is unchanged.
- `scripts/_run_expand_autoresearch.sh` — orchestrates a full 4-variants × 6-tasks × 3-reps sweep sequentially, with an EXIT trap that restores baseline preambles even if a single invocation fails. Skips runs whose output dir is already populated so you can resume.
- `scripts/_aggregate_expand.py` — rolls the 24 `expand_v{0..3}_<task>/` run dirs into one digest at `output/results/expand_summary.md`: per-task variant tables, a cross-task rollup, and a per-task direct-goto matrix (derived from `steps.json`).

## How this got used

The first sweep this drove tested whether tightening the URL-helper preamble (warning the agent off guessing host-internal IDs) improved gpt-5-mini behavior. Across 24 (variant, task) cells / 144 reps the baseline preamble wins on every aggregate metric — pass rate (16/18 vs 14–15/18), tokens (−24% vs −17 to +3%), steps, and cost. The variants do not reliably suppress direct-goto either. Net: keep trunk.

## Test plan

- [ ] `uv run scripts/compare_scenarios.py --scenario gpt5-mini-baseline --scenario gpt5-mini-guarded --task wiki-claude -n 3` still works (no inline-task flags exercised).
- [ ] `uv run scripts/compare_scenarios.py --scenario gpt5-mini-baseline --scenario gpt5-mini-guarded --task adhoc --task-url https://en.wikipedia.org --task-prompt "Find the population of Sydney" -n 1 --llm-proxy-url <url>` writes results to `output/results/cmp_*/` using an inline task.
- [ ] `./scripts/_swap_recipe_preamble.py --variant no-guess` then `./scripts/_swap_recipe_preamble.py --restore` leaves the working tree clean (no .preamble-bak, no YAML diffs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)