### PR TITLE
Disable on-page options button by default; make it build-configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ bun install
 bun run build
 ```
 
-### Customize default-enabled rules
+### Customize build-time defaults
 
 Which rules ship on by default is enumerated in
 [`extension/data/rule-defaults.json`](./extension/data/rule-defaults.json). To
-ship a build with a custom set without forking the repo, pass a partial override
-file (same JSON shape as the Options-page export) to `bun run build`:
+ship a build with a custom set without forking the repo, pass an override file
+to `bun run build`. The file is a flat JSON object whose keys are rule ids (same
+keys the Options-page export uses) plus a small set of reserved non-rule keys
+— currently `optionsButton` (boolean, default off) to enable the floating
+on-page button that opens the options page:
 
 ```sh
 bun run build --defaults ./my-defaults.json

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Which rules ship on by default is enumerated in
 [`extension/data/rule-defaults.json`](./extension/data/rule-defaults.json). To
 ship a build with a custom set without forking the repo, pass an override file
 to `bun run build`. The file is a flat JSON object whose keys are rule ids (same
-keys the Options-page export uses) plus a small set of reserved non-rule keys
-— currently `optionsButton` (boolean, default off) to enable the floating
-on-page button that opens the options page:
+keys the Options-page export uses) plus a small set of reserved non-rule keys —
+currently `optionsButton` (boolean, default off) to enable the floating on-page
+button that opens the options page:
 
 ```sh
 bun run build --defaults ./my-defaults.json

--- a/docs/src/content/docs/browser-use.md
+++ b/docs/src/content/docs/browser-use.md
@@ -184,10 +184,11 @@ default prompt with your own.
 
 On the first non-trivial page load, look for:
 
-- A circular shield-icon badge in the bottom-right corner (a11y name *"Open
-  Agent Browser Shield options"*).
 - `[data-abs-rule="<rule-id>"]` attributes in the DOM.
 - Inline `[PII masked]` / `[secret masked]` chips on pages with sensitive data.
+- If the build enables the on-page options button (off by default), a circular
+  shield-icon badge in the bottom-right corner (a11y name *"Open Agent Browser
+  Shield options"*).
 
 If none of those markers appear, the extension is not attached:
 

--- a/docs/src/content/docs/browserbase-python.md
+++ b/docs/src/content/docs/browserbase-python.md
@@ -186,10 +186,11 @@ fragment briefing the agent on what to expect:
 
 On the first non-trivial page load, look for:
 
-- A circular shield-icon badge in the bottom-right corner (a11y name *"Open
-  Agent Browser Shield options"*).
 - `[data-abs-rule="<rule-id>"]` attributes in the DOM.
 - Inline `[PII masked]` / `[secret masked]` chips on pages with sensitive data.
+- If the build enables the on-page options button (off by default), a circular
+  shield-icon badge in the bottom-right corner (a11y name *"Open Agent Browser
+  Shield options"*).
 
 Open the session's live view at
 `https://www.browserbase.com/sessions/<session.id>` to inspect the rendered page

--- a/docs/src/content/docs/hermes-agent.md
+++ b/docs/src/content/docs/hermes-agent.md
@@ -97,10 +97,11 @@ verified here, so this page doesn't prescribe a remote-attach recipe yet.
 
 On the first non-trivial page load, look for:
 
-- A circular shield-icon badge in the bottom-right corner (a11y name *"Open
-  Agent Browser Shield options"*).
 - `[data-abs-rule="<rule-id>"]` attributes in the DOM.
 - Inline `[PII masked]` / `[secret masked]` chips on pages with sensitive data.
+- If the build enables the on-page options button (off by default), a circular
+  shield-icon badge in the bottom-right corner (a11y name *"Open Agent Browser
+  Shield options"*).
 
 If none of those markers appear, the extension is not attached. Confirm the
 shield is loaded in the Chrome instance running against

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -61,7 +61,8 @@ each fresh session), pass a JSON override file to `bun run build`:
 cat > my-defaults.json <<'EOF'
 {
   "reviews-hide": false,
-  "ads-hide": false
+  "ads-hide": false,
+  "optionsButton": true
 }
 EOF
 
@@ -70,11 +71,21 @@ bun run build --defaults ./my-defaults.json
 EXTENSION_DEFAULTS_FILE=./my-defaults.json bun run build
 ```
 
-The override file is a flat `{ "<rule-id>": <boolean> }` map — the same shape
-the Options page exports and imports, so a JSON file exported from a tuned
-extension instance can be fed straight into the next build. The file may be
-partial; rules not listed keep the committed default. Unknown rule ids fail the
-build with a message naming them.
+The override file is a flat JSON object. Most keys are rule ids mapped to
+booleans — the same shape the Options page exports and imports, so a file
+exported from a tuned extension can be fed straight into the next build. A
+small set of reserved keys is also accepted for non-rule build-time toggles:
+
+- `optionsButton` (boolean, default **off**) — show the floating shield button
+  in the bottom-right corner of every page that opens this extension's options
+  page. Off by default because on sparse pages (JSON viewers, error screens,
+  interstitials) it can dominate the accessibility tree and become a
+  misleading target for browser-use agents. Enable for human-facing
+  deployments where on-page access to options is useful.
+
+The file may be partial; rules not listed keep the committed default. Unknown
+keys (neither a registered rule id nor a reserved key) and non-boolean values
+fail the build with a message naming them.
 
 Build-time overrides only affect **fresh** `chrome.storage` — users who already
 toggled rules in the Options UI keep their preferences. The typical target is

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -73,15 +73,15 @@ EXTENSION_DEFAULTS_FILE=./my-defaults.json bun run build
 
 The override file is a flat JSON object. Most keys are rule ids mapped to
 booleans — the same shape the Options page exports and imports, so a file
-exported from a tuned extension can be fed straight into the next build. A
-small set of reserved keys is also accepted for non-rule build-time toggles:
+exported from a tuned extension can be fed straight into the next build. A small
+set of reserved keys is also accepted for non-rule build-time toggles:
 
 - `optionsButton` (boolean, default **off**) — show the floating shield button
   in the bottom-right corner of every page that opens this extension's options
   page. Off by default because on sparse pages (JSON viewers, error screens,
-  interstitials) it can dominate the accessibility tree and become a
-  misleading target for browser-use agents. Enable for human-facing
-  deployments where on-page access to options is useful.
+  interstitials) it can dominate the accessibility tree and become a misleading
+  target for browser-use agents. Enable for human-facing deployments where
+  on-page access to options is useful.
 
 The file may be partial; rules not listed keep the committed default. Unknown
 keys (neither a registered rule id nor a reserved key) and non-boolean values

--- a/docs/src/content/docs/openclaw.md
+++ b/docs/src/content/docs/openclaw.md
@@ -193,10 +193,11 @@ up on the first page navigation.
 
 On the first non-trivial page load, look for:
 
-- A circular shield-icon badge in the bottom-right corner (a11y name *"Open
-  Agent Browser Shield options"*).
 - `[data-abs-rule="<rule-id>"]` attributes in the DOM.
 - Inline `[PII masked]` / `[secret masked]` chips on pages with sensitive data.
+- If the build enables the on-page options button (off by default), a circular
+  shield-icon badge in the bottom-right corner (a11y name *"Open Agent Browser
+  Shield options"*).
 
 If none of those markers appear, the extension is not attached:
 

--- a/extension/build.ts
+++ b/extension/build.ts
@@ -103,9 +103,11 @@ async function build(): Promise<void> {
           : resolve(process.cwd(), defaultsPath),
         knownRuleIds,
       })
-    : {};
+    : { rules: {} };
   if (defaultsPath) {
-    const changed = Object.keys(overrides).length;
+    const changed =
+      Object.keys(overrides.rules).length +
+      (overrides.optionsButton === undefined ? 0 : 1);
     console.log(
       `Applying ${changed} build-time default override(s) from ${defaultsPath}.`,
     );
@@ -135,7 +137,12 @@ async function build(): Promise<void> {
         Boolean(OPENAI_API_KEY),
       ),
       "process.env.EXTENSION_DEFAULT_OVERRIDES": JSON.stringify(
-        JSON.stringify(overrides),
+        JSON.stringify(overrides.rules),
+      ),
+      "process.env.EXTENSION_OPTIONS_BUTTON_DEFAULT": JSON.stringify(
+        overrides.optionsButton === undefined
+          ? ""
+          : String(overrides.optionsButton),
       ),
     },
   });

--- a/extension/scripts/__tests__/load-default-overrides.test.ts
+++ b/extension/scripts/__tests__/load-default-overrides.test.ts
@@ -25,21 +25,59 @@ describe("loadDefaultOverrides", () => {
     return file;
   }
 
-  it("returns a partial map for a valid file", () => {
+  it("returns rule overrides for a valid file", () => {
     const file = writeFile(
       "ok.json",
       JSON.stringify({ "pii-mask": true, "reviews-hide": false }),
     );
     expect(
       loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
-    ).toEqual({ "pii-mask": true, "reviews-hide": false });
+    ).toEqual({
+      rules: { "pii-mask": true, "reviews-hide": false },
+    });
   });
 
   it("accepts an empty object", () => {
     const file = writeFile("empty.json", "{}");
     expect(
       loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
-    ).toEqual({});
+    ).toEqual({ rules: {} });
+  });
+
+  it("extracts the optionsButton reserved key alongside rules", () => {
+    const file = writeFile(
+      "with-options-button.json",
+      JSON.stringify({ "pii-mask": true, optionsButton: false }),
+    );
+    expect(
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toEqual({
+      rules: { "pii-mask": true },
+      optionsButton: false,
+    });
+  });
+
+  it("accepts optionsButton on its own", () => {
+    const file = writeFile(
+      "only-options-button.json",
+      JSON.stringify({ optionsButton: true }),
+    );
+    expect(
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toEqual({
+      rules: {},
+      optionsButton: true,
+    });
+  });
+
+  it("rejects a non-boolean optionsButton value", () => {
+    const file = writeFile(
+      "bad-options-button.json",
+      JSON.stringify({ optionsButton: "yes" }),
+    );
+    expect(() =>
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toThrow(/non-boolean values for: optionsButton/);
   });
 
   it("throws when the file does not exist", () => {
@@ -65,14 +103,14 @@ describe("loadDefaultOverrides", () => {
     ).toThrow(/must be a JSON object/);
   });
 
-  it("rejects unknown rule ids", () => {
+  it("rejects unknown keys", () => {
     const file = writeFile(
       "unknown.json",
       JSON.stringify({ "pii-mask": true, "bogus-rule": false }),
     );
     expect(() =>
       loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
-    ).toThrow(/unknown rule ids: bogus-rule/);
+    ).toThrow(/unknown keys: bogus-rule/);
   });
 
   it("rejects non-boolean values", () => {
@@ -92,6 +130,6 @@ describe("loadDefaultOverrides", () => {
     );
     expect(() =>
       loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
-    ).toThrow(/unknown rule ids: bogus-rule.*non-boolean values for: pii-mask/);
+    ).toThrow(/unknown keys: bogus-rule.*non-boolean values for: pii-mask/);
   });
 });

--- a/extension/scripts/load-default-overrides.ts
+++ b/extension/scripts/load-default-overrides.ts
@@ -1,16 +1,18 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-// Loads and validates a build-time rule-defaults override file. Consumed by
+// Loads and validates a build-time defaults override file. Consumed by
 // build.ts when the operator passes `--defaults <path>` or
-// `EXTENSION_DEFAULTS_FILE=<path>`. The file shape matches the JSON the
-// in-extension Options page exports/imports — flat
-// `{ "<rule-id>": <boolean>, ... }` — so the same file works in both
-// places.
+// `EXTENSION_DEFAULTS_FILE=<path>`.
 //
-// Validation is strict: unknown rule ids and non-boolean values fail the
-// build. Infra operators want loud failures, not silent drift if a rule was
-// renamed.
+// The file is a flat JSON object. Most keys are rule ids mapped to booleans —
+// the same shape the in-extension Options page exports/imports. A small set
+// of reserved keys is also accepted for non-rule build-time toggles (e.g.
+// `optionsButton`, which controls the floating on-page options button).
+//
+// Validation is strict: unknown keys (neither a registered rule id nor a
+// reserved key) and non-boolean values fail the build. Infra operators want
+// loud failures, not silent drift if a rule was renamed.
 
 import { readFileSync } from "node:fs";
 
@@ -19,9 +21,19 @@ export interface LoadOverridesOptions {
   knownRuleIds: readonly string[];
 }
 
+export interface DefaultOverrides {
+  rules: Record<string, boolean>;
+  optionsButton?: boolean;
+}
+
+// Reserved top-level keys are not rule ids; the loader maps each one to a
+// typed field on `DefaultOverrides`. Add new build-time toggles here as they
+// appear.
+const RESERVED_KEYS = new Set<string>(["optionsButton"]);
+
 export function loadDefaultOverrides(
   options: LoadOverridesOptions,
-): Record<string, boolean> {
+): DefaultOverrides {
   const { path, knownRuleIds } = options;
 
   let raw: string;
@@ -46,18 +58,29 @@ export function loadDefaultOverrides(
 
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(
-      `Defaults file ${path} must be a JSON object mapping rule ids to booleans.`,
+      `Defaults file ${path} must be a JSON object mapping rule ids (or reserved keys) to booleans.`,
     );
   }
 
   const known = new Set<string>(knownRuleIds);
   const unknownIds: string[] = [];
   const nonBooleanIds: string[] = [];
-  const result: Record<string, boolean> = {};
+  const rules: Record<string, boolean> = {};
+  const result: DefaultOverrides = { rules };
 
   for (const [key, value] of Object.entries(
     parsed as Record<string, unknown>,
   )) {
+    if (RESERVED_KEYS.has(key)) {
+      if (typeof value !== "boolean") {
+        nonBooleanIds.push(key);
+        continue;
+      }
+      if (key === "optionsButton") {
+        result.optionsButton = value;
+      }
+      continue;
+    }
     if (!known.has(key)) {
       unknownIds.push(key);
       continue;
@@ -66,12 +89,12 @@ export function loadDefaultOverrides(
       nonBooleanIds.push(key);
       continue;
     }
-    result[key] = value;
+    rules[key] = value;
   }
 
   const issues: string[] = [];
   if (unknownIds.length > 0) {
-    issues.push(`unknown rule ids: ${unknownIds.join(", ")}`);
+    issues.push(`unknown keys: ${unknownIds.join(", ")}`);
   }
   if (nonBooleanIds.length > 0) {
     issues.push(`non-boolean values for: ${nonBooleanIds.join(", ")}`);

--- a/extension/src/globals.d.ts
+++ b/extension/src/globals.d.ts
@@ -10,5 +10,9 @@ declare namespace NodeJS {
     // JSON-stringified Partial<Record<RuleId, boolean>>. Empty `"{}"` when no
     // build-time defaults override file is supplied.
     EXTENSION_DEFAULT_OVERRIDES: string;
+    // Build-time default for the floating on-page options button. Literal
+    // `"true"` / `"false"` to force a value, or empty string when the
+    // defaults file did not set `optionsButton`.
+    EXTENSION_OPTIONS_BUTTON_DEFAULT: string;
   }
 }

--- a/extension/src/lib/__tests__/options-button-toggle.test.ts
+++ b/extension/src/lib/__tests__/options-button-toggle.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Verifies that `optionsButtonStorage` reads its initial default from
+// `process.env.EXTENSION_OPTIONS_BUTTON_DEFAULT` (substituted by build.ts
+// when the operator supplies a defaults file with an `optionsButton`
+// field). The env var is read at module load, so each case sets the value
+// and then reloads the module via `jest.isolateModulesAsync`. The
+// webext-storage stub (jest.config.cjs `moduleNameMapper`) is
+// re-instantiated inside the isolate, so `get()` returns the freshly
+// derived default rather than any stored value from a previous case.
+
+import type { optionsButtonStorage as Storage } from "../options-button-toggle";
+
+interface ToggleModule {
+  optionsButtonStorage: typeof Storage;
+  OPTIONS_BUTTON_ENABLED_DEFAULT: boolean;
+}
+
+async function loadToggle(): Promise<ToggleModule> {
+  let module!: ToggleModule;
+  await jest.isolateModulesAsync(async () => {
+    module = await import("../options-button-toggle");
+  });
+  return module;
+}
+
+describe("optionsButtonStorage default", () => {
+  const original = (process.env as Record<string, string | undefined>)
+    .EXTENSION_OPTIONS_BUTTON_DEFAULT;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete (process.env as Record<string, unknown>)
+        .EXTENSION_OPTIONS_BUTTON_DEFAULT;
+    } else {
+      process.env.EXTENSION_OPTIONS_BUTTON_DEFAULT = original;
+    }
+  });
+
+  it("falls back to the committed default when the env var is empty", async () => {
+    process.env.EXTENSION_OPTIONS_BUTTON_DEFAULT = "";
+    const { optionsButtonStorage, OPTIONS_BUTTON_ENABLED_DEFAULT } =
+      await loadToggle();
+    expect(await optionsButtonStorage.get()).toBe(
+      OPTIONS_BUTTON_ENABLED_DEFAULT,
+    );
+  });
+
+  it("uses true when the build-time override is 'true'", async () => {
+    process.env.EXTENSION_OPTIONS_BUTTON_DEFAULT = "true";
+    const { optionsButtonStorage } = await loadToggle();
+    expect(await optionsButtonStorage.get()).toBe(true);
+  });
+
+  it("uses false when the build-time override is 'false'", async () => {
+    process.env.EXTENSION_OPTIONS_BUTTON_DEFAULT = "false";
+    const { optionsButtonStorage } = await loadToggle();
+    expect(await optionsButtonStorage.get()).toBe(false);
+  });
+
+  it("ignores unrecognized strings and falls back to the committed default", async () => {
+    process.env.EXTENSION_OPTIONS_BUTTON_DEFAULT = "yes";
+    const { optionsButtonStorage, OPTIONS_BUTTON_ENABLED_DEFAULT } =
+      await loadToggle();
+    expect(await optionsButtonStorage.get()).toBe(
+      OPTIONS_BUTTON_ENABLED_DEFAULT,
+    );
+  });
+});

--- a/extension/src/lib/options-button-toggle.ts
+++ b/extension/src/lib/options-button-toggle.ts
@@ -2,15 +2,34 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 // User-controlled visibility of the floating on-page button that opens the
-// extension's options page. The button only exists for browser-use agents
-// driving the page via the accessibility tree (which can't click browser
-// chrome) — humans can ignore it or hide it via this setting.
+// extension's options page. The button is shown to humans browsing pages so
+// they can reach the options page without using the toolbar icon — but it
+// also appears in the accessibility tree, which means browser-use agents can
+// see it. On sparse pages (JSON viewers, error screens, interstitials) the
+// button can dominate the tree and become a misleading "click me to make
+// progress" target. Default off; operators who want it on for a specific
+// deployment can flip it via the build-time defaults file.
 
 import { createChromeStorageValue } from "./chrome-storage-value";
 
-export const OPTIONS_BUTTON_ENABLED_DEFAULT = true;
+export const OPTIONS_BUTTON_ENABLED_DEFAULT = false;
+
+// `process.env.EXTENSION_OPTIONS_BUTTON_DEFAULT` is substituted by build.ts
+// when the operator passes a defaults file with an `optionsButton` field.
+// Literal `"true"` / `"false"` forces a value; empty string falls back to
+// the committed default above.
+function resolveDefault(): boolean {
+  const raw = process.env.EXTENSION_OPTIONS_BUTTON_DEFAULT;
+  if (raw === "true") {
+    return true;
+  }
+  if (raw === "false") {
+    return false;
+  }
+  return OPTIONS_BUTTON_ENABLED_DEFAULT;
+}
 
 export const optionsButtonStorage = createChromeStorageValue<boolean>({
   key: "agent-browser-shield.options-button-enabled",
-  defaultValue: OPTIONS_BUTTON_ENABLED_DEFAULT,
+  defaultValue: resolveDefault(),
 });

--- a/skills/agent-browser-shield-config/SKILL.md
+++ b/skills/agent-browser-shield-config/SKILL.md
@@ -39,11 +39,14 @@ to its default. To disable only one rule while preserving others, first click
 *Export JSON*, edit the downloaded file, then paste it back. Unknown keys and
 non-boolean values are rejected with an error.
 
-The same JSON shape can also be passed at build time via
-`bun run build --defaults <path>` or `EXTENSION_DEFAULTS_FILE=<path>`. That's
-the right tool for infrastructure deployments that need a custom default set in
-every fresh session without the agent flipping toggles each time — see the
-`agent-browser-shield-install` skill for the build-time workflow.
+A superset of this JSON shape can also be passed at build time via
+`bun run build --defaults <path>` or `EXTENSION_DEFAULTS_FILE=<path>`. The
+build-time file accepts the same rule-id keys plus a small set of reserved
+non-rule keys (currently `optionsButton`) for build-time toggles that aren't
+exposed in the Options page export. That's the right tool for infrastructure
+deployments that need a custom default set in every fresh session without the
+agent flipping toggles each time — see the `agent-browser-shield-install` skill
+for the build-time workflow.
 
 ## Rule IDs
 

--- a/skills/agent-browser-shield-config/SKILL.md
+++ b/skills/agent-browser-shield-config/SKILL.md
@@ -10,16 +10,16 @@ on the next page load.
 
 ## Opening the options page
 
-Click the **shield-icon badge** in the bottom-right corner of any page — it's a
-circular button with `[data-abs="open-options"]` that opens the options tab.
-Agents driving via the accessibility tree should target the button by its
-accessible name *"Open Agent Browser Shield options"* (the shield glyph is
-`aria-hidden`). This is the reliable path for browser agents that can't reach
-the Chrome toolbar.
+Humans: right-click the toolbar icon → *Options*, or go to `chrome://extensions`
+→ *Details* → *Extension options*. The popup (toolbar icon click) exposes the
+same per-rule toggles.
 
-Humans can also right-click the toolbar icon → *Options*, or go to
-`chrome://extensions` → *Details* → *Extension options*. The popup (toolbar icon
-click) exposes the same per-rule toggles.
+Builds may also enable a floating **shield-icon badge** in the bottom-right
+corner of every page — a circular button with `[data-abs="open-options"]` and
+accessible name *"Open Agent Browser Shield options"*. The badge is off by
+default and is enabled per-build via the `optionsButton: true` field in the
+defaults file (see the `agent-browser-shield-install` skill). When enabled,
+agents driving via the accessibility tree can target it by its accessible name.
 
 ## Applying a config by pasting JSON
 

--- a/skills/agent-browser-shield-install/SKILL.md
+++ b/skills/agent-browser-shield-install/SKILL.md
@@ -179,13 +179,12 @@ JSON override file instead of using the hosted ZIP.
    Reserved non-rule keys:
 
    - `optionsButton` (boolean, default **off**) — show the floating shield
-     button in the bottom-right corner of every page that opens this
-     extension's options page. The button is visible to humans and to
-     browser-use agents reading the accessibility tree. Off by default
-     because on sparse pages (JSON viewers, error screens, interstitials) it
-     can dominate the a11y tree and become a misleading "click me to make
-     progress" target. Enable for human-facing deployments where on-page
-     access to options is useful.
+     button in the bottom-right corner of every page that opens this extension's
+     options page. The button is visible to humans and to browser-use agents
+     reading the accessibility tree. Off by default because on sparse pages
+     (JSON viewers, error screens, interstitials) it can dominate the a11y tree
+     and become a misleading "click me to make progress" target. Enable for
+     human-facing deployments where on-page access to options is useful.
 
 2. Pass the path via CLI flag or env var to `bun run build`:
 

--- a/skills/agent-browser-shield-install/SKILL.md
+++ b/skills/agent-browser-shield-install/SKILL.md
@@ -136,8 +136,10 @@ attaches.
       and unzip somewhere stable.
    2. Open `chrome://extensions`, enable **Developer mode**, click **Load
       unpacked**, select the unzipped directory.
-   3. Confirm a circular **shield-icon badge** appears in the bottom-right
-      corner of any page (a11y name: *"Open Agent Browser Shield options"*).
+   3. Confirm the extension is loaded by visiting `chrome://extensions` (or by
+      checking the toolbar icon menu). The floating on-page options button is
+      off by default — see *Customizing build-time defaults* below to ship a
+      build with it on.
 2. Attach via your runtime's normal CDP / Chrome DevTools MCP mechanism. No
    per-session extension setup on the claw side.
 
@@ -148,29 +150,42 @@ After the browser is up and you've navigated to any non-trivial page:
 - Look for `[data-abs-rule]` attributes anywhere in the DOM, or for
   `.abs-placeholder` buttons whose text matches `[… hidden — click to reveal]`,
   or for inline `[PII masked]` / `[secret masked]` chips.
-- A circular badge with selector `[data-abs="open-options"]` in the bottom-right
-  corner confirms the content script is running.
+- If the build enables the floating on-page options button (off by default), a
+  circular badge with selector `[data-abs="open-options"]` appears in the
+  bottom-right corner.
 - If none of those markers appear: the MV3 service worker may not have woken up.
   Navigate to a page that would trigger a rule (e.g. a product page for
   cart-addon-flag, a page with an email address for pii-mask) and recheck. If
   still nothing, the extension is not installed.
 
-## Customizing default-enabled rules at build time
+## Customizing build-time defaults
 
 For infra deployments where the same custom defaults should ship every session
 (so the agent doesn't have to flip toggles at runtime), build from source with a
 JSON override file instead of using the hosted ZIP.
 
-1. Write a JSON file using the same shape the Options page exports — a flat map
-   of `<rule-id>` to boolean. Partial is fine; rules not listed keep their
-   committed default from `extension/data/rule-defaults.json`:
+1. Write a JSON file mapping rule ids to booleans, plus any of the reserved
+   non-rule keys below. Rules not listed keep their committed default from
+   `extension/data/rule-defaults.json`:
 
    ```json
    {
      "reviews-hide": false,
-     "ads-hide": false
+     "ads-hide": false,
+     "optionsButton": true
    }
    ```
+
+   Reserved non-rule keys:
+
+   - `optionsButton` (boolean, default **off**) — show the floating shield
+     button in the bottom-right corner of every page that opens this
+     extension's options page. The button is visible to humans and to
+     browser-use agents reading the accessibility tree. Off by default
+     because on sparse pages (JSON viewers, error screens, interstitials) it
+     can dominate the a11y tree and become a misleading "click me to make
+     progress" target. Enable for human-facing deployments where on-page
+     access to options is useful.
 
 2. Pass the path via CLI flag or env var to `bun run build`:
 
@@ -181,7 +196,8 @@ JSON override file instead of using the hosted ZIP.
    EXTENSION_DEFAULTS_FILE=/abs/path/to/defaults.json bun run build
    ```
 
-3. Unknown rule ids fail the build with a clear error — catch typos before
+3. Unknown keys (neither a registered rule id nor a reserved key) and
+   non-boolean values fail the build with a clear error — catch typos before
    shipping.
 
 4. Package and deploy as usual (`bun run package` then upload via Path A / B / C

--- a/skills/agent-browser-shield/SKILL.md
+++ b/skills/agent-browser-shield/SKILL.md
@@ -65,7 +65,10 @@ surfaces **before you see the page**.
 
 ## Configuration
 
-Click the **shield-icon badge** in the bottom-right corner of any page
-(`[data-abs="open-options"]`, a11y name *"Open Agent Browser Shield options"*)
-to open the options tab. See the `agent-browser-shield-config` skill for the
-full rule list and the JSON-paste workflow.
+Open the options tab from the Chrome toolbar (right-click the extension icon →
+*Options*) or via `chrome://extensions` → *Details* → *Extension options*.
+Builds may also expose a floating **shield-icon badge** in the bottom-right
+corner of every page (`[data-abs="open-options"]`, a11y name *"Open Agent
+Browser Shield options"*); the badge is off by default and is enabled per-build
+via the defaults file. See the `agent-browser-shield-config` skill for the full
+rule list and the JSON-paste workflow.


### PR DESCRIPTION
## Summary

- Flip `OPTIONS_BUTTON_ENABLED_DEFAULT` from `true` to `false` so the floating shield-icon badge no longer renders out of the box.
- Extend the build-time defaults file format to accept reserved non-rule keys; add `optionsButton: boolean` as the first one. `build.ts` substitutes it into `process.env.EXTENSION_OPTIONS_BUTTON_DEFAULT`, which `options-button-toggle.ts` reads to override the committed default.
- Validator now rejects "unknown keys" (was "unknown rule ids") and preserves the existing "non-boolean values" error path; `optionsButton: "yes"` triggers it.
- Update install/config skills and the four "Verify" docs to describe the badge as opt-in.

## Why

Autoresearch on `npm-react-version` (see `output/results/expand_summary.md`) showed guarded scenarios at **1/3 pass vs 3/3 baseline** across all 4 preamble variants. The repeating failure mode: npmjs.com package page hits a Cloudflare interstitial, the agent falls back to `registry.npmjs.org` / `unpkg.com` JSON pages whose accessibility tree contains essentially nothing except a `Pretty-print` checkbox and the extension's injected `button: Open Agent Browser Shield options`. The agent, with no obvious next move, clicks the button — explicit reasoning from one failed run: *"Performed a UI click on an agent shield options button while troubleshooting."* The badge is useful for humans driving the browser directly but a footgun for agents on sparse pages.

## Test plan

- [x] `bun run preflight` (codegen + biome + eslint + tsc + knip + jest --coverage): 548/548 tests pass
- [x] New unit tests in `extension/src/lib/__tests__/options-button-toggle.test.ts` cover empty / `"true"` / `"false"` / unrecognized values for `EXTENSION_OPTIONS_BUTTON_DEFAULT`
- [x] Updated `extension/scripts/__tests__/load-default-overrides.test.ts` covers the new return shape, the reserved-key path, and the non-boolean rejection for `optionsButton`
- [x] Smoke-tested `bun run build --defaults /tmp/abs-defaults-smoke.json` with `{"optionsButton": true}` and confirmed the bundle compiles to `raw = "true"` at the `resolveDefault()` call site
- [ ] Follow-up: re-run autoresearch on `npm-react-version` after this lands to confirm the regression is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)