### PR TITLE
Add ClawHub skill link to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ guide, rule reference, and configuration.
 a mock e-commerce SPA that exercises every rule. Load it with and without the
 extension to see the before/after difference.
 
+**[ClawHub skill](https://clawhub.ai/pixiebrix/agent-browser-shield)** — for
+skill-aware [OpenClaw](https://openclaw.ai) agents, install with
+`clawhub install agent-browser-shield` to load the install paths and runtime
+behavior contract.
+
 | Before                                              | After                                             |
 | --------------------------------------------------- | ------------------------------------------------- |
 | ![Before agent-browser-shield](./images/before.png) | ![After agent-browser-shield](./images/after.png) |

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -14,6 +14,7 @@ safer, and more accurate.
 <LinkButton href="/agent-browser-shield/install/" icon="right-arrow" variant="primary">Install</LinkButton>
 <LinkButton href="/agent-browser-shield/rules/" icon="open-book">Browse the rules</LinkButton>
 <LinkButton href="https://github.com/pixiebrix/agent-browser-shield" icon="external">View on GitHub</LinkButton>
+<LinkButton href="https://clawhub.ai/pixiebrix/agent-browser-shield" icon="external">Skill on ClawHub</LinkButton>
 
 | Before                                            | After                                           |
 | ------------------------------------------------- | ----------------------------------------------- |

--- a/docs/src/content/docs/openclaw.md
+++ b/docs/src/content/docs/openclaw.md
@@ -19,8 +19,9 @@ The rest of this page covers both.
 :::tip[Skill-aware agents]
 
 If you're driving OpenClaw with a skill-aware agent, install the
-`agent-browser-shield` skill from ClawHub instead of pasting these steps into a
-prompt — it bundles the install paths below plus the runtime behavior rules:
+[`agent-browser-shield` skill from ClawHub](https://clawhub.ai/pixiebrix/agent-browser-shield)
+instead of pasting these steps into a prompt — it bundles the install paths
+below plus the runtime behavior rules:
 
 ```sh
 clawhub install agent-browser-shield


### PR DESCRIPTION
## Summary
- README gains a third bullet linking to the published ClawHub skill at https://clawhub.ai/pixiebrix/agent-browser-shield
- Docs landing page gains a "Skill on ClawHub" LinkButton next to the GitHub one
- `openclaw.md`'s existing skill-aware tip turns the inline "ClawHub" mention into a hyperlink to the skill page

## Test plan
- [ ] Render the docs site locally (`cd docs && bun run dev`) and confirm the new LinkButton and the openclaw.md hyperlink point at the right URL
- [ ] Eyeball the README on GitHub to confirm the new bullet renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)