### PR TITLE
Shrink product detail image to keep blocked content above the fold

### DIFF
--- a/demo-site/src/pages/ProductDetail.tsx
+++ b/demo-site/src/pages/ProductDetail.tsx
@@ -76,7 +76,7 @@ export default function ProductDetail() {
           <img
             src={product.image}
             alt={product.title}
-            className="w-full rounded border border-stone-200 bg-white"
+            className="mx-auto max-h-64 w-auto rounded border border-stone-200 bg-white object-contain"
           />
         </div>
 


### PR DESCRIPTION
## Summary
- Cap the product detail image at `max-h-64` with `object-contain` so the dark-pattern and injection demos stay visible on the smaller viewports Browserbase uses for demo sessions.

## Test plan
- [ ] Run the demo site locally and open a product detail page; image is no longer full-column width and the surrounding blocked elements are reachable without scrolling at ~1024px viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)