### PR TITLE
Stop hidden-text-strip from removing oklch-background buttons

### DIFF
--- a/extension/src/rules/__tests__/hidden-text-strip.test.ts
+++ b/extension/src/rules/__tests__/hidden-text-strip.test.ts
@@ -313,6 +313,25 @@ describe("hiddenTextStripRule", () => {
     expect(document.querySelector("#x")).toBeNull();
   });
 
+  // Tailwind v4 (and any modern stylesheet using CSS Color Level 4)
+  // compiles backgrounds to `oklch()` / `lab()` / `color()`, which browsers
+  // expose in computed style unnormalized. The walker historically treated
+  // those as transparent and kept climbing, so a `bg-orange-500` button
+  // with white text inside a white card looked like white-on-white and got
+  // stripped. Bail when we hit a background we can't parse rather than
+  // falling through to a distant white ancestor.
+  it("preserves white text on an oklch background nested in a white card", () => {
+    document.body.innerHTML = `
+      <aside style="background-color: rgb(255, 255, 255)">
+        <a id="buy" href="/checkout"
+           style="background-color: oklch(0.705 0.213 47.604); color: rgb(255, 255, 255)">Buy Now</a>
+      </aside>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#buy")).not.toBeNull();
+  });
+
   it("preserves text with normal contrast against its background", () => {
     document.body.setAttribute("style", "background-color: rgb(255, 255, 255)");
     document.body.innerHTML = `

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -291,13 +291,21 @@ function parseColor(value: string): RGBA | null {
 // Effective background color: walk up ancestors and composite the first
 // opaque background we find. `transparent` and `rgba(_, _, _, 0)` mean
 // "ask my parent." Falls back to white because every browser paints the
-// canvas white when nothing intervenes.
-function effectiveBackgroundColor(element: Element): RGB {
+// canvas white when nothing intervenes. Returns null when we hit a
+// background whose computed value we can't parse (CSS Color Level 4
+// syntaxes like `oklch()` / `lab()` / `color()` reach computed style
+// unnormalized) — walking past it to a distant white ancestor would
+// strip legitimate UI like a `bg-orange-500` button with white text
+// sitting inside an otherwise-white card.
+function effectiveBackgroundColor(element: Element): RGB | null {
   let current: Element | null = element;
   while (current) {
     const style = globalThis.getComputedStyle(current);
     const bg = parseColor(style.backgroundColor);
-    if (bg && bg[3] >= 0.999) {
+    if (!bg) {
+      return null;
+    }
+    if (bg[3] >= 0.999) {
       return [bg[0], bg[1], bg[2]];
     }
     current = current.parentElement;
@@ -338,6 +346,9 @@ function detectColorMatch(
     return null;
   }
   const bg = effectiveBackgroundColor(element);
+  if (!bg) {
+    return null;
+  }
   const distance = colorDistance([fg[0], fg[1], fg[2]], bg);
   if (distance > COLOR_MATCH_DISTANCE) {
     return null;


### PR DESCRIPTION
## Summary
- `hidden-text-strip`'s color-match walker treated unparseable computed `background-color` values (CSS Color Level 4 syntaxes — `oklch()`, `lab()`, `color()`, …) as transparent and climbed past them, so a Tailwind v4 `bg-orange-500` button with white text inside a white card looked like white-on-white and got removed. Demo: the **Buy Now** link on https://shield-dark-pattern-demo.vercel.app/product/p-headphones-1 (also clobbered the `-35%` discount badge).
- `effectiveBackgroundColor` now bails when it hits a background it can't parse, rather than falling through to the white default. White-on-white injection detection is unchanged (browsers normalize sRGB hex/named/hsl/rgb to `rgb(...)` in computed style, so the regex still parses every legitimate match).
- Regression test pins the behavior to the Buy Now shape (oklch bg, white text, white ancestor).

## Test plan
- [x] `bun run check` clean
- [x] `bun run test` — 549/549 passing, including new regression
- [x] Built extension and loaded into headless Chromium against the demo page; Buy Now link, `-35%` badge, and other Tailwind-styled controls survive; injection / scarcity / countdown / reviews rules still fire as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)