### PR TITLE
Rename CLAUDE.md to AGENTS.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ suite — list here only what CI can't catch. -->
 
 - [ ] Manually loaded the extension and exercised the affected rule(s)
 - [ ] Updated relevant skill docs in `skills/` if rules or trace layout changed
-  (see [CLAUDE.md](../CLAUDE.md))
+  (see [AGENTS.md](../AGENTS.md))
 
 ## CLA
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with
-code in this repository.
+This file provides guidance to coding agents (Claude Code, Cursor, Codex,
+Aider, etc.) when working with code in this repository.
 
 ## Branching workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
-This file provides guidance to coding agents (Claude Code, Cursor, Codex,
-Aider, etc.) when working with code in this repository.
+This file provides guidance to coding agents (Claude Code, Cursor, Codex, Aider,
+etc.) when working with code in this repository.
 
 ## Branching workflow
 

--- a/skills/agent-browser-shield-site-rules/SKILL.md
+++ b/skills/agent-browser-shield-site-rules/SKILL.md
@@ -49,7 +49,7 @@ Chrome for Testing downloads (~170 MB) — let it complete before continuing.
 
 ### 1. Branch off main
 
-Per CLAUDE.md GitHub flow: one branch per host (or one bundled branch if you're
+Per AGENTS.md GitHub flow: one branch per host (or one bundled branch if you're
 sweeping many hosts at once).
 
 ```bash
@@ -175,7 +175,7 @@ bun run build-site-data
 ```
 
 The script regenerates `extension/src/rules/site-data.generated.ts`. Per
-CLAUDE.md, the generated file is committed alongside the YAML.
+AGENTS.md, the generated file is committed alongside the YAML.
 
 ### 5. Commit and open the PR
 


### PR DESCRIPTION
## Summary

- Renames `CLAUDE.md` → `AGENTS.md` so the existing repo briefing is discovered by all coding agents (Cursor, Codex, Aider, Goose, etc.) without maintaining duplicates. Claude Code also reads `AGENTS.md`.
- Updates the opening line of the file to be tool-neutral.
- Updates the two in-repo references: `.github/PULL_REQUEST_TEMPLATE.md` and `skills/agent-browser-shield-site-rules/SKILL.md`.

## Test plan

- [ ] CI green (no code changes; markdownlint + mdformat pre-commit hooks cover the doc churn).
- [ ] Spot-check that the PR template link resolves to `AGENTS.md` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)