### PR TITLE
Re-scan SPA-mutated subtrees in pii-mask and secrets-mask

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,23 @@ duplicate a rule between them.
 - `bun run check` runs Biome then ESLint; `bun run check:fix` runs both with
   `--fix`/`--write`.
 
+## Rule authoring: re-scan SPA mutations
+
+Rule `apply` runs once at `document_idle`. Client-side route changes in SPAs
+(React Router, Vue Router, etc.) swap subtrees in and out without a new page
+load, so anything that only ran in `apply` will never see post-navigation
+content — and most of our targets (PII, secrets, scarcity badges, hidden
+text) are exactly the kind of late-mounted content SPAs are built on.
+
+Default to wiring a `createSubtreeWatcher` (`extension/src/lib/subtree-watcher.ts`)
+into any rule that mutates the DOM, with `skipPlaceholderSubtrees: true` when
+the rule inserts placeholders. Mirror the pattern used in `pii-mask`,
+`secrets-mask`, `scarcity-hide`, `hidden-text-strip`, etc.: a shared
+`scanAndX(root)` function called by both `apply` and the watcher's
+`onSubtrees`, plus a `teardown` that calls `watcher.stop()`. Skip the watcher
+only when there is nothing to re-scan after initial load — e.g., a one-shot
+landmark injection — and call that out in a comment.
+
 ## Rule defaults
 
 The initial enabled/disabled state for each rule lives in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,17 +60,18 @@ duplicate a rule between them.
 Rule `apply` runs once at `document_idle`. Client-side route changes in SPAs
 (React Router, Vue Router, etc.) swap subtrees in and out without a new page
 load, so anything that only ran in `apply` will never see post-navigation
-content — and most of our targets (PII, secrets, scarcity badges, hidden
-text) are exactly the kind of late-mounted content SPAs are built on.
+content — and most of our targets (PII, secrets, scarcity badges, hidden text)
+are exactly the kind of late-mounted content SPAs are built on.
 
-Default to wiring a `createSubtreeWatcher` (`extension/src/lib/subtree-watcher.ts`)
-into any rule that mutates the DOM, with `skipPlaceholderSubtrees: true` when
-the rule inserts placeholders. Mirror the pattern used in `pii-mask`,
-`secrets-mask`, `scarcity-hide`, `hidden-text-strip`, etc.: a shared
-`scanAndX(root)` function called by both `apply` and the watcher's
-`onSubtrees`, plus a `teardown` that calls `watcher.stop()`. Skip the watcher
-only when there is nothing to re-scan after initial load — e.g., a one-shot
-landmark injection — and call that out in a comment.
+Default to wiring a `createSubtreeWatcher`
+(`extension/src/lib/subtree-watcher.ts`) into any rule that mutates the DOM,
+with `skipPlaceholderSubtrees: true` when the rule inserts placeholders. Mirror
+the pattern used in `pii-mask`, `secrets-mask`, `scarcity-hide`,
+`hidden-text-strip`, etc.: a shared `scanAndX(root)` function called by both
+`apply` and the watcher's `onSubtrees`, plus a `teardown` that calls
+`watcher.stop()`. Skip the watcher only when there is nothing to re-scan after
+initial load — e.g., a one-shot landmark injection — and call that out in a
+comment.
 
 ## Rule defaults
 

--- a/extension/src/rules/__tests__/pii-mask.test.ts
+++ b/extension/src/rules/__tests__/pii-mask.test.ts
@@ -6,8 +6,20 @@ const INVALID_CARD = "4111 1111 1111 1112"; // Same shape, Luhn-invalid.
 const SSN = "123-45-6789";
 const PHONE = "(555) 123-4567";
 
+const MUTATION_THROTTLE_MS = 250;
+
+async function flushMutations(): Promise<void> {
+  await Promise.resolve();
+}
+
 beforeEach(() => {
   document.body.innerHTML = "";
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  piiMaskRule.teardown();
+  jest.useRealTimers();
 });
 
 describe("pii-mask", () => {
@@ -84,5 +96,46 @@ describe("pii-mask", () => {
 
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
     expect(document.body.textContent).toContain(SSN);
+  });
+});
+
+describe("pii-mask lazy-loaded subtrees", () => {
+  it("masks PII appearing after a client-side route change", async () => {
+    piiMaskRule.apply(document.body);
+
+    const route = document.createElement("section");
+    route.innerHTML = `<p>SSN ${SSN}</p>`;
+    document.body.append(route);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    const placeholder = document.querySelector(`.${PLACEHOLDER_CLASS}`);
+    expect(placeholder?.textContent).toBe("[ssn hidden]");
+    expect(document.body.textContent).not.toContain(SSN);
+  });
+
+  it("teardown stops the observer", async () => {
+    piiMaskRule.apply(document.body);
+    piiMaskRule.teardown();
+
+    const route = document.createElement("section");
+    route.innerHTML = `<p>SSN ${SSN}</p>`;
+    document.body.append(route);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+
+  it("does not loop when its own placeholder is inserted", async () => {
+    document.body.innerHTML = `<p>SSN ${SSN}</p>`;
+    piiMaskRule.apply(document.body);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 });

--- a/extension/src/rules/__tests__/secrets-mask.test.ts
+++ b/extension/src/rules/__tests__/secrets-mask.test.ts
@@ -18,8 +18,20 @@ const HIGH_ENTROPY_HEX =
 // Random base64-ish, 40 chars.
 const HIGH_ENTROPY_B64 = "k3M9xQ8vP2nL5tR7yW1aZ4bC6dE0fG2hJ8iK3lMn";
 
+const MUTATION_THROTTLE_MS = 250;
+
+async function flushMutations(): Promise<void> {
+  await Promise.resolve();
+}
+
 beforeEach(() => {
   document.body.innerHTML = "";
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  secretsMaskRule.teardown();
+  jest.useRealTimers();
 });
 
 describe("secrets-mask", () => {
@@ -175,5 +187,46 @@ describe("secrets-mask", () => {
 
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
     expect(document.body.textContent).toContain(AWS_KEY);
+  });
+});
+
+describe("secrets-mask lazy-loaded subtrees", () => {
+  it("masks secrets appearing after a client-side route change", async () => {
+    secretsMaskRule.apply(document.body);
+
+    const route = document.createElement("section");
+    route.innerHTML = `<p>key: ${AWS_KEY}</p>`;
+    document.body.append(route);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    const placeholder = document.querySelector(`.${PLACEHOLDER_CLASS}`);
+    expect(placeholder?.textContent).toBe("[aws key hidden]");
+    expect(document.body.textContent).not.toContain(AWS_KEY);
+  });
+
+  it("teardown stops the observer", async () => {
+    secretsMaskRule.apply(document.body);
+    secretsMaskRule.teardown();
+
+    const route = document.createElement("section");
+    route.innerHTML = `<p>key: ${AWS_KEY}</p>`;
+    document.body.append(route);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+
+  it("does not loop when its own placeholder is inserted", async () => {
+    document.body.innerHTML = `<p>key: ${AWS_KEY}</p>`;
+    secretsMaskRule.apply(document.body);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
   });
 });

--- a/extension/src/rules/pii-mask.ts
+++ b/extension/src/rules/pii-mask.ts
@@ -4,6 +4,7 @@
 import { walkTextNodes } from "../lib/dom-utils";
 import type { InlineMatch } from "../lib/placeholder";
 import { replaceMatchesInTextNode } from "../lib/placeholder";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import type { Rule } from "./types";
 
 const RULE_ID = "pii-mask" as const;
@@ -75,7 +76,7 @@ function collectMatches(text: string): InlineMatch[] {
   return merged;
 }
 
-function apply(root: ParentNode): void {
+function scanAndMask(root: ParentNode): void {
   for (const node of walkTextNodes(root, { minLength: MIN_TEXT_LENGTH })) {
     const matches = collectMatches(node.nodeValue ?? "");
     if (matches.length > 0) {
@@ -84,9 +85,26 @@ function apply(root: ParentNode): void {
   }
 }
 
+const watcher = createSubtreeWatcher({
+  skipPlaceholderSubtrees: true,
+  onSubtrees: (roots) => {
+    for (const root of roots) {
+      scanAndMask(root);
+    }
+  },
+});
+
+function apply(root: ParentNode): void {
+  scanAndMask(root);
+  watcher.start(root);
+}
+
 export const piiMaskRule = {
   id: RULE_ID,
   label: "Mask PII",
   description: "Hide credit card numbers, phone numbers, and SSNs.",
   apply,
+  teardown: () => {
+    watcher.stop();
+  },
 } satisfies Rule;

--- a/extension/src/rules/secrets-mask.ts
+++ b/extension/src/rules/secrets-mask.ts
@@ -4,6 +4,7 @@
 import { walkTextNodes } from "../lib/dom-utils";
 import type { InlineMatch } from "../lib/placeholder";
 import { replaceMatchesInTextNode } from "../lib/placeholder";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import type { Rule } from "./types";
 
 const RULE_ID = "secrets-mask" as const;
@@ -146,7 +147,7 @@ function collectMatches(text: string): InlineMatch[] {
   return merged;
 }
 
-function apply(root: ParentNode): void {
+function scanAndMask(root: ParentNode): void {
   for (const node of walkTextNodes(root, { minLength: MIN_TEXT_LENGTH })) {
     const matches = collectMatches(node.nodeValue ?? "");
     if (matches.length > 0) {
@@ -155,10 +156,27 @@ function apply(root: ParentNode): void {
   }
 }
 
+const watcher = createSubtreeWatcher({
+  skipPlaceholderSubtrees: true,
+  onSubtrees: (roots) => {
+    for (const root of roots) {
+      scanAndMask(root);
+    }
+  },
+});
+
+function apply(root: ParentNode): void {
+  scanAndMask(root);
+  watcher.start(root);
+}
+
 export const secretsMaskRule = {
   id: RULE_ID,
   label: "Mask Secrets",
   description:
     "Hide API keys, tokens, JWTs, private keys, and other high-entropy credentials.",
   apply,
+  teardown: () => {
+    watcher.stop();
+  },
 } satisfies Rule;


### PR DESCRIPTION
## Summary
- `pii-mask` and `secrets-mask` were the only DOM-mutating rules without a `createSubtreeWatcher`, so on SPAs they only scanned the initial `document_idle` snapshot. The demo site's `/checkout` view (and any client-side route swap) rendered card numbers, SSNs, and API keys that the rules never saw. Both rules now wire a watcher with `skipPlaceholderSubtrees: true` and a matching `teardown`, mirroring `scarcity-hide` / `hidden-text-strip`.
- Adds a "Rule authoring: re-scan SPA mutations" section to `AGENTS.md` so future DOM-mutating rules default to wiring a watcher.
- Adds lazy-load tests for both rules: masks content appended after `apply`, `teardown` stops the observer, and the rule does not loop on its own placeholder insertion.

## Test plan
- [ ] `bun run check` (Biome + ESLint)
- [ ] `bun run typecheck`
- [ ] `bun run test` (555 tests, all green locally; +6 new)
- [ ] Manually load the demo site, refresh `/`, click *Checkout* — card number `4111 1111 1111 1111`, SSN `123-45-6789`, and both `(555) …` phones should mask as `[card hidden]` / `[ssn hidden]` / `[phone hidden]` without a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)