### PR TITLE
Add confirmshame-neutralize rule

### DIFF
--- a/clawhub/agent-browser-shield/SKILL.md
+++ b/clawhub/agent-browser-shield/SKILL.md
@@ -87,9 +87,9 @@ Use when OpenClaw is connecting to a Chromium you launch yourself.
 - `data-abs-cleared` — pre-checked checkbox the extension unchecked on a
   cart/checkout page.
 - `data-abs-confirmshame-orig-text` / `…-orig-value` / `…-orig-aria` /
-  `…-orig-title` — a decline button whose guilt-tripping copy was rewritten
-  in place to a neutral "No thanks". The underlying control is unchanged;
-  click it normally.
+  `…-orig-title` — a decline button whose guilt-tripping copy was rewritten in
+  place to a neutral "No thanks". The underlying control is unchanged; click it
+  normally.
 - `<style id="abs-ads-hide-easylist">` — stylesheet hiding ad selectors. Removed
   elements are gone, not hidden behind a click.
 

--- a/clawhub/agent-browser-shield/SKILL.md
+++ b/clawhub/agent-browser-shield/SKILL.md
@@ -86,6 +86,10 @@ Use when OpenClaw is connecting to a Chromium you launch yourself.
   user did not explicitly request. `aria-label` carries detail.
 - `data-abs-cleared` — pre-checked checkbox the extension unchecked on a
   cart/checkout page.
+- `data-abs-confirmshame-orig-text` / `…-orig-value` / `…-orig-aria` /
+  `…-orig-title` — a decline button whose guilt-tripping copy was rewritten
+  in place to a neutral "No thanks". The underlying control is unchanged;
+  click it normally.
 - `<style id="abs-ads-hide-easylist">` — stylesheet hiding ad selectors. Removed
   elements are gone, not hidden behind a click.
 

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -3,7 +3,7 @@ title: Rules reference
 description: The defense rules shipped with agent-browser-shield, what each one does, and its default state.
 ---
 
-The extension ships 21 rules grouped into five rough categories. Each rule is
+The extension ships 22 rules grouped into five rough categories. Each rule is
 independently toggleable from the extension popup. Rules marked **default: on**
 are active on fresh install; **default: off** rules must be enabled manually.
 
@@ -228,6 +228,32 @@ out of scope.
 
 Prior art: Pre-checked opt-ins are *Preselection* in Mathur et al. 2019 and
 Brignull's deceptive.design catalog (both cited in the section preamble).
+
+### Neutralize Confirmshame Buttons
+
+- **ID:** `confirmshame-neutralize`
+- **Default:** on
+
+Rewrite guilt-tripping decline buttons to a neutral `No thanks` so an agent
+reading the DOM or accessibility tree isn't pushed away from the decline
+option by manipulative copy. Coverage spans monetary confirmshame
+("No, I'd rather pay full price", "I don't want to save money", "I hate
+discounts"), health and safety guilt ("I don't care about my family's
+safety", "I'm fine being unprotected"), loyalty downgrades ("Downgrade to
+basic", "Forfeit my Gold status"), gamified progress loss ("Lose my streak",
+"Sacrifice my XP"), imperative self-commands ("Charge me extra", "Stop
+helping me save"), sarcastic acceptance ("Whatever, take my money"), and
+the reverse-positive "Yes, [bad outcome]" framing common on confirmation
+dialogs ("Yes, skip my savings", "Confirm: pay full price").
+
+The underlying control is preserved — only its visible label and any
+matching `aria-label` / `title` are rewritten — so the agent can still click
+it normally. Plain decline labels like "No thanks", "Decline", "Maybe later",
+"Skip", and "Continue as guest" are left untouched.
+
+Prior art: Cataloged as *Confirmshaming* in Brignull's deceptive.design and
+as part of the *Misdirection* family in Mathur et al. 2019 (both cited in the
+section preamble).
 
 ### Flag Cart Add-Ons (Sneak-Into-Basket)
 

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -235,24 +235,24 @@ Brignull's deceptive.design catalog (both cited in the section preamble).
 - **Default:** on
 
 Rewrite guilt-tripping decline buttons to a neutral `No thanks` so an agent
-reading the DOM or accessibility tree isn't pushed away from the decline
-option by manipulative copy. Coverage spans monetary confirmshame
-("No, I'd rather pay full price", "I don't want to save money", "I hate
-discounts"), health and safety guilt ("I don't care about my family's
-safety", "I'm fine being unprotected"), loyalty downgrades ("Downgrade to
-basic", "Forfeit my Gold status"), gamified progress loss ("Lose my streak",
-"Sacrifice my XP"), imperative self-commands ("Charge me extra", "Stop
-helping me save"), sarcastic acceptance ("Whatever, take my money"), and
-the reverse-positive "Yes, [bad outcome]" framing common on confirmation
-dialogs ("Yes, skip my savings", "Confirm: pay full price").
+reading the DOM or accessibility tree isn't pushed away from the decline option
+by manipulative copy. Coverage spans monetary confirmshame ("No, I'd rather pay
+full price", "I don't want to save money", "I hate discounts"), health and
+safety guilt ("I don't care about my family's safety", "I'm fine being
+unprotected"), loyalty downgrades ("Downgrade to basic", "Forfeit my Gold
+status"), gamified progress loss ("Lose my streak", "Sacrifice my XP"),
+imperative self-commands ("Charge me extra", "Stop helping me save"), sarcastic
+acceptance ("Whatever, take my money"), and the reverse-positive "Yes, \[bad
+outcome\]" framing common on confirmation dialogs ("Yes, skip my savings",
+"Confirm: pay full price").
 
-The underlying control is preserved — only its visible label and any
-matching `aria-label` / `title` are rewritten — so the agent can still click
-it normally. Plain decline labels like "No thanks", "Decline", "Maybe later",
-"Skip", and "Continue as guest" are left untouched.
+The underlying control is preserved — only its visible label and any matching
+`aria-label` / `title` are rewritten — so the agent can still click it normally.
+Plain decline labels like "No thanks", "Decline", "Maybe later", "Skip", and
+"Continue as guest" are left untouched.
 
-Prior art: Cataloged as *Confirmshaming* in Brignull's deceptive.design and
-as part of the *Misdirection* family in Mathur et al. 2019 (both cited in the
+Prior art: Cataloged as *Confirmshaming* in Brignull's deceptive.design and as
+part of the *Misdirection* family in Mathur et al. 2019 (both cited in the
 section preamble).
 
 ### Flag Cart Add-Ons (Sneak-Into-Basket)

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -7,6 +7,7 @@
     "prompt-injection-hide": true,
     "countdown-timer-hide": true,
     "scarcity-hide": true,
+    "confirmshame-neutralize": true,
     "footer-hide": true,
     "checkout-checkbox-clear": true,
     "cookie-banner-hide": true,

--- a/extension/src/rules/__tests__/confirmshame-neutralize.test.ts
+++ b/extension/src/rules/__tests__/confirmshame-neutralize.test.ts
@@ -1,0 +1,389 @@
+import {
+  confirmshameNeutralizeRule,
+  isConfirmshameLabel,
+} from "../confirmshame-neutralize";
+
+const MUTATION_THROTTLE_MS = 250;
+const NEUTRAL_LABEL = "No thanks";
+
+async function flushMutations(): Promise<void> {
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  confirmshameNeutralizeRule.teardown();
+  jest.useRealTimers();
+});
+
+describe("isConfirmshameLabel", () => {
+  it.each([
+    "No, I'd rather pay full price",
+    "I would rather pay full price",
+    "I prefer to pay more",
+    "I'd rather keep paying retail",
+    "I'm fine paying full price",
+    "I'm OK paying more",
+    "I'm happy without the discount",
+    "I'm fine without the offer",
+    "I don't want to save money",
+    "I do not want to save money",
+    "I don't care about deals",
+    "I don't need to get the discount",
+    "I don't want to receive offers",
+    "I hate saving money",
+    "I dislike discounts",
+    "I don't like deals",
+    "I don't deserve a discount",
+    "I love paying full price",
+    "I enjoy overpaying",
+    "Skip and miss out on this deal",
+    "Continue without my discount",
+    "Proceed and pay full price",
+    "I'm not smart enough to save",
+    "I'm not interested in saving money",
+    "Maybe never",
+    // Health / safety / family / privacy guilt
+    "I don't want to protect my family",
+    "I don't need to protect my account",
+    "I don't care about my family",
+    "I don't care about my kids",
+    "I don't care about my privacy",
+    "I don't care about my security",
+    "I don't care about the safety of my family",
+    "I'd rather be unsafe",
+    "I would rather be vulnerable",
+    "I'd rather be hacked",
+    "I'm fine being unprotected",
+    "I'm OK being at risk",
+    // Loyalty / membership downgrade
+    "Downgrade to basic",
+    "Downgrade my account",
+    "Downgrade my membership",
+    "Remove my VIP benefits",
+    "Forfeit my Gold status",
+    "Give up my membership",
+    "Drop my Premium",
+    "Lose my Platinum perks",
+    "I don't deserve VIP",
+    // Gamification / streak loss
+    "Lose my streak",
+    "Forfeit all my XP",
+    "Abandon my progress",
+    "Sacrifice my rank",
+    "Throw away my hard-earned points",
+    "Give up all of my coins",
+    "Yes, lose my streak",
+    "Yes, reset my progress",
+    "Yes, forfeit my XP",
+    "Yes, lose 30 days",
+    // Imperative self-commands
+    "Make me pay full price",
+    "Let me pay more",
+    "Force me to pay retail",
+    "Charge me more",
+    "Charge me extra",
+    "Charge me 20% more",
+    "Charge me $5 more",
+    "Stop helping me save",
+    "Stop trying to help me find deals",
+    "Don't help me save",
+    "Don't help me protect my account",
+    // Sarcastic acceptance
+    "Sure, charge me",
+    "Whatever, take my money",
+    "Fine, take my cash",
+    "Of course, I love spam",
+    "Alright, charge me",
+    // Reverse-positive ("Yes, [bad outcome]")
+    "Yes, skip my savings",
+    "Yes, forfeit my discount",
+    "Yes, take away my coupon",
+    "Yes, cancel my membership",
+    "Yes, lose my streak", // also caught by gamification
+    "Yes, pay full price",
+    "Yes, charge me 20% more",
+    "Yes, charge me $50 more",
+    "Confirm: pay full price",
+    "Confirm — pay more",
+    "Yes, place my order without my discount",
+    "Yes, place order without the coupon",
+  ])("matches confirmshame copy: %s", (text) => {
+    expect(isConfirmshameLabel(text)).toBe(true);
+  });
+
+  it.each([
+    "No thanks",
+    "No",
+    "Decline",
+    "Maybe later",
+    "Skip",
+    "Skip for now",
+    "Close",
+    "Cancel",
+    "Dismiss",
+    "Continue as guest",
+    "Continue without an account",
+    "Sign in later",
+    "Not now",
+    "Remind me later",
+    "Subscribe",
+    "Save 20%",
+    "Get the discount",
+    "Yes, save my spot",
+    // Health / safety adjacent that should NOT trigger
+    "I'd rather be alone",
+    "I'm fine being here",
+    "Protect my account", // affirmative call to action
+    "Stay protected",
+    // Loyalty adjacent
+    "Upgrade to Premium",
+    "Manage my membership",
+    "View my Gold benefits",
+    "Downgrade plan", // missing required object — keep this as ambiguous-OK
+    // Gamification adjacent
+    "Reset settings",
+    "Reset progress", // bare "reset" without "yes,"/"lose" qualifier
+    "View my streak",
+    "Continue my progress",
+    "Start a new game",
+    // Imperative adjacent
+    "Charge me later",
+    "Charge me",
+    "Make me a member",
+    "Stop the timer",
+    // Confirm-dialog adjacent that should NOT trigger
+    "Yes",
+    "Yes, I'm sure",
+    "Yes, continue",
+    "Yes, confirm",
+    "Confirm",
+    "Confirm order",
+    "Place order",
+    "Yes, place my order",
+    // Sarcastic adjacent
+    "Sure",
+    "Sure, sounds good",
+    "Whatever works",
+    "Fine",
+    "OK",
+  ])("leaves plain refusal / unrelated text alone: %s", (text) => {
+    expect(isConfirmshameLabel(text)).toBe(false);
+  });
+
+  it("ignores empty / whitespace text", () => {
+    expect(isConfirmshameLabel("")).toBe(false);
+    expect(isConfirmshameLabel("   ")).toBe(false);
+  });
+
+  it("ignores text longer than the button-label cap", () => {
+    const long = `${"x ".repeat(200)} I hate saving money`;
+    expect(isConfirmshameLabel(long)).toBe(false);
+  });
+});
+
+describe("confirmshameNeutralizeRule.apply", () => {
+  it("rewrites a confirmshame <button> in place", () => {
+    document.body.innerHTML = `<button id="b">No, I'd rather pay full price</button>`;
+    confirmshameNeutralizeRule.apply(document.body);
+
+    const button = document.querySelector<HTMLButtonElement>("#b");
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toBe(NEUTRAL_LABEL);
+  });
+
+  it("rewrites a [role='button'] anchor in place", () => {
+    document.body.innerHTML = `<a id="a" role="button">I don't want to save money</a>`;
+    confirmshameNeutralizeRule.apply(document.body);
+
+    const anchor = document.querySelector<HTMLAnchorElement>("#a");
+    expect(anchor).not.toBeNull();
+    expect(anchor?.textContent).toBe(NEUTRAL_LABEL);
+  });
+
+  it("rewrites an <input type='button'> via the value attribute", () => {
+    document.body.innerHTML = `<input id="i" type="button" value="I hate saving money">`;
+    confirmshameNeutralizeRule.apply(document.body);
+
+    const input = document.querySelector<HTMLInputElement>("#i");
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe(NEUTRAL_LABEL);
+  });
+
+  it("rewrites confirmshame aria-label and title when present", () => {
+    document.body.innerHTML = `
+      <button id="b" aria-label="I don't want to save money" title="I hate discounts">
+        No, I'd rather pay full price
+      </button>
+    `;
+    confirmshameNeutralizeRule.apply(document.body);
+
+    const button = document.querySelector<HTMLButtonElement>("#b");
+    expect(button?.getAttribute("aria-label")).toBe(NEUTRAL_LABEL);
+    expect(button?.getAttribute("title")).toBe(NEUTRAL_LABEL);
+  });
+
+  it("leaves benign decline buttons untouched", () => {
+    document.body.innerHTML = `
+      <button id="a">No thanks</button>
+      <button id="b">Decline</button>
+      <button id="c">Maybe later</button>
+      <button id="d">Continue as guest</button>
+    `;
+    confirmshameNeutralizeRule.apply(document.body);
+
+    expect(document.querySelector("#a")?.textContent).toBe("No thanks");
+    expect(document.querySelector("#b")?.textContent).toBe("Decline");
+    expect(document.querySelector("#c")?.textContent).toBe("Maybe later");
+    expect(document.querySelector("#d")?.textContent).toBe("Continue as guest");
+  });
+
+  it("leaves non-button elements untouched even if their text matches", () => {
+    document.body.innerHTML = `<p id="p">I'd rather pay full price for this article.</p>`;
+    confirmshameNeutralizeRule.apply(document.body);
+
+    expect(document.querySelector("#p")?.textContent).toBe(
+      "I'd rather pay full price for this article.",
+    );
+  });
+
+  it("preserves the button element identity (event handlers stick)", () => {
+    document.body.innerHTML = `<button id="b">I hate saving money</button>`;
+    const before = document.querySelector<HTMLButtonElement>("#b");
+    let clicks = 0;
+    before?.addEventListener("click", () => {
+      clicks++;
+    });
+
+    confirmshameNeutralizeRule.apply(document.body);
+
+    const after = document.querySelector<HTMLButtonElement>("#b");
+    expect(after).toBe(before);
+    after?.click();
+    expect(clicks).toBe(1);
+  });
+
+  it("does not re-rewrite an already-neutralized button on a second apply", () => {
+    document.body.innerHTML = `<button id="b">I'd rather pay full price</button>`;
+    confirmshameNeutralizeRule.apply(document.body);
+    confirmshameNeutralizeRule.apply(document.body);
+
+    const button = document.querySelector<HTMLButtonElement>("#b");
+    expect(button?.textContent).toBe(NEUTRAL_LABEL);
+    expect(button?.dataset.absConfirmshameOrigText).toBe(
+      "I'd rather pay full price",
+    );
+  });
+});
+
+describe("confirmshameNeutralizeRule lazy-loaded buttons", () => {
+  it("rewrites a confirmshame button inserted after apply()", async () => {
+    confirmshameNeutralizeRule.apply(document.body);
+
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = `<button id="late">I don't want to save money</button>`;
+    document.body.append(wrapper);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelector("#late")?.textContent).toBe(NEUTRAL_LABEL);
+  });
+
+  it("rewrites a button that is itself the inserted root", async () => {
+    confirmshameNeutralizeRule.apply(document.body);
+
+    const button = document.createElement("button");
+    button.id = "root";
+    button.textContent = "I hate saving money";
+    document.body.append(button);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelector("#root")?.textContent).toBe(NEUTRAL_LABEL);
+  });
+
+  it("teardown restores original text, value, aria-label, and title", () => {
+    // Build the button without surrounding whitespace so the textContent
+    // round-trip is byte-exact — confirmshame buttons in the wild are
+    // usually plain text, and this rule preserves whatever was there.
+    const button = document.createElement("button");
+    button.id = "b";
+    button.setAttribute("aria-label", "I hate saving money");
+    button.setAttribute("title", "I hate saving money");
+    button.textContent = "No, I'd rather pay full price";
+    const input = document.createElement("input");
+    input.id = "i";
+    input.type = "button";
+    input.value = "I don't want to save money";
+    document.body.append(button, input);
+
+    confirmshameNeutralizeRule.apply(document.body);
+
+    expect(button.textContent).toBe(NEUTRAL_LABEL);
+    expect(input.value).toBe(NEUTRAL_LABEL);
+
+    confirmshameNeutralizeRule.teardown();
+
+    expect(button.textContent).toBe("No, I'd rather pay full price");
+    expect(button.getAttribute("aria-label")).toBe("I hate saving money");
+    expect(button.getAttribute("title")).toBe("I hate saving money");
+    expect(Object.hasOwn(button.dataset, "absConfirmshameOrigText")).toBe(
+      false,
+    );
+    expect(input.value).toBe("I don't want to save money");
+    expect(Object.hasOwn(input.dataset, "absConfirmshameOrigValue")).toBe(
+      false,
+    );
+  });
+
+  it("teardown stops the observer so later additions are ignored", async () => {
+    confirmshameNeutralizeRule.apply(document.body);
+    confirmshameNeutralizeRule.teardown();
+
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = `<button id="late">I hate saving money</button>`;
+    document.body.append(wrapper);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelector("#late")?.textContent).toBe(
+      "I hate saving money",
+    );
+  });
+});
+
+describe("confirmshameNeutralizeRule known limitations", () => {
+  it("does NOT re-neutralize when an existing button's text node is mutated in place", async () => {
+    // Encodes the limitation documented in the rule's file header: the
+    // shared subtree watcher only observes childList mutations, and
+    // `alreadyRewritten()` short-circuits on the stash data-attr — so a
+    // framework that mutates the existing text node's `nodeValue` (e.g.
+    // React re-rendering `<button>{label}</button>` when `label` flips
+    // back to the confirmshame copy) restores the original text and we
+    // do not re-neutralize. If this assumption ever breaks on a real
+    // site, see the TODO at the top of confirmshame-neutralize.ts.
+    document.body.innerHTML = `<button id="b">I'd rather pay full price</button>`;
+    confirmshameNeutralizeRule.apply(document.body);
+
+    const button = document.querySelector<HTMLButtonElement>("#b");
+    expect(button?.textContent).toBe(NEUTRAL_LABEL);
+
+    const textNode = button?.firstChild;
+    expect(textNode?.nodeType).toBe(Node.TEXT_NODE);
+    if (textNode) {
+      textNode.nodeValue = "I'd rather pay full price";
+    }
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(button?.textContent).toBe("I'd rather pay full price");
+  });
+});

--- a/extension/src/rules/confirmshame-neutralize.ts
+++ b/extension/src/rules/confirmshame-neutralize.ts
@@ -1,0 +1,314 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Rewrite "confirmshaming" decline buttons to a neutral label so an agent
+// reading the DOM/a11y tree isn't pushed away from the decline option by
+// guilt-tripping copy ("I'd rather pay full price", "I don't want to save
+// money", "I hate discounts", "Maybe never").
+//
+// Strategy: in-place text rewrite, NOT a placeholder. The agent still needs
+// to click the underlying control — only the visible label and any
+// confirmshame-styled aria-label / title are neutralized. The original text
+// is stashed on the element so teardown can restore the page exactly.
+//
+// Detection is intentionally narrow: every pattern requires a self-deprecating
+// or benefit-rejecting clause, so plain decline labels ("No thanks",
+// "Decline", "Maybe later", "Skip", "Close", "Continue as guest") never
+// match. The cost of a false negative (one confirmshame button survives) is
+// much lower than the cost of a false positive (a benign decline gets
+// re-labeled and the agent is confused about which button does what).
+//
+// Limitation: React-controlled buttons may re-render their text from
+// component state, restoring the original copy. The subtree watcher catches
+// new button nodes via childList mutations, but not in-place
+// characterData updates on a text node already inside a known button. In
+// practice confirmshame copy is set when the modal opens and doesn't change
+// after, so this is a deliberate trade-off vs. observing characterData
+// globally.
+//
+// TODO: if we hit a site that re-renders confirmshame copy in place after
+// our rewrite, extend createSubtreeWatcher to optionally observe
+// characterData on the rewritten subtree (or watch for the stash data-attr
+// being clobbered) and re-neutralize.
+
+import { log } from "../lib/log";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import type { Rule } from "./types";
+
+const RULE_ID = "confirmshame-neutralize" as const;
+
+// Stamped on rewritten controls so re-scans skip them and teardown can find
+// and restore them. Each attribute stashes the corresponding original value.
+const ORIGINAL_TEXT_ATTR = "data-abs-confirmshame-orig-text";
+const ORIGINAL_VALUE_ATTR = "data-abs-confirmshame-orig-value";
+const ORIGINAL_ARIA_ATTR = "data-abs-confirmshame-orig-aria";
+const ORIGINAL_TITLE_ATTR = "data-abs-confirmshame-orig-title";
+
+// Decline label that replaces confirmshame copy. "No thanks" reads as a
+// plain refusal in every context this rule fires in (modals, signup forms,
+// exit-intent overlays). "Cancel" was rejected because it implies an
+// in-flight action; "Decline" was rejected as slightly clinical.
+const NEUTRAL_LABEL = "No thanks";
+
+// Confirmshame copy is short. Capping prevents matching inside paragraph
+// prose that happens to live inside a [role="button"] wrapper or a giant
+// custom-component button.
+const MAX_BUTTON_TEXT_LENGTH = 240;
+
+// Each pattern targets a confirmshame *signature*: self-deprecation
+// ("I'm not smart enough"), benefit rejection ("I hate saving money"),
+// guilt-by-comparison ("I'd rather pay full price"), forced-acceptance
+// framing ("Yes, pay full price"), imperative self-commands ("Charge me
+// extra"), sarcastic acceptance ("Whatever, take my money"), or topical
+// guilt around health, family, loyalty status, and gamified progress
+// ("I don't care about my family's safety", "Forfeit my XP"). Plain refusal
+// text like "No thanks" or "Maybe later" must not match.
+const CONFIRMSHAME_PATTERNS: RegExp[] = [
+  // --- Monetary: pay more / forgo a discount ---
+
+  // "I'd rather pay full price" / "I prefer paying more" / "I would rather pay extra"
+  /\bi(?:'?d|\s+would)?\s+(?:rather|prefer(?:\s+to)?)\s+(?:keep\s+)?pay(?:ing)?\s+(?:full|more|extra|retail|the\s+full)/i,
+  // "I'm fine / OK / happy paying more / spending more / without [the discount/savings/offer]"
+  /\bi(?:'?m|\s+am)\s+(?:fine|ok(?:ay)?|happy|good)\s+(?:with\s+)?(?:paying|spending)\s+(?:full|more|extra|retail)/i,
+  /\bi(?:'?m|\s+am)\s+(?:fine|ok(?:ay)?|happy|good)\s+without\s+(?:the\s+)?(?:discount|saving|offer|deal|coupon|reward|free)/i,
+  // "I don't want / need to save money / get the discount / receive offers"
+  /\bi\s+(?:do\s+not|don'?t)\s+(?:want|need)\s+to\s+(?:save|win|earn|get|receive|hear|learn|miss)\b.{0,30}(?:money|cash|discount|deal|offer|reward|coupon|saving|free|update|news)/i,
+  // "I don't care about deals / love discounts / want updates"
+  /\bi\s+(?:do\s+not|don'?t)\s+(?:care\s+(?:about|for)|like|love|want|need)\s+(?:any\s+)?(?:discounts?|deals?|offers?|rewards?|coupons?|savings?|bargains?|free\s+(?:stuff|gifts?|shipping|samples?)|updates?|news|promotions?)\b/i,
+  // "I hate / dislike / don't like saving / discounts / deals / free shipping / good prices"
+  /\bi\s+(?:hate|dislike|don'?t\s+like)\s+(?:saving|discounts|deals|bargains|rewards|coupons|free|good\s+prices)/i,
+  // "I don't deserve [to save / a discount / Premium / ...]" — also catches
+  // loyalty-tier confirmshame like "I don't deserve VIP".
+  /\bi\s+(?:do\s+not|don'?t)\s+deserve\b/i,
+  // "I love / enjoy paying full price / overpaying"
+  /\bi\s+(?:love|enjoy|like)\s+(?:to\s+)?(?:pay(?:ing)?\s+(?:full|more|extra|retail)|overpaying)/i,
+  // "Skip / Continue / Proceed and miss out / and lose / and pay full / without my discount"
+  /\b(?:skip|continue|proceed|go\s+on)\b.{0,40}\b(?:and\s+miss|and\s+lose|and\s+pay\s+full|without\s+(?:my|the)\s+(?:discount|saving|offer|deal|coupon|reward))\b/i,
+  // "I'm not smart / cheap / frugal / interested in saving"
+  /\bi(?:'?m|\s+am)\s+not\s+(?:smart|cheap|frugal|interested\s+in\s+saving)/i,
+  // "Maybe never" (strictly stronger than "maybe later" and effectively always confirmshame)
+  /\bmaybe\s+never\b/i,
+
+  // --- Health / safety / family / privacy guilt ---
+  // Common on insurance, security, password-manager, identity-theft,
+  // parental-control, and antivirus apps.
+
+  // "I don't want / need to protect my [family/account/data/...]"
+  /\bi\s+(?:do\s+not|don'?t)\s+(?:want|need)\s+to\s+protect\s+(?:my|our)\b/i,
+  // "I don't care about my family / safety / security / privacy / health"
+  /\bi\s+(?:do\s+not|don'?t)\s+care\s+about\s+(?:my\s+|our\s+|the\s+)?(?:family|kids?|children|safety|security|privacy|health|future|home|identity|data|account|password|finances?)\b/i,
+  // "I'd rather be unsafe / vulnerable / exposed / at risk / hacked"
+  /\bi(?:'?d|\s+would)?\s+rather\s+be\s+(?:unsafe|vulnerable|exposed|unprotected|at\s+risk|in\s+danger|hacked|breached)/i,
+  // "I'm fine being vulnerable / unsafe / at risk"
+  /\bi(?:'?m|\s+am)\s+(?:fine|ok(?:ay)?|happy)\s+(?:being\s+|with\s+being\s+)(?:unsafe|vulnerable|exposed|unprotected|at\s+risk|in\s+danger|hacked)/i,
+
+  // --- Loyalty / membership downgrade framing ---
+
+  // "Downgrade to basic" / "Downgrade my plan" — never a positive action when
+  // worded as a button label on a retention/upsell modal.
+  /\bdowngrade\s+(?:to\s+|me\s+|my\s+(?:account|plan|membership|subscription|tier))/i,
+  // "Remove / forfeit / give up / drop my [Gold/VIP/membership/benefits/perks/...]"
+  /\b(?:remove|forfeit|give\s+up|drop|lose)\s+my\s+(?:gold|silver|platinum|bronze|vip|pro|premium|plus|elite|membership|benefits|perks|status|rewards|points)\b/i,
+
+  // --- Gamification / streak / progress loss ---
+  // Duolingo, Habitica, fitness, language, and other gamified apps. "Reset"
+  // alone is intentionally excluded — it's a legitimate settings action;
+  // require an unambiguous loss verb.
+
+  // "Lose / forfeit / abandon / sacrifice / throw away my streak / progress / XP / ..."
+  /\b(?:lose|forfeit|abandon|destroy|sacrifice|throw\s+away|give\s+up)\s+(?:my|all\s+(?:my|of\s+my))\s+(?:streak|progress|xp|points?|coins?|gems?|rank|level|score|badges?|achievements?|stats?|hard[\s-]?earned)/i,
+  // "Yes, lose / reset / forfeit my streak / 30 days of progress / XP /
+  // ..." — the "yes" affirmative reframes "reset" as confirmshame.
+  /\byes,?\s+(?:lose|reset|forfeit|sacrifice)\b.{0,20}\b(?:streak|progress|xp|points?|rank|score|days?|years?|months?)\b/i,
+
+  // --- Imperative self-commands (ordering bad treatment) ---
+
+  // "Make / let / force me [to] pay full / more / extra / retail"
+  /\b(?:make|let|force)\s+me\s+(?:to\s+)?pay\s+(?:full|more|extra|retail)\b/i,
+  // "Charge me more / extra / full / 20% more / $5 more"
+  /\bcharge\s+me\s+(?:more|extra|full|retail|the\s+full|\$\d|\d+\s*%)/i,
+  // "Stop helping me save / win / find / ..."
+  /\bstop\s+(?:trying\s+to\s+)?help(?:ing)?\s+me\s+(?:save|win|earn|find|get|with)/i,
+  // "Don't help me save / win / earn / find / protect"
+  /\bdon'?t\s+help\s+me\s+(?:save|win|earn|find|get|protect)\b/i,
+
+  // --- Sarcastic acceptance ---
+  // Require the sarcastic opener AND a recognized confirmshame follow-up so
+  // bare "Sure" / "Whatever" confirm buttons don't trigger.
+
+  /\b(?:sure|whatever|fine|alright|of\s+course),?\s+(?:charge\s+me|take\s+my\s+(?:money|cash)|i\s+love\s+(?:spam|junk\s+mail|paying|overpaying))/i,
+
+  // --- Reverse-positive ("Yes, [bad outcome]") ---
+  // The confirmshame on confirmation dialogs that survives after the
+  // upstream modal's decline button was already neutralized. The "yes"
+  // makes the bad outcome read as an affirmation.
+
+  // "Yes, skip / forfeit / lose / take away / remove my discount / savings / streak / ..."
+  /\byes,?\s+(?:skip|forfeit|lose|take\s+away|remove|cancel|reject)\s+(?:my|the)\s+(?:saving|discount|deal|offer|coupon|reward|points?|streak|progress|benefits?|membership|access)/i,
+  // "Yes, pay / charge me / spend full / more / extra / $X / X%"
+  /\byes,?\s+(?:pay|charge\s+me|spend)\s+(?:full|more|extra|retail|the\s+full|\$\d|\d+\s*%)/i,
+  // "Confirm: pay / skip / forfeit / lose / charge full / more / my / the ..."
+  /\bconfirm\s*[:\-—]?\s*(?:pay|skip|forfeit|lose|charge)\s+(?:full|more|extra|my|the)/i,
+  // "Yes, place [my] order without my / the discount / coupon / deal"
+  /\byes,?\s+place\s+(?:my\s+)?order\s+without\s+(?:my|the)\s+(?:discount|coupon|deal|offer)/i,
+];
+
+export function isConfirmshameLabel(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed.length > MAX_BUTTON_TEXT_LENGTH) {
+    return false;
+  }
+  return CONFIRMSHAME_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+const BUTTON_SELECTOR = [
+  "button",
+  '[role="button"]',
+  'input[type="button"]',
+  'input[type="submit"]',
+  'input[type="reset"]',
+].join(",");
+
+function alreadyRewritten(element: Element): boolean {
+  return (
+    element.hasAttribute(ORIGINAL_TEXT_ATTR) ||
+    element.hasAttribute(ORIGINAL_VALUE_ATTR)
+  );
+}
+
+function rewriteInput(input: HTMLInputElement): boolean {
+  const original = input.value;
+  if (!original || !isConfirmshameLabel(original)) {
+    return false;
+  }
+  input.setAttribute(ORIGINAL_VALUE_ATTR, original);
+  input.value = NEUTRAL_LABEL;
+  return true;
+}
+
+function rewriteButtonLike(element: HTMLElement): boolean {
+  const text = element.textContent;
+  if (!isConfirmshameLabel(text)) {
+    return false;
+  }
+  // Stash the visible text and overwrite via textContent. This drops any
+  // nested icons / spans, which is an accepted trade-off — confirmshame
+  // buttons are almost always plain text, and teardown restores the text
+  // verbatim. Avoiding innerHTML round-trips keeps us off the rule's
+  // attack-surface even on adversarial pages.
+  element.setAttribute(ORIGINAL_TEXT_ATTR, text);
+  element.textContent = NEUTRAL_LABEL;
+  return true;
+}
+
+function rewriteAttribute(
+  element: Element,
+  attributeName: string,
+  stashAttribute: string,
+): void {
+  const value = element.getAttribute(attributeName);
+  if (value && isConfirmshameLabel(value)) {
+    element.setAttribute(stashAttribute, value);
+    element.setAttribute(attributeName, NEUTRAL_LABEL);
+  }
+}
+
+function neutralize(element: HTMLElement): boolean {
+  if (alreadyRewritten(element)) {
+    return false;
+  }
+  const changed =
+    element instanceof HTMLInputElement
+      ? rewriteInput(element)
+      : rewriteButtonLike(element);
+  if (changed) {
+    rewriteAttribute(element, "aria-label", ORIGINAL_ARIA_ATTR);
+    rewriteAttribute(element, "title", ORIGINAL_TITLE_ATTR);
+  }
+  return changed;
+}
+
+function scanAndNeutralize(root: ParentNode): void {
+  let count = 0;
+  // querySelectorAll doesn't include the root itself — check it explicitly
+  // so a freshly-inserted button-shaped subtree root is handled.
+  if (
+    root instanceof Element &&
+    root.matches(BUTTON_SELECTOR) &&
+    neutralize(root as HTMLElement)
+  ) {
+    count++;
+  }
+  const candidates = root.querySelectorAll<HTMLElement>(BUTTON_SELECTOR);
+  for (const candidate of candidates) {
+    if (!candidate.isConnected) {
+      continue;
+    }
+    if (neutralize(candidate)) {
+      count++;
+    }
+  }
+  if (count > 0) {
+    log("confirmshame buttons neutralized", { count });
+  }
+}
+
+const watcher = createSubtreeWatcher({
+  onSubtrees: (roots) => {
+    for (const root of roots) {
+      scanAndNeutralize(root);
+    }
+  },
+});
+
+function apply(root: ParentNode): void {
+  scanAndNeutralize(root);
+  watcher.start(root);
+}
+
+function restoreOne(element: Element): void {
+  const text = element.getAttribute(ORIGINAL_TEXT_ATTR);
+  if (text !== null) {
+    element.textContent = text;
+    element.removeAttribute(ORIGINAL_TEXT_ATTR);
+  }
+  const value = element.getAttribute(ORIGINAL_VALUE_ATTR);
+  if (value !== null && element instanceof HTMLInputElement) {
+    element.value = value;
+    element.removeAttribute(ORIGINAL_VALUE_ATTR);
+  }
+  const aria = element.getAttribute(ORIGINAL_ARIA_ATTR);
+  if (aria !== null) {
+    element.setAttribute("aria-label", aria);
+    element.removeAttribute(ORIGINAL_ARIA_ATTR);
+  }
+  const title = element.getAttribute(ORIGINAL_TITLE_ATTR);
+  if (title !== null) {
+    element.setAttribute("title", title);
+    element.removeAttribute(ORIGINAL_TITLE_ATTR);
+  }
+}
+
+function restoreAll(): void {
+  const rewritten = document.querySelectorAll(
+    `[${ORIGINAL_TEXT_ATTR}], [${ORIGINAL_VALUE_ATTR}]`,
+  );
+  for (const element of rewritten) {
+    restoreOne(element);
+  }
+}
+
+export const confirmshameNeutralizeRule = {
+  id: RULE_ID,
+  label: "Neutralize Confirmshame Buttons",
+  description:
+    'Rewrite guilt-tripping decline buttons ("No, I\'d rather pay full price") to a neutral "No thanks" so the agent isn\'t pushed away from the decline option by manipulative copy.',
+  apply,
+  teardown: () => {
+    watcher.stop();
+    restoreAll();
+  },
+} satisfies Rule;

--- a/extension/src/rules/index.ts
+++ b/extension/src/rules/index.ts
@@ -6,6 +6,7 @@ import { cartAddonFlagRule } from "./cart-addon-flag";
 import { chatWidgetHideRule } from "./chat-widget-hide";
 import { checkoutCheckboxClearRule } from "./checkout-checkbox-clear";
 import { commentsHideRule } from "./comments-hide";
+import { confirmshameNeutralizeRule } from "./confirmshame-neutralize";
 import { cookieBannerHideRule } from "./cookie-banner-hide";
 import { countdownTimerHideRule } from "./countdown-timer-hide";
 import { crossOriginFrameHideRule } from "./cross-origin-frame-hide";
@@ -39,6 +40,7 @@ const RULES_TUPLE = [
   promptInjectionHideRule,
   countdownTimerHideRule,
   scarcityHideRule,
+  confirmshameNeutralizeRule,
   footerHideRule,
   checkoutCheckboxClearRule,
   cookieBannerHideRule,

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -12,6 +12,7 @@ export const RULE_DEFAULTS: Readonly<Record<RuleId, boolean>> = {
   "prompt-injection-hide": true,
   "countdown-timer-hide": true,
   "scarcity-hide": true,
+  "confirmshame-neutralize": true,
   "footer-hide": true,
   "checkout-checkbox-clear": true,
   "cookie-banner-hide": true,

--- a/skills/agent-browser-shield-config/SKILL.md
+++ b/skills/agent-browser-shield-config/SKILL.md
@@ -57,6 +57,8 @@ for the build-time workflow.
 - `prompt-injection-hide` — placeholder over likely injection surfaces
 - `countdown-timer-hide` — remove urgency countdowns
 - `scarcity-hide` — remove "only N left" scarcity cues
+- `confirmshame-neutralize` — rewrite guilt-tripping decline buttons ("No, I'd
+  rather pay full price") to a neutral "No thanks"
 - `footer-hide` — collapse site footers
 - `checkout-checkbox-clear` — uncheck pre-checked checkout boxes
 - `cookie-banner-hide` — strip cookie consent banners

--- a/skills/agent-browser-shield-diagnose/SKILL.md
+++ b/skills/agent-browser-shield-diagnose/SKILL.md
@@ -103,7 +103,8 @@ Two ways to view the diff:
   - Missing nodes on the guarded side that the baseline used to read
   - `abs-placeholder` lines on the guarded side (see the `agent-browser-shield`
     skill for marker semantics) — the agent may have failed to recognize these
-  - Extra `abs-cart-addon-flag` or `data-abs-cleared` markers
+  - Extra `abs-cart-addon-flag`, `data-abs-cleared`, or
+    `data-abs-confirmshame-orig-*` markers
   - Truncation: large guarded trees can blow past the model's context budget
 
 ## 4. Cross-check against the reasoning chain

--- a/skills/agent-browser-shield/SKILL.md
+++ b/skills/agent-browser-shield/SKILL.md
@@ -29,6 +29,10 @@ surfaces **before you see the page**.
   donation, round-up, gift wrap, carbon offset, shipping protection, driver tip,
   etc.). The line item itself is still in the cart.
 - `data-abs-cleared` — a pre-checked checkbox the extension unchecked.
+- `data-abs-confirmshame-orig-text` / `…-orig-value` / `…-orig-aria` /
+  `…-orig-title` — a decline button whose guilt-tripping copy ("No, I'd
+  rather pay full price") was rewritten in place to a neutral "No thanks".
+  The control is still the original decline button; click it normally.
 - `<style id="abs-ads-hide-easylist">` — silently CSS-hides ~13k EasyList ad
   selectors (you will not see those elements at all).
 

--- a/skills/agent-browser-shield/SKILL.md
+++ b/skills/agent-browser-shield/SKILL.md
@@ -30,9 +30,9 @@ surfaces **before you see the page**.
   etc.). The line item itself is still in the cart.
 - `data-abs-cleared` — a pre-checked checkbox the extension unchecked.
 - `data-abs-confirmshame-orig-text` / `…-orig-value` / `…-orig-aria` /
-  `…-orig-title` — a decline button whose guilt-tripping copy ("No, I'd
-  rather pay full price") was rewritten in place to a neutral "No thanks".
-  The control is still the original decline button; click it normally.
+  `…-orig-title` — a decline button whose guilt-tripping copy ("No, I'd rather
+  pay full price") was rewritten in place to a neutral "No thanks". The control
+  is still the original decline button; click it normally.
 - `<style id="abs-ads-hide-easylist">` — silently CSS-hides ~13k EasyList ad
   selectors (you will not see those elements at all).
 


### PR DESCRIPTION
## Summary

- New `confirmshame-neutralize` rule (default on) that rewrites guilt-tripping decline buttons to a neutral "No thanks" so an agent reading the DOM / a11y tree isn't pushed away from the decline option by manipulative copy. Coverage spans 7 categories: monetary confirmshame, health/safety/family guilt, loyalty downgrades, gamified progress loss, imperative self-commands, sarcastic acceptance, and the "Yes, [bad outcome]" reverse-positive framing common on confirmation dialogs.
- In-place text rewrite (not a placeholder) — the underlying control is preserved so the agent can still click it normally. Original text/value/aria-label/title is stashed in data attributes for clean teardown restoration.
- SPA-aware via `createSubtreeWatcher`. Known limitation (encoded in a regression test): in-place `characterData` mutations on an already-rewritten button's text node are not caught, since the shared watcher only observes `childList`. Confirmshame copy is set when the modal opens and rarely changes after, so this is a deliberate trade-off matching `scarcity-hide` / `cart-addon-flag`. Header has a TODO to extend the watcher if a real site violates that assumption.
- Detection is intentionally narrow: every pattern requires a self-deprecating or benefit-rejecting clause, so plain decline labels ("No thanks", "Decline", "Maybe later", "Continue as guest") never match. False-negative cost (one confirmshame button survives) is lower than false-positive cost (an unrelated button gets relabeled and the agent can't find the right control).

## Prior art

Cataloged as *Confirmshaming* in Brignull's [deceptive.design](https://www.deceptive.design/) and as part of the *Misdirection* family in [Mathur et al. 2019 *Dark Patterns at Scale*](https://webtransparency.cs.princeton.edu/dark-patterns/).

## Test plan

- [x] `bun run preflight` (codegen + biome + eslint + tsc + knip + jest coverage) — 32 suites / 703 tests pass
- [x] `bun run build` — extension bundles cleanly
- [ ] Manual: load the unpacked extension, open a newsletter signup modal with confirmshame copy, verify the decline button reads "No thanks" and still dismisses the modal when clicked
- [ ] Manual: verify benign decline labels ("No thanks", "Maybe later", "Continue as guest") are unmodified on real sites
- [ ] Follow-up (not in this PR): add a confirmshame fixture to `demo-site/` (probably the newsletter modal on `/`) so the demo coverage matrix in `demo-site/README.md` stays current

🤖 Generated with [Claude Code](https://claude.com/claude-code)