### PR TITLE
Expand Biome scope to demo-site and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           if-no-files-found: error
 
   demo-site:
-    name: Demo site (build)
+    name: Demo site (check / build)
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -108,6 +108,8 @@ jobs:
             echo "::error::package.json or bun.lock was modified by \`bun install --frozen-lockfile\` — your lockfile is out of sync. Run \`bun install\` locally and commit both files."
             exit 1
           fi
+      - name: Check (Biome format + lint)
+        run: bun run check
       - name: Build
         run: bun run build
 
@@ -136,7 +138,8 @@ jobs:
             exit 1
           fi
       # `astro build` does not type-check .astro frontmatter; `astro check` does.
-      - name: Check (types + content schema)
+      # `biome check .` covers .ts/.tsx/.json under docs/ via the root biome.json.
+      - name: Check (astro check + Biome)
         run: bun run check
       - name: Build
         run: bun run build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,8 +77,11 @@ repos:
       - id: biome-check
         name: Biome check (format + lint)
         additional_dependencies: ["@biomejs/biome@2.4.15"]
-        files: ^extension/.*\.(ts|tsx|js|jsx|mjs|cjs|json|jsonc)$
-        exclude: ^extension/dist/|\.generated\.(ts|tsx|js|jsx)$
+        # File scope here mirrors the `includes` in the root `biome.json`. Keep
+        # them in sync — Biome resolves its own scope from biome.json; the regex
+        # below is purely to skip invoking the hook on irrelevant changes.
+        files: ^(extension|demo-site)/.*\.(ts|tsx|js|jsx|mjs|cjs|json|jsonc|css)$|^docs/.*\.(ts|tsx|json|jsonc)$
+        exclude: /(dist|node_modules|\.astro)/|\.generated\.(ts|tsx|js|jsx)$
 
   - repo: local
     hooks:

--- a/biome.json
+++ b/biome.json
@@ -8,8 +8,11 @@
   "files": {
     "includes": [
       "extension/**",
+      "demo-site/**",
+      "docs/**/*.{ts,tsx,json,jsonc}",
       "!**/dist",
       "!**/node_modules",
+      "!**/.astro",
       "!**/*.generated.*"
     ]
   },

--- a/demo-site/bun.lock
+++ b/demo-site/bun.lock
@@ -10,6 +10,7 @@
         "react-router-dom": "^7.1.5",
       },
       "devDependencies": {
+        "@biomejs/biome": "2.4.15",
         "@tailwindcss/vite": "^4.0.6",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
@@ -21,6 +22,24 @@
     },
   },
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
+
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],

--- a/demo-site/package.json
+++ b/demo-site/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "check": "biome check ."
   },
   "dependencies": {
     "react": "^19.2.0",
@@ -15,6 +16,7 @@
     "react-router-dom": "^7.1.5"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.15",
     "@tailwindcss/vite": "^4.0.6",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",

--- a/demo-site/src/App.tsx
+++ b/demo-site/src/App.tsx
@@ -2,11 +2,11 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { Outlet } from "react-router-dom";
-import Header from "./components/Header";
-import Footer from "./components/Footer";
-import CookieBanner from "./components/CookieBanner";
-import NewsletterModal from "./components/NewsletterModal";
 import ChatWidget from "./components/ChatWidget";
+import CookieBanner from "./components/CookieBanner";
+import Footer from "./components/Footer";
+import Header from "./components/Header";
+import NewsletterModal from "./components/NewsletterModal";
 
 export default function App() {
   return (

--- a/demo-site/src/components/AdSlot.tsx
+++ b/demo-site/src/components/AdSlot.tsx
@@ -6,7 +6,10 @@ interface AdSlotProps {
   label?: string;
 }
 
-export default function AdSlot({ variant = "banner", label = "Advertisement" }: AdSlotProps) {
+export default function AdSlot({
+  variant = "banner",
+  label = "Advertisement",
+}: AdSlotProps) {
   const dims =
     variant === "sidebar"
       ? "h-72 w-full"
@@ -21,8 +24,12 @@ export default function AdSlot({ variant = "banner", label = "Advertisement" }: 
       data-ad-slot="1234567890"
     >
       <div className="flex h-full flex-col items-center justify-center text-stone-600">
-        <span className="text-[10px] uppercase tracking-widest text-amber-700">{label}</span>
-        <span className="text-sm">Your dream vacation is one click away — Sunsail Cruises ✈️</span>
+        <span className="text-[10px] uppercase tracking-widest text-amber-700">
+          {label}
+        </span>
+        <span className="text-sm">
+          Your dream vacation is one click away — Sunsail Cruises ✈️
+        </span>
       </div>
     </ins>
   );

--- a/demo-site/src/components/CookieBanner.tsx
+++ b/demo-site/src/components/CookieBanner.tsx
@@ -5,7 +5,9 @@ import { useState } from "react";
 
 export default function CookieBanner() {
   const [dismissed, setDismissed] = useState(false);
-  if (dismissed) return null;
+  if (dismissed) {
+    return null;
+  }
   return (
     <div
       id="onetrust-banner-sdk"
@@ -16,11 +18,14 @@ export default function CookieBanner() {
     >
       <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 py-4 md:flex-row md:items-center md:justify-between">
         <div className="max-w-3xl text-sm text-stone-700">
-          <strong className="block text-base text-slate-900">We value your privacy</strong>
-          We and our 847 advertising partners store and access cookies on your device to
-          personalize ads, measure ad performance, develop audience insights, and improve
-          our products. By clicking "Accept All" you consent to this use of cookies. You
-          can manage your preferences at any time in our Cookie Settings.
+          <strong className="block text-base text-slate-900">
+            We value your privacy
+          </strong>
+          We and our 847 advertising partners store and access cookies on your
+          device to personalize ads, measure ad performance, develop audience
+          insights, and improve our products. By clicking "Accept All" you
+          consent to this use of cookies. You can manage your preferences at any
+          time in our Cookie Settings.
         </div>
         <div className="flex shrink-0 gap-2">
           <button

--- a/demo-site/src/components/CountdownBadge.tsx
+++ b/demo-site/src/components/CountdownBadge.tsx
@@ -33,7 +33,8 @@ export default function CountdownBadge({
     <div className="inline-flex items-center gap-2 rounded bg-red-50 px-3 py-1.5 text-sm text-red-700 ring-1 ring-red-200">
       <span aria-hidden="true">⚡</span>
       <span>
-        {label} <span className="font-mono font-semibold">{format(remaining)}</span>
+        {label}{" "}
+        <span className="font-mono font-semibold">{format(remaining)}</span>
       </span>
     </div>
   );

--- a/demo-site/src/components/Footer.tsx
+++ b/demo-site/src/components/Footer.tsx
@@ -44,7 +44,8 @@ export default function Footer() {
         </div>
       </div>
       <div className="border-t border-slate-800 py-4 text-center text-xs text-stone-400">
-        © 2026 RiverMart Holdings, Inc. — Conditions of Use | Privacy Notice | Your Ads Privacy Choices
+        © 2026 RiverMart Holdings, Inc. — Conditions of Use | Privacy Notice |
+        Your Ads Privacy Choices
       </div>
     </footer>
   );

--- a/demo-site/src/components/NewsletterModal.tsx
+++ b/demo-site/src/components/NewsletterModal.tsx
@@ -8,12 +8,16 @@ export default function NewsletterModal() {
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
-    if (dismissed) return;
+    if (dismissed) {
+      return;
+    }
     const id = setTimeout(() => setOpen(true), 6000);
     return () => clearTimeout(id);
   }, [dismissed]);
 
-  if (!open || dismissed) return null;
+  if (!open || dismissed) {
+    return null;
+  }
 
   return (
     <div
@@ -36,8 +40,9 @@ export default function NewsletterModal() {
           Don&apos;t miss our weekly deals
         </h2>
         <p className="mb-4 text-sm text-stone-600">
-          Subscribe to the RiverMart newsletter and get 10% off your next order. Stay in
-          the loop on flash sales, new arrivals, and members-only events.
+          Subscribe to the RiverMart newsletter and get 10% off your next order.
+          Stay in the loop on flash sales, new arrivals, and members-only
+          events.
         </p>
         <form
           onSubmit={(e) => {
@@ -60,8 +65,8 @@ export default function NewsletterModal() {
           </button>
         </form>
         <p className="mt-3 text-xs text-stone-500">
-          By signing up, you agree to receive marketing emails from RiverMart. You can
-          unsubscribe at any time.
+          By signing up, you agree to receive marketing emails from RiverMart.
+          You can unsubscribe at any time.
         </p>
       </div>
     </div>

--- a/demo-site/src/components/ReviewSection.tsx
+++ b/demo-site/src/components/ReviewSection.tsx
@@ -13,19 +13,30 @@ function stars(n: number): string {
   return "★★★★★☆☆☆☆☆".slice(5 - Math.round(n), 10 - Math.round(n));
 }
 
-export default function ReviewSection({ reviews, averageRating, ratingCount }: ReviewSectionProps) {
+export default function ReviewSection({
+  reviews,
+  averageRating,
+  ratingCount,
+}: ReviewSectionProps) {
   return (
-    <section id="reviewsMedley" className="rounded border border-stone-200 bg-white p-6">
+    <section
+      id="reviewsMedley"
+      className="rounded border border-stone-200 bg-white p-6"
+    >
       <h2 className="text-xl font-semibold text-slate-900">Customer reviews</h2>
       <div className="mt-2 flex items-baseline gap-3 text-sm">
         <span className="text-yellow-500">{stars(averageRating)}</span>
-        <span className="font-semibold">{averageRating.toFixed(1)} out of 5</span>
-        <span className="text-stone-500">{ratingCount.toLocaleString()} global ratings</span>
+        <span className="font-semibold">
+          {averageRating.toFixed(1)} out of 5
+        </span>
+        <span className="text-stone-500">
+          {ratingCount.toLocaleString()} global ratings
+        </span>
       </div>
       <div className="mt-6 space-y-6">
-        {reviews.map((review, idx) => (
+        {reviews.map((review) => (
           <article
-            key={idx}
+            key={`${review.author}-${review.date}-${review.title}`}
             itemScope
             itemType="https://schema.org/Review"
             className="border-t border-stone-200 pt-4"
@@ -38,10 +49,13 @@ export default function ReviewSection({ reviews, averageRating, ratingCount }: R
             </header>
             <div className="text-sm text-yellow-500" itemProp="reviewRating">
               {stars(review.stars)}
-              <span className="ml-2 font-semibold text-slate-900">{review.title}</span>
+              <span className="ml-2 font-semibold text-slate-900">
+                {review.title}
+              </span>
             </div>
             <div className="text-xs text-stone-500">
-              Reviewed in the United States on <time itemProp="datePublished">{review.date}</time>
+              Reviewed in the United States on{" "}
+              <time itemProp="datePublished">{review.date}</time>
             </div>
             <p className="mt-2 text-sm text-stone-800" itemProp="reviewBody">
               {review.body}

--- a/demo-site/src/components/ScarcityBadge.tsx
+++ b/demo-site/src/components/ScarcityBadge.tsx
@@ -6,13 +6,18 @@ interface ScarcityBadgeProps {
   tone?: "warning" | "info";
 }
 
-export default function ScarcityBadge({ text, tone = "warning" }: ScarcityBadgeProps) {
+export default function ScarcityBadge({
+  text,
+  tone = "warning",
+}: ScarcityBadgeProps) {
   const cls =
     tone === "warning"
       ? "bg-red-50 text-red-700 ring-red-200"
       : "bg-amber-50 text-amber-800 ring-amber-200";
   return (
-    <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ring-1 ${cls}`}>
+    <span
+      className={`inline-block rounded px-2 py-0.5 text-xs font-medium ring-1 ${cls}`}
+    >
       {text}
     </span>
   );

--- a/demo-site/src/components/SocialEmbed.tsx
+++ b/demo-site/src/components/SocialEmbed.tsx
@@ -6,7 +6,10 @@ interface SocialEmbedProps {
   title?: string;
 }
 
-export default function SocialEmbed({ videoId, title = "Video review" }: SocialEmbedProps) {
+export default function SocialEmbed({
+  videoId,
+  title = "Video review",
+}: SocialEmbedProps) {
   return (
     <div className="my-4 aspect-video w-full max-w-2xl overflow-hidden rounded border border-stone-200">
       <iframe

--- a/demo-site/src/data/products.ts
+++ b/demo-site/src/data/products.ts
@@ -68,7 +68,7 @@ export const products: Product[] = [
     rating: 4.7,
     ratingCount: 9214,
     description:
-      'Heirloom-quality 12-inch cast iron skillet. Pre-seasoned with organic flaxseed oil so it\'s ready to use out of the box. Improves with every meal.',
+      "Heirloom-quality 12-inch cast iron skillet. Pre-seasoned with organic flaxseed oil so it's ready to use out of the box. Improves with every meal.",
     bulletPoints: [
       "Heat-retaining solid iron construction",
       "Oven safe to 500°F",

--- a/demo-site/src/main.tsx
+++ b/demo-site/src/main.tsx
@@ -5,14 +5,16 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import App from "./App.tsx";
-import Home from "./pages/Home.tsx";
-import ProductDetail from "./pages/ProductDetail.tsx";
 import Cart from "./pages/Cart.tsx";
 import Checkout from "./pages/Checkout.tsx";
+import Home from "./pages/Home.tsx";
+import ProductDetail from "./pages/ProductDetail.tsx";
 import "./index.css";
 
 const root = document.getElementById("root");
-if (!root) throw new Error("#root not found");
+if (!root) {
+  throw new Error("#root not found");
+}
 
 createRoot(root).render(
   <StrictMode>

--- a/demo-site/src/pages/Cart.tsx
+++ b/demo-site/src/pages/Cart.tsx
@@ -2,8 +2,8 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { Link } from "react-router-dom";
-import { products } from "../data/products";
 import ScarcityBadge from "../components/ScarcityBadge";
+import { products } from "../data/products";
 
 interface LineItem {
   title: string;
@@ -67,17 +67,15 @@ export default function Cart() {
       <h1 className="text-2xl font-semibold text-slate-900">Shopping Cart</h1>
 
       <div className="rounded border border-amber-300 bg-amber-50 p-3 text-sm">
-        <ScarcityBadge
-          text="5 other people have this in their cart — checkout soon to avoid losing items"
-        />
+        <ScarcityBadge text="5 other people have this in their cart — checkout soon to avoid losing items" />
       </div>
 
       <div className="grid gap-6 lg:grid-cols-[1fr,300px]">
         <div className="rounded border border-stone-200 bg-white">
           <ul>
-            {lines.map((line, idx) => (
+            {lines.map((line) => (
               <li
-                key={idx}
+                key={line.title}
                 className="flex gap-4 border-b border-stone-200 px-4 py-4 last:border-b-0"
               >
                 {line.image ? (
@@ -117,22 +115,22 @@ export default function Cart() {
             <label className="flex items-start gap-2 text-sm text-stone-700">
               <input type="checkbox" defaultChecked className="mt-0.5" />
               <span>
-                <strong>Add gift wrap</strong> (+$4.99) — Make this order feel like a
-                gift.
+                <strong>Add gift wrap</strong> (+$4.99) — Make this order feel
+                like a gift.
               </span>
             </label>
             <label className="flex items-start gap-2 text-sm text-stone-700">
               <input type="checkbox" defaultChecked className="mt-0.5" />
               <span>
-                <strong>Add 2-year protection</strong> (+$12.00) — Covers accidental
-                damage and mechanical failure.
+                <strong>Add 2-year protection</strong> (+$12.00) — Covers
+                accidental damage and mechanical failure.
               </span>
             </label>
             <label className="flex items-start gap-2 text-sm text-stone-700">
               <input type="checkbox" defaultChecked className="mt-0.5" />
               <span>
-                Subscribe to RiverMart deals emails — Get exclusive deals and 10% off
-                your next order.
+                Subscribe to RiverMart deals emails — Get exclusive deals and
+                10% off your next order.
               </span>
             </label>
             <label className="flex items-start gap-2 text-sm text-stone-700">

--- a/demo-site/src/pages/Checkout.tsx
+++ b/demo-site/src/pages/Checkout.tsx
@@ -50,29 +50,29 @@ export default function Checkout() {
               <label className="flex items-start gap-2">
                 <input type="checkbox" defaultChecked className="mt-0.5" />
                 <span>
-                  <strong>Save payment information for future purchases</strong> — One-click
-                  checkout on your next order.
+                  <strong>Save payment information for future purchases</strong>{" "}
+                  — One-click checkout on your next order.
                 </span>
               </label>
               <label className="flex items-start gap-2">
                 <input type="checkbox" defaultChecked className="mt-0.5" />
                 <span>
-                  <strong>Sign me up for the RiverMart Store Card</strong> — Earn 5% back
-                  on every purchase. (Subject to credit approval.)
+                  <strong>Sign me up for the RiverMart Store Card</strong> —
+                  Earn 5% back on every purchase. (Subject to credit approval.)
                 </span>
               </label>
               <label className="flex items-start gap-2">
                 <input type="checkbox" defaultChecked className="mt-0.5" />
                 <span>
-                  Donate $1 to RiverMart&apos;s Hunger Relief Foundation. Round-up
-                  applied to order total.
+                  Donate $1 to RiverMart&apos;s Hunger Relief Foundation.
+                  Round-up applied to order total.
                 </span>
               </label>
               <label className="flex items-start gap-2">
                 <input type="checkbox" defaultChecked className="mt-0.5" />
                 <span>
-                  Enroll in carbon-offset shipping (+$0.75). Helps offset the carbon
-                  footprint of your delivery.
+                  Enroll in carbon-offset shipping (+$0.75). Helps offset the
+                  carbon footprint of your delivery.
                 </span>
               </label>
               <label className="flex items-start gap-2">
@@ -84,7 +84,9 @@ export default function Checkout() {
         </div>
 
         <div className="h-fit rounded border border-stone-200 bg-white p-4">
-          <h2 className="mb-3 text-lg font-semibold text-slate-900">Order summary</h2>
+          <h2 className="mb-3 text-lg font-semibold text-slate-900">
+            Order summary
+          </h2>
           <dl className="space-y-1 text-sm">
             <div className="flex justify-between">
               <dt>Items (6):</dt>
@@ -115,7 +117,8 @@ export default function Checkout() {
             Place your order
           </button>
           <p className="mt-3 text-xs text-stone-500">
-            By placing your order, you agree to RiverMart&apos;s Conditions of Use.
+            By placing your order, you agree to RiverMart&apos;s Conditions of
+            Use.
           </p>
         </div>
       </div>

--- a/demo-site/src/pages/Home.tsx
+++ b/demo-site/src/pages/Home.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-import { products } from "../data/products";
-import ProductCard from "../components/ProductCard";
-import CountdownBadge from "../components/CountdownBadge";
 import AdSlot from "../components/AdSlot";
+import CountdownBadge from "../components/CountdownBadge";
+import ProductCard from "../components/ProductCard";
+import { products } from "../data/products";
 
 export default function Home() {
   const featured = products.slice(0, 3);
@@ -18,18 +18,23 @@ export default function Home() {
       >
         <h1 className="text-3xl font-bold">Spring Refresh Sale</h1>
         <p className="mt-2 max-w-2xl text-stone-300">
-          Up to 40% off home, kitchen, and electronics. Members get free 2-day shipping
-          on every order.
+          Up to 40% off home, kitchen, and electronics. Members get free 2-day
+          shipping on every order.
         </p>
         <div className="mt-4">
-          <CountdownBadge initialSeconds={3 * 3600 + 17 * 60 + 42} label="Sale ends in" />
+          <CountdownBadge
+            initialSeconds={3 * 3600 + 17 * 60 + 42}
+            label="Sale ends in"
+          />
         </div>
       </section>
 
       <AdSlot variant="banner" label="Sponsored" />
 
       <section aria-label="Today's deals">
-        <h2 className="mb-3 text-xl font-semibold text-slate-900">Today&apos;s Deals</h2>
+        <h2 className="mb-3 text-xl font-semibold text-slate-900">
+          Today&apos;s Deals
+        </h2>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {featured.map((product, idx) => (
             <ProductCard
@@ -53,12 +58,18 @@ export default function Home() {
         className="rounded border border-dashed border-amber-400 bg-amber-50 p-4 text-center text-sm text-stone-600"
         data-ad-slot="sidebar-1"
       >
-        <div className="text-[10px] uppercase tracking-widest text-amber-700">Advertisement</div>
-        <div className="mt-1">Refinance your mortgage with Mortimer Loans — rates from 5.99% APR</div>
+        <div className="text-[10px] uppercase tracking-widest text-amber-700">
+          Advertisement
+        </div>
+        <div className="mt-1">
+          Refinance your mortgage with Mortimer Loans — rates from 5.99% APR
+        </div>
       </aside>
 
       <section aria-label="Recommended for you">
-        <h2 className="mb-3 text-xl font-semibold text-slate-900">Recommended for you</h2>
+        <h2 className="mb-3 text-xl font-semibold text-slate-900">
+          Recommended for you
+        </h2>
         <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
           {grid.map((product) => (
             <ProductCard key={product.id} product={product} />

--- a/demo-site/src/pages/ProductDetail.tsx
+++ b/demo-site/src/pages/ProductDetail.tsx
@@ -1,23 +1,27 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-import { useParams, Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
+import CountdownBadge from "../components/CountdownBadge";
+import ReviewSection from "../components/ReviewSection";
+import ScarcityBadge from "../components/ScarcityBadge";
+import SocialEmbed from "../components/SocialEmbed";
+import { INJECTIONS } from "../data/injection-fixtures";
 import { getProduct } from "../data/products";
 import { getReviews } from "../data/reviews";
-import { INJECTIONS } from "../data/injection-fixtures";
-import CountdownBadge from "../components/CountdownBadge";
-import ScarcityBadge from "../components/ScarcityBadge";
-import ReviewSection from "../components/ReviewSection";
-import SocialEmbed from "../components/SocialEmbed";
 
 // React strips JSX comment children at build time, so an `<!-- ... -->` literal
 // would never reach the DOM. We need real HTML comments here so html-comment-strip
 // has something to remove — dangerouslySetInnerHTML is the only way to ship them
-// through React.
+// through React. The "untrusted" content is a static literal from our own fixture
+// file, not user input.
 function HtmlCommentInjection() {
   return (
     <span
-      dangerouslySetInnerHTML={{ __html: INJECTIONS.PRODUCT_DETAIL_HTML_COMMENT }}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: demo fixture for the html-comment-strip rule; static content from injection-fixtures.ts, no user input
+      dangerouslySetInnerHTML={{
+        __html: INJECTIONS.PRODUCT_DETAIL_HTML_COMMENT,
+      }}
     />
   );
 }
@@ -39,7 +43,9 @@ export default function ProductDetail() {
   }
 
   const discountPct = product.listPrice
-    ? Math.round(((product.listPrice - product.price) / product.listPrice) * 100)
+    ? Math.round(
+        ((product.listPrice - product.price) / product.listPrice) * 100,
+      )
     : 0;
 
   return (
@@ -81,7 +87,9 @@ export default function ProductDetail() {
         </div>
 
         <div className="space-y-3">
-          <h1 className="text-2xl font-semibold text-slate-900">{product.title}</h1>
+          <h1 className="text-2xl font-semibold text-slate-900">
+            {product.title}
+          </h1>
           <div className="text-sm text-orange-700 hover:underline">
             Visit the {product.brand} Store
           </div>
@@ -101,11 +109,15 @@ export default function ProductDetail() {
                 -{discountPct}%
               </span>
             )}
-            <span className="text-3xl text-red-700">${product.price.toFixed(2)}</span>
+            <span className="text-3xl text-red-700">
+              ${product.price.toFixed(2)}
+            </span>
             {product.listPrice && (
               <span className="text-sm text-stone-500">
                 List Price:{" "}
-                <span className="line-through">${product.listPrice.toFixed(2)}</span>
+                <span className="line-through">
+                  ${product.listPrice.toFixed(2)}
+                </span>
               </span>
             )}
           </div>
@@ -114,7 +126,10 @@ export default function ProductDetail() {
 
           <div className="flex flex-wrap gap-2 pt-2">
             <ScarcityBadge text="Only 2 left in stock — order soon" />
-            <ScarcityBadge text="12 people are viewing this right now" tone="info" />
+            <ScarcityBadge
+              text="12 people are viewing this right now"
+              tone="info"
+            />
             <ScarcityBadge text="Selling fast" />
           </div>
 
@@ -145,7 +160,9 @@ export default function ProductDetail() {
       </article>
 
       <section aria-label="About this item">
-        <h2 className="mb-2 text-lg font-semibold text-slate-900">About this item</h2>
+        <h2 className="mb-2 text-lg font-semibold text-slate-900">
+          About this item
+        </h2>
         <div className="max-w-3xl space-y-2 text-sm text-stone-800">
           <p>
             {product.description}{" "}
@@ -176,11 +193,17 @@ export default function ProductDetail() {
       </section>
 
       <section aria-label="From the manufacturer">
-        <h2 className="mb-2 text-lg font-semibold text-slate-900">From the manufacturer</h2>
+        <h2 className="mb-2 text-lg font-semibold text-slate-900">
+          From the manufacturer
+        </h2>
         <p className="max-w-3xl text-sm text-stone-700">
-          Watch the launch video to see what makes the {product.title} different.
+          Watch the launch video to see what makes the {product.title}{" "}
+          different.
         </p>
-        <SocialEmbed videoId="dQw4w9WgXcQ" title={`${product.title} demo video`} />
+        <SocialEmbed
+          videoId="dQw4w9WgXcQ"
+          title={`${product.title} demo video`}
+        />
       </section>
 
       <ReviewSection

--- a/demo-site/vite.config.ts
+++ b/demo-site/vite.config.ts
@@ -1,9 +1,9 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   base: "/",

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -11,6 +11,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
+        "@biomejs/biome": "2.4.15",
         "typescript": "^6.0.3",
       },
     },
@@ -45,6 +46,24 @@
     "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
 
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "check": "astro check",
+    "check": "astro check && biome check .",
     "astro": "astro"
   },
   "dependencies": {
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@biomejs/biome": "2.4.15",
     "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Summary

- `biome.json` `includes` previously covered only `extension/**`, so the React/TS files most likely to be co-edited with extension rule work were unlinted and unformatted. Expands scope to `demo-site/**` and `docs/**/*.{ts,tsx,json,jsonc}`.
- Installs `@biomejs/biome@2.4.15` as a devDep in `demo-site/` and `docs/`, adds a `check` script in each (docs chains `astro check && biome check .`), and wires both into the existing CI jobs.
- Updates the pre-commit `biome-check` files filter to match the expanded scope so the local hook tracks CI.
- Flushed out a backlog of formatting drift across `demo-site/` and three lint findings, all addressed in this PR:
  - `noArrayIndexKey` in `Cart.tsx` and `ReviewSection.tsx` — replaced index keys with stable derived keys (`line.title`, `\`${author}-${date}-${title}\``).
  - `noDangerouslySetInnerHtml` in `ProductDetail.tsx` — added a `biome-ignore` with a clear `why` (intentional demo fixture for `html-comment-strip`; content is a static literal from `injection-fixtures.ts`).

Follow-up to #91 — together those two PRs close out the "bring sibling sites up to the extension's strictness bar" finding from the agent-readiness audit.

## Test plan

- [x] `biome check .` clean across all 152 files in scope
- [x] `bun run check` works in both `demo-site/` and `docs/` (each picks up the root `biome.json`)
- [x] `bun run build` still passes for `demo-site/` and `docs/`
- [x] `bun run preflight` in `extension/` still green (unchanged)
- [x] `pre-commit run` against representative changed files passes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)