### PR TITLE
Add Pyright type-check to scripts/ Python tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+          # Full history so the strict-on-new-files ratchet below can compute
+          # `origin/<base>...HEAD` — the default shallow checkout lacks the
+          # merge base on most PRs.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
       - name: Set up Python
         run: uv python install 3.14
@@ -182,9 +186,10 @@ jobs:
         run: uvx pyright
       # New-file ratchet: every newly-added Python file must opt in to
       # `# pyright: strict`. Stops legacy debt in scripts/ from growing
-      # while we leave the global mode at standard.
+      # while we leave the global mode at standard. base_ref is passed via
+      # env so it isn't expanded inside the shell (zizmor template-injection).
       - name: Pyright strict-on-new-files ratchet
         if: github.event_name == 'pull_request'
-        run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1
-          uv run scripts/check_pyright_strict_on_new_files.py "origin/${{ github.base_ref }}"
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: uv run scripts/check_pyright_strict_on_new_files.py "origin/$BASE_REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   python:
-    name: Python (ruff + bandit)
+    name: Python (ruff + bandit + pyright)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -175,3 +175,8 @@ jobs:
         run: uvx ruff format --check scripts/
       - name: Bandit security scan
         run: uvx --from "bandit[toml]" bandit -c pyproject.toml -r scripts/
+      # Pyright config lives in pyproject.toml `[tool.pyright]`; basic mode
+      # with import resolution disabled (PEP 723 inline-deps aren't installed
+      # into a shared venv). Ratchet up via per-file `# pyright: strict`.
+      - name: Pyright type check
+        run: uvx pyright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,16 @@ jobs:
         run: uvx ruff format --check scripts/
       - name: Bandit security scan
         run: uvx --from "bandit[toml]" bandit -c pyproject.toml -r scripts/
-      # Pyright config lives in pyproject.toml `[tool.pyright]`; basic mode
+      # Pyright config lives in pyproject.toml `[tool.pyright]`; standard mode
       # with import resolution disabled (PEP 723 inline-deps aren't installed
       # into a shared venv). Ratchet up via per-file `# pyright: strict`.
       - name: Pyright type check
         run: uvx pyright
+      # New-file ratchet: every newly-added Python file must opt in to
+      # `# pyright: strict`. Stops legacy debt in scripts/ from growing
+      # while we leave the global mode at standard.
+      - name: Pyright strict-on-new-files ratchet
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          uv run scripts/check_pyright_strict_on_new_files.py "origin/${{ github.base_ref }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,6 +108,20 @@ repos:
         additional_dependencies: ["bandit[toml]"]
         files: ^scripts/.*\.py$
 
+  # Pyright runs against the whole `scripts/` tree (config in pyproject.toml)
+  # — file-scoped invocation would miss cross-file inference. The PyPI
+  # `pyright` package wraps the node binary and downloads it on first run,
+  # so the hook works in any pre-commit environment without a system `uvx`.
+  - repo: local
+    hooks:
+      - id: pyright
+        name: Pyright (Python type check)
+        language: python
+        entry: pyright
+        additional_dependencies: ["pyright==1.1.410"]
+        files: ^scripts/.*\.py$|^pyproject\.toml$
+        pass_filenames: false
+
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.8
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,15 @@ skips = ["B404", "B603", "B607"]
 include = ["scripts"]
 exclude = [".venv", "output", "benchmark", "node_modules", "extension", "demo-site", "docs"]
 pythonVersion = "3.12"
-# Basic mode is the starting ratchet — strict typing on the entire ~7.6k-LOC
-# scripts tree at once would be a multi-week migration. Promote individual
-# files (or directories) to `strict` via per-file `# pyright: strict` markers
-# as they get cleaned up; tighten the global mode here once the long tail is
-# done.
-typeCheckingMode = "basic"
+# Standard mode is the current floor — the existing tree passes it without
+# changes, and it catches real correctness issues (None subscripting,
+# optional member access, unbound variables). Full strict on the ~7.6k-LOC
+# tree would fire ~800 errors (mostly missing generic args on dict/list in
+# data-shuffling helpers), so strict is opted into per-file via
+# `# pyright: strict` headers — enforced on new files by
+# `scripts/check_pyright_strict_on_new_files.py`. Tighten the global mode
+# here once the long tail of legacy helpers is annotated.
+typeCheckingMode = "standard"
 # PEP 723 inline-deps (`# /// script` headers) are not installed into a
 # shared venv, so pyright cannot resolve `import browserbase`, `import httpx`,
 # etc. Silencing the import categories preserves real type-checking on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,20 @@ exclude_dirs = [".venv", "output", "benchmark", "node_modules"]
 # (e.g. `sips`, `git`). These scripts are dev tooling, not user-facing
 # services; the argv lists are static and `shell=True` is never used.
 skips = ["B404", "B603", "B607"]
+
+[tool.pyright]
+include = ["scripts"]
+exclude = [".venv", "output", "benchmark", "node_modules", "extension", "demo-site", "docs"]
+pythonVersion = "3.12"
+# Basic mode is the starting ratchet — strict typing on the entire ~7.6k-LOC
+# scripts tree at once would be a multi-week migration. Promote individual
+# files (or directories) to `strict` via per-file `# pyright: strict` markers
+# as they get cleaned up; tighten the global mode here once the long tail is
+# done.
+typeCheckingMode = "basic"
+# PEP 723 inline-deps (`# /// script` headers) are not installed into a
+# shared venv, so pyright cannot resolve `import browserbase`, `import httpx`,
+# etc. Silencing the import categories preserves real type-checking on
+# our own code without trying to materialize 20+ ephemeral environments.
+reportMissingImports = "none"
+reportMissingModuleSource = "none"

--- a/scripts/benchmark_report.py
+++ b/scripts/benchmark_report.py
@@ -1774,7 +1774,11 @@ def render_html(run_id: str, manifest: dict[str, Any], rows: list[dict[str, Any]
         (s, t): [] for s in scenario_ids for t in task_ids
     }
     for r in rows:
-        key = (r.get("scenario_id"), r.get("task_id"))
+        scenario_id = r.get("scenario_id")
+        task_id = r.get("task_id")
+        if not isinstance(scenario_id, str) or not isinstance(task_id, str):
+            continue
+        key = (scenario_id, task_id)
         if key in cell_rows:
             cell_rows[key].append(r)
     summary_by_key: dict[tuple[str, str], dict[str, Any]] = {

--- a/scripts/check_pyright_strict_on_new_files.py
+++ b/scripts/check_pyright_strict_on_new_files.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env -S uv run --script
+# Copyright (c) 2026 PixieBrix, Inc.
+# Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+# pyright: strict
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Enforce the per-file pyright-strict ratchet on newly-added scripts.
+
+The global pyright mode in `pyproject.toml` is `standard` because flipping
+the whole ~7.6k-LOC `scripts/` tree to strict would fire hundreds of
+"missing generic argument" errors in legacy data-shuffling helpers. To stop
+the legacy debt from growing, every file ADDED in a PR must opt in to
+strict mode with a `# pyright: strict` header comment. Existing files stay
+on standard until they're cleaned up and promoted explicitly.
+
+Usage:
+  uv run scripts/check_pyright_strict_on_new_files.py [base-ref]
+
+`base-ref` defaults to `origin/main`. In CI we pass `origin/${{ github.base_ref }}`.
+Local pre-commit runs operate on staged files only and skip this script
+(the diff against a base ref isn't meaningful for a single commit).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+STRICT_MARKER = "# pyright: strict"
+SCAN_LINE_BUDGET = 20
+
+
+def added_python_files(base_ref: str) -> list[Path]:
+    """Return paths of Python files added (not modified) since base_ref."""
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=A",
+            f"{base_ref}...HEAD",
+            "--",
+            "scripts/*.py",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [Path(line) for line in result.stdout.splitlines() if line]
+
+
+def has_strict_marker(path: Path) -> bool:
+    """True if `# pyright: strict` appears in the file's header comment block.
+
+    Pyright only honors the directive if it precedes the first non-comment
+    line, so we cap the scan at SCAN_LINE_BUDGET lines — enough room for a
+    shebang, license header, and PEP 723 dep block.
+    """
+    try:
+        with path.open() as f:
+            for _ in range(SCAN_LINE_BUDGET):
+                line = f.readline()
+                if not line:
+                    break
+                if line.strip() == STRICT_MARKER:
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def main() -> int:
+    base_ref = sys.argv[1] if len(sys.argv) > 1 else "origin/main"
+    new_files = added_python_files(base_ref)
+    if not new_files:
+        return 0
+
+    missing = [path for path in new_files if not has_strict_marker(path)]
+    if not missing:
+        print(f"OK — all {len(new_files)} new Python file(s) declare `{STRICT_MARKER}`")
+        return 0
+
+    for path in missing:
+        # GitHub Actions annotation — surfaces inline in PR review.
+        print(
+            f"::error file={path}::New Python file must declare "
+            f"`{STRICT_MARKER}` in its top comment block "
+            f"(legacy files stay on `standard` mode; new files ratchet to strict).",
+            file=sys.stderr,
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- The ~7,600-LOC `scripts/` tree had `ruff` + `bandit` but no static type checker, despite being heavily type-annotated in practice. Adds Pyright (basic mode) as a CI gate and pre-commit hook so type regressions in the benchmark harness and orchestration helpers are caught at PR time rather than at the next benchmark run.
- Config lives in `pyproject.toml [tool.pyright]`. `typeCheckingMode = "basic"` so the existing tree passes today; per-file ratchet via `# pyright: strict` markers as helpers get cleaned up.
- `reportMissingImports = "none"` / `reportMissingModuleSource = "none"` because PEP 723 inline-deps (`# /// script` headers) aren't installed into a shared venv — pyright can't see `browserbase`, `httpx`, `dotenv`, etc., but still type-checks cross-file inference within `scripts/`.
- CI: a new `Pyright type check` step in the existing `python` job (renamed `Python (ruff + bandit + pyright)`).
- Pre-commit: a local hook using the PyPI `pyright==1.1.410` wrapper so it works in any environment without needing `uvx` on PATH.

Surfaced one real soundness bug in `scripts/benchmark_report.py:render_html` — a row with a missing `scenario_id` / `task_id` would build a `(None, None)` cell key that silently failed the `key in cell_rows` check. Explicit `isinstance` narrowing preserves the drop-rows-with-missing-ids semantics.

Closes out the "Add a Python type-checker scoped to `scripts/`" item from the agent-readiness audit.

## Test plan

- [x] `uvx pyright` from repo root returns `0 errors, 0 warnings, 0 informations`
- [x] `pre-commit run pyright` succeeds against changed files
- [x] Full `pre-commit run --files .github/workflows/ci.yml .pre-commit-config.yaml pyproject.toml scripts/benchmark_report.py` passes all hooks
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)