### PR TITLE
Add pytest suite for scripts/ helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   python:
-    name: Python (ruff + bandit + pyright)
+    name: Python (ruff + bandit + pyright + pytest)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -187,6 +187,12 @@ jobs:
       # into a shared venv). Ratchet up via per-file `# pyright: strict`.
       - name: Pyright type check
         run: uvx pyright
+      # Pytest covers the pure helpers shared across the benchmark loop
+      # (`_judge`, `_blockcheck`, `_stagehand`, `compare_scenarios`). The
+      # `--with` packages match what's imported at module load time of any
+      # helper a test pulls in (`python-dotenv` for compare_scenarios).
+      - name: Pytest (scripts/ helpers)
+        run: uvx --with pytest --with python-dotenv pytest
       # New-file ratchet: every newly-added Python file must opt in to
       # `# pyright: strict`. Stops legacy debt in scripts/ from growing
       # while we leave the global mode at standard. base_ref is passed via

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,6 +125,19 @@ repos:
         files: ^scripts/.*\.py$|^pyproject\.toml$
         pass_filenames: false
 
+  # Pytest runs the full suite (config in pyproject.toml `[tool.pytest.ini_options]`)
+  # so cross-file imports and conftest sys.path injection resolve consistently.
+  # The python-dotenv dep matches `compare_scenarios`'s module-level import.
+  - repo: local
+    hooks:
+      - id: pytest
+        name: Pytest (scripts/ helpers)
+        language: python
+        entry: pytest
+        additional_dependencies: ["pytest>=8", "python-dotenv>=1"]
+        files: ^scripts/.*\.py$|^pyproject\.toml$
+        pass_filenames: false
+
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.8
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,20 @@ ignore = [
 quote-style = "double"
 indent-style = "space"
 
+[tool.pytest.ini_options]
+testpaths = ["scripts/tests"]
+# `scripts/` lives outside any package and tests reach into it via
+# `from _judge import …` thanks to conftest.py's sys.path injection. Tell
+# pytest to prepend testpaths to sys.path so the conftest itself is found
+# before any rootdir-walking.
+addopts = "-ra"
+pythonpath = ["scripts"]
+
 [tool.bandit]
-exclude_dirs = [".venv", "output", "benchmark", "node_modules"]
+# `scripts/tests` is excluded because pytest's assertion mechanism is
+# `assert`, which trips B101 across every test line. The test files have
+# no production threat surface.
+exclude_dirs = [".venv", "output", "benchmark", "node_modules", "scripts/tests"]
 # B404/B603/B607: subprocess import + fixed-argv calls + partial paths
 # (e.g. `sips`, `git`). These scripts are dev tooling, not user-facing
 # services; the argv lists are static and `shell=True` is never used.

--- a/scripts/_judge.py
+++ b/scripts/_judge.py
@@ -86,12 +86,15 @@ class ExtractedAnswer:
 
 
 def build_judge_user_prompt(task: str, criteria: str, final_answer: str | None) -> str:
-    answer = final_answer.strip() if final_answer else "(no final answer reported)"
+    # Strip first, then test for emptiness — a whitespace-only answer
+    # ("   ") is semantically the same as a missing one and must surface
+    # the explicit placeholder so the judge LLM sees the intent.
+    answer = (final_answer or "").strip() or "(no final answer reported)"
     return f"Task: {task}\n\nSuccess criteria: {criteria}\n\nAgent's final answer:\n{answer}"
 
 
 def build_extractor_user_prompt(task: str, criteria: str, final_answer: str | None) -> str:
-    answer = final_answer.strip() if final_answer else "(no final answer reported)"
+    answer = (final_answer or "").strip() or "(no final answer reported)"
     return f"Task: {task}\n\nSuccess criteria: {criteria}\n\nAgent's final answer:\n{answer}"
 
 

--- a/scripts/tests/__init__.py
+++ b/scripts/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 PixieBrix, Inc.
+# Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+# pyright: strict

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 PixieBrix, Inc.
+# Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+# pyright: strict
+
+"""Pytest configuration for the scripts/ helper tests.
+
+The scripts/ directory is intentionally not a package (it holds PEP 723
+inline-dep entry points, not a library), so we put it on sys.path here so
+tests can `from _judge import …` the same way the scripts import each
+other at runtime.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))

--- a/scripts/tests/test_blockcheck.py
+++ b/scripts/tests/test_blockcheck.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 PixieBrix, Inc.
+# Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+# pyright: strict
+
+"""Tests for `_blockcheck` helpers — the LLM-as-block-detector module that
+decides whether a benchmark run hit an anti-agent defense."""
+
+from __future__ import annotations
+
+from _blockcheck import _truncate_middle  # pyright: ignore[reportPrivateUsage]
+
+
+class TestTruncateMiddle:
+    def test_under_budget_returns_input_unchanged(self) -> None:
+        assert _truncate_middle("short text", max_chars=100) == "short text"
+
+    def test_at_exact_budget_returns_unchanged(self) -> None:
+        text = "x" * 50
+        assert _truncate_middle(text, max_chars=50) == text
+
+    def test_over_budget_keeps_head_and_tail(self) -> None:
+        text = "A" * 1000 + "B" * 1000
+        out = _truncate_middle(text, max_chars=200)
+        # Both the start of the original (the "A" run) and the end (the "B"
+        # run) must survive so block signals at either end aren't dropped.
+        assert out.startswith("A")
+        assert out.endswith("B")
+        assert " […] " in out
+
+    def test_truncated_length_stays_close_to_budget(self) -> None:
+        text = "x" * 10_000
+        out = _truncate_middle(text, max_chars=500)
+        # The function reserves room for the ellipsis marker, so the result
+        # is at most max_chars (well, max_chars-ish; the marker is 5 chars).
+        assert len(out) <= 500
+
+    def test_empty_input(self) -> None:
+        assert _truncate_middle("", max_chars=100) == ""

--- a/scripts/tests/test_compare_scenarios.py
+++ b/scripts/tests/test_compare_scenarios.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026 PixieBrix, Inc.
+# Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+# pyright: strict
+
+"""Tests for `compare_scenarios` pure helpers — the formatters and
+aggregators that render the cost-diff Markdown digest the benchmark loop
+emits. A regression in `mean` or `summarize_scenario` silently corrupts
+every diff report."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from compare_scenarios import (
+    fmt_abs_delta,
+    fmt_float,
+    fmt_int,
+    fmt_money,
+    fmt_pct_delta,
+    fmt_secs,
+    judge_verdict,
+    mean,
+    summarize_scenario,
+    token_field,
+)
+
+
+class TestFmtInt:
+    def test_none_renders_em_dash(self) -> None:
+        assert fmt_int(None) == "—"
+
+    def test_integer_thousands_separator(self) -> None:
+        assert fmt_int(1234567) == "1,234,567"
+
+    def test_float_is_rounded(self) -> None:
+        assert fmt_int(1234.7) == "1,235"
+
+    def test_non_numeric_falls_back_to_str(self) -> None:
+        assert fmt_int("oops") == "oops"
+
+
+class TestFmtMoney:
+    def test_none_renders_em_dash(self) -> None:
+        assert fmt_money(None) == "—"
+
+    def test_four_decimal_precision(self) -> None:
+        # Per-call LLM costs run to sub-cent precision; four decimals is the
+        # convention so $0.0001-level deltas are visible in the diff.
+        assert fmt_money(0.123456) == "$0.1235"
+
+    def test_zero(self) -> None:
+        assert fmt_money(0) == "$0.0000"
+
+
+class TestFmtSecs:
+    def test_none_renders_em_dash(self) -> None:
+        assert fmt_secs(None) == "—"
+
+    def test_one_decimal_precision(self) -> None:
+        assert fmt_secs(12.34) == "12.3s"
+
+
+class TestFmtFloat:
+    def test_default_one_decimal(self) -> None:
+        assert fmt_float(3.14159) == "3.1"
+
+    def test_custom_precision(self) -> None:
+        assert fmt_float(3.14159, places=3) == "3.142"
+
+
+class TestFmtPctDelta:
+    def test_none_or_zero_baseline_renders_em_dash(self) -> None:
+        assert fmt_pct_delta(None, 100) == "—"
+        assert fmt_pct_delta(0, 100) == "—"
+        assert fmt_pct_delta(100, None) == "—"
+
+    def test_positive_delta_signed(self) -> None:
+        assert fmt_pct_delta(100, 150) == "+50%"
+
+    def test_negative_delta_signed(self) -> None:
+        assert fmt_pct_delta(100, 80) == "-20%"
+
+
+class TestFmtAbsDelta:
+    def test_none_renders_em_dash(self) -> None:
+        assert fmt_abs_delta(None, 100) == "—"
+        assert fmt_abs_delta(100, None) == "—"
+
+    def test_int_kind_signed_with_thousands(self) -> None:
+        assert fmt_abs_delta(1000, 1500, kind="int") == "+500"
+        assert fmt_abs_delta(5000, 3000, kind="int") == "-2,000"
+
+    def test_money_kind_four_decimals(self) -> None:
+        assert fmt_abs_delta(0.5, 0.7, kind="money") == "+0.2000"
+
+    def test_secs_kind_one_decimal(self) -> None:
+        assert fmt_abs_delta(10, 12.5, kind="secs") == "+2.5s"
+
+
+class TestMean:
+    def test_empty_list_returns_none(self) -> None:
+        assert mean([]) is None
+
+    def test_all_none_returns_none(self) -> None:
+        # Critical: a column where every row has missing data must not
+        # crash with `statistics.mean([])` — it must yield None so the diff
+        # renders an em-dash instead.
+        assert mean([None, None, None]) is None
+
+    def test_filters_none_before_averaging(self) -> None:
+        # A reasoning-tokens column may have None for non-reasoning models
+        # mixed with real values for reasoning models in the same row set.
+        assert mean([10, None, 20, None, 30]) == 20.0
+
+    def test_mixed_int_and_float(self) -> None:
+        assert mean([1, 2.5, 4]) == 2.5
+
+
+class TestTokenField:
+    def test_returns_none_when_tokens_block_absent(self) -> None:
+        rows: list[dict[str, Any]] = [{"scenario": "a"}, {"scenario": "b"}]
+        assert token_field(rows, "input") == [None, None]
+
+    def test_picks_named_token_field_per_row(self) -> None:
+        rows: list[dict[str, Any]] = [
+            {"tokens": {"input": 100, "output": 50}},
+            {"tokens": {"input": 200, "output": 75}},
+        ]
+        assert token_field(rows, "input") == [100, 200]
+        assert token_field(rows, "output") == [50, 75]
+
+    def test_missing_subfield_returns_none(self) -> None:
+        rows: list[dict[str, Any]] = [
+            {"tokens": {"input": 100}},
+            {"tokens": {"input": 200, "reasoning": 30}},
+        ]
+        assert token_field(rows, "reasoning") == [None, 30]
+
+
+class TestJudgeVerdict:
+    def test_error_row_returns_error(self) -> None:
+        # Error wins over judge state — a run that crashed mid-flight
+        # shouldn't be counted as pass/fail based on a stale judge field.
+        assert judge_verdict({"error": "timeout", "judge": {"pass": True}}) == "error"
+
+    def test_pass_true(self) -> None:
+        assert judge_verdict({"judge": {"pass": True}}) == "pass"
+
+    def test_pass_false(self) -> None:
+        assert judge_verdict({"judge": {"pass": False}}) == "fail"
+
+    def test_missing_judge_block_is_ungraded(self) -> None:
+        assert judge_verdict({}) == "ungraded"
+        assert judge_verdict({"judge": {}}) == "ungraded"
+
+    def test_pass_field_none_is_ungraded(self) -> None:
+        # Judge was attempted but couldn't decide (e.g., model refused) —
+        # distinct from "didn't run" but rendered the same in the diff.
+        assert judge_verdict({"judge": {"pass": None}}) == "ungraded"
+
+
+class TestSummarizeScenario:
+    def test_empty_rows_returns_zeroed_summary(self) -> None:
+        result = summarize_scenario([])
+        assert result["n"] == 0
+        assert result["pass"] == 0
+        assert result["fail"] == 0
+        assert result["input"] is None  # mean of empty → None
+        assert result["cost"] is None
+
+    def test_counts_judge_verdicts(self) -> None:
+        rows: list[dict[str, Any]] = [
+            {"judge": {"pass": True}},
+            {"judge": {"pass": True}},
+            {"judge": {"pass": False}},
+            {"error": "timeout"},
+            {"judge": {}},
+        ]
+        result = summarize_scenario(rows)
+        assert result["n"] == 5
+        assert result["pass"] == 2
+        assert result["fail"] == 1
+        assert result["error"] == 1
+        assert result["ungraded"] == 1
+
+    def test_averages_numeric_fields(self) -> None:
+        rows: list[dict[str, Any]] = [
+            {
+                "tokens": {"input": 100, "output": 50, "total": 150},
+                "cost_usd": 0.001,
+                "steps_taken": 5,
+                "duration_s": 10.0,
+            },
+            {
+                "tokens": {"input": 200, "output": 100, "total": 300},
+                "cost_usd": 0.003,
+                "steps_taken": 7,
+                "duration_s": 14.0,
+            },
+        ]
+        result = summarize_scenario(rows)
+        assert result["input"] == 150.0
+        assert result["output"] == 75.0
+        assert result["total"] == 225.0
+        assert result["cost"] == 0.002
+        assert result["steps"] == 6.0
+        assert result["duration"] == 12.0

--- a/scripts/tests/test_judge.py
+++ b/scripts/tests/test_judge.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 PixieBrix, Inc.
+# Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+# pyright: strict
+
+"""Tests for `_judge` helpers — prompt assembly and model resolution shared
+by benchmark_run.py and benchmark_report.py."""
+
+from __future__ import annotations
+
+from _judge import (
+    DEFAULT_JUDGE_MODEL,
+    build_extractor_user_prompt,
+    build_judge_user_prompt,
+    resolve_judge_model,
+)
+
+
+class TestBuildJudgeUserPrompt:
+    def test_includes_task_criteria_and_answer(self) -> None:
+        prompt = build_judge_user_prompt(
+            task="Find the price",
+            criteria="Returns the dollar amount",
+            final_answer="$42.99",
+        )
+        assert "Find the price" in prompt
+        assert "Returns the dollar amount" in prompt
+        assert "$42.99" in prompt
+
+    def test_missing_answer_renders_placeholder(self) -> None:
+        # `None` and the empty string both mean "agent never produced an
+        # answer" — both must surface as the same human-readable placeholder
+        # so the judge LLM doesn't see literal "None" or "".
+        for missing in (None, "", "   "):
+            prompt = build_judge_user_prompt("t", "c", missing)
+            assert "(no final answer reported)" in prompt
+
+    def test_strips_whitespace_around_answer(self) -> None:
+        prompt = build_judge_user_prompt("t", "c", "  hello  \n")
+        assert "hello" in prompt
+        assert "  hello  " not in prompt
+
+
+class TestBuildExtractorUserPrompt:
+    def test_same_shape_as_judge(self) -> None:
+        # Judge and extractor currently share an identical prompt shape; if
+        # this ever diverges, the assertion forces the divergence to be
+        # explicit rather than accidental.
+        task, criteria, answer = "t", "c", "a"
+        assert build_extractor_user_prompt(task, criteria, answer) == build_judge_user_prompt(
+            task, criteria, answer
+        )
+
+
+class TestResolveJudgeModel:
+    def test_explicit_args_model_wins(self) -> None:
+        assert (
+            resolve_judge_model("anthropic/claude-3-5-sonnet", {"judge_model": "openai/gpt-4o"})
+            == "anthropic/claude-3-5-sonnet"
+        )
+
+    def test_falls_back_to_scenario_default(self) -> None:
+        assert resolve_judge_model(None, {"judge_model": "openai/gpt-4o"}) == "openai/gpt-4o"
+
+    def test_falls_back_to_module_default(self) -> None:
+        assert resolve_judge_model(None, {}) == DEFAULT_JUDGE_MODEL
+
+    def test_empty_args_model_treated_as_unset(self) -> None:
+        # CLI may surface an empty `--judge-model ""` — should NOT short-circuit
+        # the lookup chain to "use the empty string as a model name".
+        assert resolve_judge_model("", {"judge_model": "openai/gpt-4o"}) == "openai/gpt-4o"

--- a/scripts/tests/test_stagehand.py
+++ b/scripts/tests/test_stagehand.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 PixieBrix, Inc.
+# Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+# pyright: strict
+
+"""Tests for `_stagehand.extract_usage` — defensive parser that pulls token
+usage out of Stagehand event payloads across OpenAI, Anthropic, and Gemini
+shapes. Regressions here corrupt the per-row `tokens` field that the cost
+diff and cost ratchets read."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _stagehand import extract_usage
+
+
+class TestExtractUsageBasic:
+    def test_returns_none_for_non_dict_payload(self) -> None:
+        assert extract_usage(None) is None
+        assert extract_usage("not a dict") is None
+        assert extract_usage([]) is None
+
+    def test_returns_none_when_no_usage_block(self) -> None:
+        assert extract_usage({"event_type": "log", "message": "hi"}) is None
+
+    def test_returns_none_when_usage_block_has_no_token_fields(self) -> None:
+        # `usage` present but neither input nor output token counts under it —
+        # should not synthesize a `total: 0` result.
+        assert extract_usage({"usage": {"latency_ms": 123}}) is None
+
+
+class TestExtractUsageVendorShapes:
+    def test_openai_style_snake_case(self) -> None:
+        payload: dict[str, Any] = {
+            "usage": {
+                "prompt_tokens": 1200,
+                "completion_tokens": 300,
+                "prompt_tokens_details": {"cached_tokens": 800},
+                "completion_tokens_details": {"reasoning_tokens": 100},
+            }
+        }
+        result = extract_usage(payload)
+        assert result == {
+            "input": 1200,
+            "output": 300,
+            "total": 1500,
+            "cached": 800,
+            "reasoning": 100,
+        }
+
+    def test_anthropic_style(self) -> None:
+        payload: dict[str, Any] = {
+            "usage": {
+                "input_tokens": 500,
+                "output_tokens": 200,
+                "cache_read_input_tokens": 400,
+                "cache_creation_input_tokens": 50,
+            }
+        }
+        result = extract_usage(payload)
+        assert result == {
+            "input": 500,
+            "output": 200,
+            "total": 700,
+            "cached": 400,
+            "cache_creation": 50,
+        }
+
+    def test_gemini_style_camel_case(self) -> None:
+        payload: dict[str, Any] = {
+            "tokenUsage": {
+                "promptTokenCount": 800,
+                "candidatesTokenCount": 250,
+                "cachedContentTokenCount": 600,
+            }
+        }
+        result = extract_usage(payload)
+        assert result == {
+            "input": 800,
+            "output": 250,
+            "total": 1050,
+            "cached": 600,
+        }
+
+
+class TestExtractUsageDefensive:
+    def test_finds_usage_nested_under_event_envelope(self) -> None:
+        # Stagehand frequently wraps the LLM response in an outer event
+        # envelope; the BFS should find usage anywhere in the tree.
+        payload: dict[str, Any] = {
+            "event_type": "agent.llm_call",
+            "response": {
+                "id": "resp_abc",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        }
+        result = extract_usage(payload)
+        assert result == {"input": 100, "output": 50, "total": 150}
+
+    def test_zero_output_with_nonzero_input(self) -> None:
+        # An aborted / refused call may report input tokens with no output.
+        # We still want a record so it shows up in totals — not silently
+        # dropped as "no usage info".
+        result = extract_usage({"usage": {"input_tokens": 42, "output_tokens": 0}})
+        assert result == {"input": 42, "output": 0, "total": 42}
+
+    def test_omits_optional_fields_when_absent(self) -> None:
+        # If the provider didn't report cached/reasoning tokens at all, the
+        # result must NOT carry `cached: 0` — downstream code uses presence
+        # to decide whether to show the column.
+        result = extract_usage({"usage": {"input_tokens": 10, "output_tokens": 5}})
+        assert result == {"input": 10, "output": 5, "total": 15}
+        assert result is not None
+        assert "cached" not in result
+        assert "reasoning" not in result


### PR DESCRIPTION
## Summary

The benchmark loop's foundation lives in `_judge`, `_blockcheck`, `_stagehand`, and `compare_scenarios` — pure helpers shared across `benchmark_run.py`, `benchmark_report.py`, and `agent_task.py`. A regression in any of them silently corrupts every benchmark run, and each run costs minutes of wall-time on Browserbase. Adds **55 tests** covering:

- `_blockcheck._truncate_middle` — middle-truncation invariants for the detector trajectory budget.
- `_judge.build_judge_user_prompt` / `build_extractor_user_prompt` / `resolve_judge_model` — prompt assembly and the model-resolution chain (`args → scenario defaults → DEFAULT_JUDGE_MODEL`).
- `_stagehand.extract_usage` — OpenAI/Anthropic/Gemini token-usage shapes, defensive nested-payload walking, cached/reasoning field presence semantics.
- `compare_scenarios` formatters and aggregators — `fmt_int/money/secs/float/pct_delta/abs_delta`, `mean`, `token_field`, `judge_verdict`, `summarize_scenario`.

Surfaced one real defect on the way through: `build_judge_user_prompt(\"t\", \"c\", \"   \")` was inserting an empty string into the judge prompt rather than the documented `(no final answer reported)` placeholder. Fixed inline — `(final_answer or \"\").strip() or \"(no final answer reported)\"`.

Config wiring:
- `[tool.pytest.ini_options]` in `pyproject.toml` — `testpaths` + `pythonpath = [\"scripts\"]` so tests `from _judge import …` the same way scripts do at runtime via `sys.path.insert`. `conftest.py` mirrors the path injection defensively.
- Bandit excludes `scripts/tests` — pytest uses `assert` as its assertion mechanism, which trips B101 on every test line.
- CI: new `Pytest (scripts/ helpers)` step in the python job (renamed `Python (ruff + bandit + pyright + pytest)`) via `uvx --with pytest --with python-dotenv pytest`.
- Pre-commit: matching local hook with the same dep set.

All 6 new files declare `# pyright: strict` per the ratchet from #93.

Closes the second H/M item from the agent-readiness audit (test the Python helpers).

## Test plan

- [x] `uvx --with pytest --with python-dotenv pytest` — 55 passed in 0.04s
- [x] `uvx pyright` — 0 errors, 0 warnings, 0 informations
- [x] `pre-commit run` against all changed files — every hook green (Bandit, Ruff, Pyright, Pytest, actionlint)
- [x] `scripts/check_pyright_strict_on_new_files.py origin/main` reports all 6 new files compliant
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)