### PR TITLE
Centralize data-abs-* DOM markers in lib/dom-markers.ts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,16 @@ the pattern used in `pii-mask`, `secrets-mask`, `scarcity-hide`,
 initial load — e.g., a one-shot landmark injection — and call that out in a
 comment.
 
+## DOM marker attributes
+
+Every `data-abs-*` attribute the engine or any rule writes onto the page is
+declared and exported from `extension/src/lib/dom-markers.ts` — the single
+canonical registry. Engine-level markers are named `<PURPOSE>_ATTR`; per-rule
+markers are `<RULE>_<PURPOSE>_ATTR`. Import the constant; do not inline the
+literal. An ESLint `no-restricted-syntax` rule (`eslint.config.js`) blocks raw
+`"data-abs-…"` string and template literals everywhere except the registry
+itself, so name collisions and convention drift surface at lint time.
+
 ## Rule defaults
 
 The initial enabled/disabled state for each rule lives in

--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -313,4 +313,27 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    // `data-abs-*` attributes are the extension's DOM marker namespace —
+    // every one the engine or any rule stamps on a node has to be declared
+    // and exported from `src/lib/dom-markers.ts` so collisions surface at
+    // compile time and new rules have one canonical naming reference.
+    // Allowed only in the registry file itself.
+    ignores: ["src/lib/dom-markers.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "Literal[value=/^data-abs-/]",
+          message:
+            "data-abs-* attribute names must be declared in src/lib/dom-markers.ts and imported — no inline string literals.",
+        },
+        {
+          selector: "TemplateElement[value.raw=/^data-abs-/]",
+          message:
+            "data-abs-* attribute names must be declared in src/lib/dom-markers.ts and imported — no inline template literals.",
+        },
+      ],
+    },
+  },
 );

--- a/extension/src/lib/dom-markers.ts
+++ b/extension/src/lib/dom-markers.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Single source of truth for every `data-abs-*` DOM attribute the extension
+// writes onto pages. Every marker the engine or any rule stamps on a node
+// must be declared here and imported — the ESLint rule
+// `no-restricted-syntax/data-abs-literal` (scoped in `eslint.config.js`)
+// blocks raw `"data-abs-…"` string literals outside this file so new rules
+// can't accidentally collide on a name or drift from the convention.
+//
+// Naming: engine-level markers are `<PURPOSE>_ATTR`; per-rule markers are
+// `<RULE>_<PURPOSE>_ATTR`. Keep the literal prefix `data-abs-` consistent.
+
+// Engine-level — set by the placeholder/runtime machinery, read by rules.
+
+// Names the rule responsible for a placeholder element. Set on every
+// placeholder the engine emits; rules read it via `attachReveal` to thread
+// the original target back through user reveal clicks.
+export const RULE_ATTR = "data-abs-rule";
+
+// Stamped onto the original element after the user clicks to reveal a
+// placeholder, so a rule's subtree watcher doesn't immediately re-hide it
+// on the next scan.
+export const REVEALED_ATTR = "data-abs-revealed";
+
+// Stamped onto elements hidden in-place via display:none (removeEntirely
+// rules). We don't detach the node because doing so breaks React's fiber
+// when it tries to reconcile siblings — the original stays in the DOM,
+// just non-rendering. The attribute lets the rule skip re-processing it.
+export const HIDDEN_ATTR = "data-abs-hidden";
+
+// Set by the engine on placeholder containers to record which display mode
+// (`inline` / `block`) they were emitted in, so post-render adjustments can
+// re-render against the right shape.
+export const PLACEHOLDER_MODE_ATTR = "data-abs-placeholder-mode";
+
+// Per-rule — set by exactly one rule's `apply` and read by its watcher /
+// teardown. Add new entries here when a new rule needs an attribute marker.
+
+// `checkout-checkbox-clear`: marks checkboxes the rule has unchecked so the
+// next scan doesn't re-process them.
+export const CHECKOUT_CHECKBOX_CLEARED_ATTR = "data-abs-cleared";
+
+// `cart-addon-flag`: marks the wrapper of a sneaky add-on item the rule has
+// already badged, so the watcher doesn't double-badge on re-scan.
+export const CART_ADDON_FLAGGED_ATTR = "data-abs-cart-addon-flagged";
+
+// `confirmshame-neutralize`: stores the original copy of attributes the
+// rule rewrites so reveal-on-click can restore the user-visible
+// confirmshame language.
+export const CONFIRMSHAME_ORIGINAL_TEXT_ATTR =
+  "data-abs-confirmshame-orig-text";
+export const CONFIRMSHAME_ORIGINAL_VALUE_ATTR =
+  "data-abs-confirmshame-orig-value";
+export const CONFIRMSHAME_ORIGINAL_ARIA_ATTR =
+  "data-abs-confirmshame-orig-aria";
+export const CONFIRMSHAME_ORIGINAL_TITLE_ATTR =
+  "data-abs-confirmshame-orig-title";

--- a/extension/src/lib/placeholder-count.ts
+++ b/extension/src/lib/placeholder-count.ts
@@ -11,7 +11,8 @@
 // placeholder construction/destruction site individually.
 
 import throttle from "lodash/throttle";
-import { HIDDEN_ATTR, PLACEHOLDER_CLASS } from "./placeholder";
+import { HIDDEN_ATTR } from "./dom-markers";
+import { PLACEHOLDER_CLASS } from "./placeholder";
 
 const COUNT_SELECTOR = `.${PLACEHOLDER_CLASS}, [${HIDDEN_ATTR}]`;
 const REPORT_THROTTLE_MS = 250;

--- a/extension/src/lib/placeholder.ts
+++ b/extension/src/lib/placeholder.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
+import { REVEALED_ATTR, RULE_ATTR } from "./dom-markers";
 import { log } from "./log";
 import type { RuleId } from "./storage";
 
@@ -8,15 +9,6 @@ export const PLACEHOLDER_CLASS = "abs-placeholder";
 export const LABEL_CLASS = "abs-placeholder__label";
 export const LABEL_TEXT_CLASS = "abs-placeholder__text";
 export const LABEL_ICON_CLASS = "abs-placeholder__icon";
-export const RULE_ATTR = "data-abs-rule";
-// Stamped onto the original element after the user clicks to reveal, so a
-// rule's subtree watcher doesn't immediately re-hide it on the next scan.
-export const REVEALED_ATTR = "data-abs-revealed";
-// Stamped onto elements hidden in-place via display:none (removeEntirely
-// rules). We don't detach the node because doing so breaks React's fiber when
-// it tries to reconcile siblings — the original is left in the DOM, just
-// non-rendering. The attribute lets the rule skip re-processing it.
-export const HIDDEN_ATTR = "data-abs-hidden";
 
 export interface InlineMatch {
   start: number;

--- a/extension/src/lib/rule-engine.ts
+++ b/extension/src/lib/rule-engine.ts
@@ -8,6 +8,7 @@ import {
   getRuleAvailabilityStates,
   subscribeRuleAvailability,
 } from "./availability";
+import { PLACEHOLDER_MODE_ATTR } from "./dom-markers";
 import {
   getEnforcementEnabled,
   subscribeEnforcementEnabled,
@@ -29,8 +30,6 @@ import {
 } from "./placeholder-display";
 import type { RuleStates } from "./storage";
 import { getRuleStates, subscribe } from "./storage";
-
-const PLACEHOLDER_MODE_ATTR = "data-abs-placeholder-mode";
 
 // Inline placeholders and the inner .${LABEL_CLASS} of block placeholders are
 // <button> elements so screen readers and browser-use agents see them as

--- a/extension/src/lib/selector-hide-rule.ts
+++ b/extension/src/lib/selector-hide-rule.ts
@@ -15,12 +15,8 @@
 
 import type { URLPattern } from "urlpattern-polyfill";
 import type { Rule } from "../rules/types";
-import {
-  HIDDEN_ATTR,
-  PLACEHOLDER_CLASS,
-  REVEALED_ATTR,
-  replaceWithBlockPlaceholder,
-} from "./placeholder";
+import { HIDDEN_ATTR, REVEALED_ATTR } from "./dom-markers";
+import { PLACEHOLDER_CLASS, replaceWithBlockPlaceholder } from "./placeholder";
 import type { RuleId } from "./storage";
 import { createSubtreeWatcher } from "./subtree-watcher";
 

--- a/extension/src/rules/__tests__/ads-hide.test.ts
+++ b/extension/src/rules/__tests__/ads-hide.test.ts
@@ -1,4 +1,5 @@
-import { HIDDEN_ATTR, PLACEHOLDER_CLASS } from "../../lib/placeholder";
+import { HIDDEN_ATTR } from "../../lib/dom-markers";
+import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { adsHideRule } from "../ads-hide";
 
 const RULE_ID = "ads-hide";

--- a/extension/src/rules/__tests__/cart-addon-flag.test.ts
+++ b/extension/src/rules/__tests__/cart-addon-flag.test.ts
@@ -2,10 +2,10 @@
  * @jest-environment jsdom
  * @jest-environment-options {"url": "https://shop.example.com/cart"}
  */
+import { CART_ADDON_FLAGGED_ATTR as FLAGGED_ATTR } from "../../lib/dom-markers";
 import { cartAddonFlagRule, matchAddon } from "../cart-addon-flag";
 
 const MUTATION_THROTTLE_MS = 250;
-const FLAGGED_ATTR = "data-abs-cart-addon-flagged";
 const FLAG_CLASS = "abs-cart-addon-flag";
 
 async function flushMutations(): Promise<void> {

--- a/extension/src/rules/__tests__/chat-widget-hide.test.ts
+++ b/extension/src/rules/__tests__/chat-widget-hide.test.ts
@@ -1,4 +1,5 @@
-import { HIDDEN_ATTR, PLACEHOLDER_CLASS } from "../../lib/placeholder";
+import { HIDDEN_ATTR } from "../../lib/dom-markers";
+import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { chatWidgetHideRule } from "../chat-widget-hide";
 
 const RULE_ID = "chat-widget-hide";

--- a/extension/src/rules/__tests__/checkout-checkbox-clear.test.ts
+++ b/extension/src/rules/__tests__/checkout-checkbox-clear.test.ts
@@ -3,10 +3,10 @@
  * @jest-environment-options {"url": "https://shop.example.com/checkout"}
  */
 import { isCheckoutUrl } from "../../lib/checkout-url";
+import { CHECKOUT_CHECKBOX_CLEARED_ATTR as CLEARED_ATTR } from "../../lib/dom-markers";
 import { checkoutCheckboxClearRule } from "../checkout-checkbox-clear";
 
 const MUTATION_THROTTLE_MS = 250;
-const CLEARED_ATTR = "data-abs-cleared";
 
 async function flushMutations(): Promise<void> {
   await Promise.resolve();

--- a/extension/src/rules/__tests__/cookie-banner-hide.test.ts
+++ b/extension/src/rules/__tests__/cookie-banner-hide.test.ts
@@ -1,4 +1,5 @@
-import { HIDDEN_ATTR, PLACEHOLDER_CLASS } from "../../lib/placeholder";
+import { HIDDEN_ATTR } from "../../lib/dom-markers";
+import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { cookieBannerHideRule } from "../cookie-banner-hide";
 
 const RULE_ID = "cookie-banner-hide";

--- a/extension/src/rules/__tests__/countdown-timer-hide.test.ts
+++ b/extension/src/rules/__tests__/countdown-timer-hide.test.ts
@@ -1,4 +1,5 @@
-import { PLACEHOLDER_CLASS, RULE_ATTR } from "../../lib/placeholder";
+import { RULE_ATTR } from "../../lib/dom-markers";
+import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import {
   countdownTimerHideRule,
   matchesTimerPattern,

--- a/extension/src/rules/__tests__/footer-hide.test.ts
+++ b/extension/src/rules/__tests__/footer-hide.test.ts
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  * @jest-environment-options {"url": "https://www.amazon.com/dp/B0CN6JSMCW"}
  */
-import { PLACEHOLDER_CLASS, RULE_ATTR } from "../../lib/placeholder";
+import { RULE_ATTR } from "../../lib/dom-markers";
+import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { footerHideRule, selectorsFor } from "../footer-hide";
 
 const MUTATION_THROTTLE_MS = 250;

--- a/extension/src/rules/__tests__/newsletter-modal-hide.test.ts
+++ b/extension/src/rules/__tests__/newsletter-modal-hide.test.ts
@@ -1,4 +1,5 @@
-import { HIDDEN_ATTR, PLACEHOLDER_CLASS } from "../../lib/placeholder";
+import { HIDDEN_ATTR } from "../../lib/dom-markers";
+import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { newsletterModalHideRule } from "../newsletter-modal-hide";
 
 const RULE_ID = "newsletter-modal-hide";

--- a/extension/src/rules/__tests__/reviews-hide.test.ts
+++ b/extension/src/rules/__tests__/reviews-hide.test.ts
@@ -1,4 +1,5 @@
-import { PLACEHOLDER_CLASS, RULE_ATTR } from "../../lib/placeholder";
+import { RULE_ATTR } from "../../lib/dom-markers";
+import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { reviewsHideRule, selectorsFor } from "../reviews-hide";
 
 beforeEach(() => {

--- a/extension/src/rules/__tests__/scarcity-hide.test.ts
+++ b/extension/src/rules/__tests__/scarcity-hide.test.ts
@@ -1,4 +1,5 @@
-import { PLACEHOLDER_CLASS, RULE_ATTR } from "../../lib/placeholder";
+import { RULE_ATTR } from "../../lib/dom-markers";
+import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { matchesScarcityPattern, scarcityHideRule } from "../scarcity-hide";
 
 const MUTATION_THROTTLE_MS = 250;

--- a/extension/src/rules/__tests__/social-embed-hide.test.ts
+++ b/extension/src/rules/__tests__/social-embed-hide.test.ts
@@ -1,4 +1,5 @@
-import { PLACEHOLDER_CLASS, RULE_ATTR } from "../../lib/placeholder";
+import { RULE_ATTR } from "../../lib/dom-markers";
+import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { socialEmbedHideRule } from "../social-embed-hide";
 
 beforeEach(() => {

--- a/extension/src/rules/cart-addon-flag.ts
+++ b/extension/src/rules/cart-addon-flag.ts
@@ -27,18 +27,17 @@
 // URLs and capping element text length keep the false-positive rate low.
 
 import { isCheckoutUrl } from "../lib/checkout-url";
+import {
+  CART_ADDON_FLAGGED_ATTR as FLAGGED_ATTR,
+  RULE_ATTR,
+} from "../lib/dom-markers";
 import { findInnermostMatches } from "../lib/dom-utils";
 import { log } from "../lib/log";
-import { RULE_ATTR } from "../lib/placeholder";
 import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import type { Rule } from "./types";
 
 const RULE_ID = "cart-addon-flag" as const;
 
-// Marks elements we've already annotated so subsequent scans skip them
-// and the chip we prepended isn't itself counted as a fresh match on a
-// containing element.
-const FLAGGED_ATTR = "data-abs-cart-addon-flagged";
 const FLAG_CLASS = "abs-cart-addon-flag";
 
 // Cart line-item labels rarely exceed ~150 chars; capping prevents matching

--- a/extension/src/rules/checkout-checkbox-clear.ts
+++ b/extension/src/rules/checkout-checkbox-clear.ts
@@ -13,15 +13,12 @@
 // agent/user must stick, or we'd be in a fight loop.
 
 import { isCheckoutUrl } from "../lib/checkout-url";
+import { CHECKOUT_CHECKBOX_CLEARED_ATTR as CLEARED_ATTR } from "../lib/dom-markers";
 import { log } from "../lib/log";
 import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import type { Rule } from "./types";
 
 const RULE_ID = "checkout-checkbox-clear" as const;
-
-// Marks checkboxes we've already cleared so re-scans skip them and a
-// subsequent re-check by the agent/user is not undone.
-const CLEARED_ATTR = "data-abs-cleared";
 
 // React/Vue track checked state internally; setting `.checked` directly skips
 // their value-tracker, so onChange handlers never fire and totals don't

--- a/extension/src/rules/confirmshame-neutralize.ts
+++ b/extension/src/rules/confirmshame-neutralize.ts
@@ -31,18 +31,17 @@
 // characterData on the rewritten subtree (or watch for the stash data-attr
 // being clobbered) and re-neutralize.
 
+import {
+  CONFIRMSHAME_ORIGINAL_ARIA_ATTR as ORIGINAL_ARIA_ATTR,
+  CONFIRMSHAME_ORIGINAL_TEXT_ATTR as ORIGINAL_TEXT_ATTR,
+  CONFIRMSHAME_ORIGINAL_TITLE_ATTR as ORIGINAL_TITLE_ATTR,
+  CONFIRMSHAME_ORIGINAL_VALUE_ATTR as ORIGINAL_VALUE_ATTR,
+} from "../lib/dom-markers";
 import { log } from "../lib/log";
 import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import type { Rule } from "./types";
 
 const RULE_ID = "confirmshame-neutralize" as const;
-
-// Stamped on rewritten controls so re-scans skip them and teardown can find
-// and restore them. Each attribute stashes the corresponding original value.
-const ORIGINAL_TEXT_ATTR = "data-abs-confirmshame-orig-text";
-const ORIGINAL_VALUE_ATTR = "data-abs-confirmshame-orig-value";
-const ORIGINAL_ARIA_ATTR = "data-abs-confirmshame-orig-aria";
-const ORIGINAL_TITLE_ATTR = "data-abs-confirmshame-orig-title";
 
 // Decline label that replaces confirmshame copy. "No thanks" reads as a
 // plain refusal in every context this rule fires in (modals, signup forms,

--- a/extension/src/rules/cross-origin-frame-hide.ts
+++ b/extension/src/rules/cross-origin-frame-hide.ts
@@ -19,7 +19,8 @@
 // cross-origin iframe children. Nested cross-origin frames inside a
 // same-origin iframe are caught by the same-origin frame's own instance.
 
-import { REVEALED_ATTR, replaceWithBlockPlaceholder } from "../lib/placeholder";
+import { REVEALED_ATTR } from "../lib/dom-markers";
+import { replaceWithBlockPlaceholder } from "../lib/placeholder";
 import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import type { Rule } from "./types";
 

--- a/extension/src/rules/roach-motel-flag.ts
+++ b/extension/src/rules/roach-motel-flag.ts
@@ -27,8 +27,8 @@
 // sr-only class allowlist plus the 1×1 + overflow:hidden inline envelope.
 
 import { URLPattern } from "urlpattern-polyfill";
+import { RULE_ATTR } from "../lib/dom-markers";
 import { log } from "../lib/log";
-import { RULE_ATTR } from "../lib/placeholder";
 import { SR_ONLY_INLINE_STYLE } from "../lib/sr-only";
 import type { JustDeleteMeEntry } from "./justdeleteme.generated";
 import { JUSTDELETEME_ENTRIES } from "./justdeleteme.generated";

--- a/extension/src/rules/scarcity-hide.ts
+++ b/extension/src/rules/scarcity-hide.ts
@@ -16,8 +16,9 @@
 // frequently lazy-load. Unlike countdown-timer-hide, we don't need a
 // snapshot/decrement check — the pattern itself is the signal.
 
+import { REVEALED_ATTR } from "../lib/dom-markers";
 import { findInnermostMatches, isInsidePlaceholder } from "../lib/dom-utils";
-import { REVEALED_ATTR, replaceWithBlockPlaceholder } from "../lib/placeholder";
+import { replaceWithBlockPlaceholder } from "../lib/placeholder";
 import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import type { Rule } from "./types";
 

--- a/extension/src/rules/search-url-helper.ts
+++ b/extension/src/rules/search-url-helper.ts
@@ -15,8 +15,8 @@
 // extension/data/sites/*.yaml and are compiled into site-data.generated.ts
 // by `bun run build-site-data`.
 
+import { RULE_ATTR } from "../lib/dom-markers";
 import { log } from "../lib/log";
-import { RULE_ATTR } from "../lib/placeholder";
 import { SR_ONLY_INLINE_STYLE } from "../lib/sr-only";
 import { SEARCH_URL_HELPER_RECIPES } from "./site-data.generated";
 import type { Rule } from "./types";


### PR DESCRIPTION
## Summary

The extension stamps 10 distinct `data-abs-*` attributes onto pages from 6 different files — until now each declared its own local `const`. No collision today (verified), but the pattern doesn't scale, and with 23 rules already registered there's no canonical naming reference for the 24th.

Introduces `extension/src/lib/dom-markers.ts` as the single source of truth:

- Engine-level markers (`RULE_ATTR`, `REVEALED_ATTR`, `HIDDEN_ATTR`, `PLACEHOLDER_MODE_ATTR`).
- Per-rule markers (`CART_ADDON_FLAGGED_ATTR`, `CHECKOUT_CHECKBOX_CLEARED_ATTR`, four `CONFIRMSHAME_ORIGINAL_*_ATTR`s).
- Documented naming convention: `<PURPOSE>_ATTR` for engine, `<RULE>_<PURPOSE>_ATTR` for per-rule.

Adds an ESLint `no-restricted-syntax` rule blocking raw `data-abs-…` string and template literals everywhere except the registry itself, so future collisions or convention drift fail lint instead of slipping through review. Verified the rule fires on both literal forms.

All existing importers updated to point at the registry — 6 rule files, 4 lib files, 9 test files. Re-exports through `placeholder.ts` were considered and rejected: the indirection would dilute the "one canonical location" goal a new agent needs.

`AGENTS.md` gets a `## DOM marker attributes` section explaining the registry and the lint enforcement.

Closes out the third item from the agent-readiness audit (DOM marker registry).

## Test plan

- [x] `bun run preflight` green — 33 suites / 752 tests pass, biome + eslint clean, knip clean, coverage at the existing ratchet
- [x] Verified the new lint rule fires on inline `"data-abs-foo"` and ``\`data-abs-${id}\``` outside `dom-markers.ts`
- [x] `pre-commit run` on all changed files passes every hook (mdformat reformatted AGENTS.md once, then clean)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)