### PR TITLE
Promote _blockcheck.py to pyright strict

### DIFF
--- a/scripts/_blockcheck.py
+++ b/scripts/_blockcheck.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026 PixieBrix, Inc.
 # Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
+# pyright: strict
+
 """LLM-as-detector helper that decides whether a benchmark run was blocked
 by an anti-agent / anti-scraping defense (Cloudflare, hCaptcha,
 "Press & Hold", "Access Denied" / 403, 429 rate-limit, login walls, etc.).
@@ -13,6 +15,12 @@ Shape mirrors `_judge.py` so it composes the same way at call sites:
 The detector reads the *trajectory* (URLs visited + ariaTree text +
 reasoning) from the per-row events JSONL, since block signals live there
 rather than in the agent's final answer.
+
+`build_traces.parse_events_file` and `correlate_steps` return loose
+`dict[str, Any]` shapes today (a TypedDict refactor would touch ~1k lines
+of build_traces.py — deferred). `summarize_trajectory` narrows each
+accessed value with `cast()` at the boundary so strict mode sees concrete
+types, mirroring the pattern established in `_stagehand.extract_usage`.
 """
 
 from __future__ import annotations
@@ -21,7 +29,7 @@ import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import build_traces
@@ -104,24 +112,35 @@ def summarize_trajectory(event_path: Path, *, max_chars: int = 6000) -> str:
     fine.
     """
     parsed = build_traces.parse_events_file(event_path)
-    steps = build_traces.correlate_steps(parsed.get("actions") or [], parsed.get("messages") or [])
+    actions = cast("list[dict[str, Any]]", parsed.get("actions") or [])
+    messages = cast("list[dict[str, Any]]", parsed.get("messages") or [])
+    steps = build_traces.correlate_steps(actions, messages)
     if not steps:
         return "(no trajectory events captured)"
 
+    def step_tr_kind(step: dict[str, Any]) -> str:
+        tr_any: Any = step.get("tool_result") or {}
+        if not isinstance(tr_any, dict):
+            return ""
+        return str(cast("dict[str, Any]", tr_any).get("kind") or "")
+
     # Budget per step's ariaTree slice. Leave headroom for headers,
     # reasoning, and metadata so the final string stays near max_chars.
-    n_aria = sum(1 for s in steps if (s.get("tool_result") or {}).get("kind") == "aria_tree")
+    n_aria = sum(1 for s in steps if step_tr_kind(s) == "aria_tree")
     aria_budget = (max_chars - 600) // max(n_aria, 1)
     aria_budget = max(400, min(aria_budget, 1200))
 
     lines: list[str] = []
     for s in steps:
         idx = s.get("index")
-        tool_name = (s.get("tool_call") or {}).get("tool_name") or s.get("type") or "?"
+        tool_call_any: Any = s.get("tool_call") or {}
+        tool_call = cast("dict[str, Any]", tool_call_any) if isinstance(tool_call_any, dict) else {}
+        tool_name = tool_call.get("tool_name") or s.get("type") or "?"
         page_url = s.get("page_url") or ""
-        tr = s.get("tool_result") or {}
-        kind = tr.get("kind") or ""
-        text = tr.get("text") or ""
+        tr_any: Any = s.get("tool_result") or {}
+        tr = cast("dict[str, Any]", tr_any) if isinstance(tr_any, dict) else {}
+        kind = str(tr.get("kind") or "")
+        text = str(tr.get("text") or "")
 
         header = f"[step {idx}] {tool_name}"
         if page_url:
@@ -130,7 +149,7 @@ def summarize_trajectory(event_path: Path, *, max_chars: int = 6000) -> str:
             header += f"  ({kind})"
         lines.append(header)
 
-        reasoning = (s.get("reasoning") or "").strip()
+        reasoning = str(s.get("reasoning") or "").strip()
         if reasoning:
             lines.append(f"  reasoning: {_truncate_middle(reasoning, 400)}")
 
@@ -146,7 +165,10 @@ def summarize_trajectory(event_path: Path, *, max_chars: int = 6000) -> str:
 
 
 def build_block_user_prompt(task: str, trajectory: str, final_answer: str | None) -> str:
-    answer = final_answer.strip() if final_answer else "(no final answer reported)"
+    # Mirrors `_judge.build_judge_user_prompt`: strip first, then test for
+    # emptiness so a whitespace-only answer surfaces the explicit placeholder
+    # rather than slipping into the detector LLM's prompt as nothing.
+    answer = (final_answer or "").strip() or "(no final answer reported)"
     return (
         f"Task: {task}\n\n"
         f"Trajectory (steps with URLs, accessibility-tree snippets, and "

--- a/scripts/tests/test_blockcheck.py
+++ b/scripts/tests/test_blockcheck.py
@@ -8,7 +8,10 @@ decides whether a benchmark run hit an anti-agent defense."""
 
 from __future__ import annotations
 
-from _blockcheck import _truncate_middle  # pyright: ignore[reportPrivateUsage]
+from _blockcheck import (
+    _truncate_middle,  # pyright: ignore[reportPrivateUsage]
+    build_block_user_prompt,
+)
 
 
 class TestTruncateMiddle:
@@ -37,3 +40,30 @@ class TestTruncateMiddle:
 
     def test_empty_input(self) -> None:
         assert _truncate_middle("", max_chars=100) == ""
+
+
+class TestBuildBlockUserPrompt:
+    def test_includes_task_trajectory_and_answer(self) -> None:
+        prompt = build_block_user_prompt(
+            task="Find the price",
+            trajectory="[step 0] goto  url=https://example.com",
+            final_answer="$42.99",
+        )
+        assert "Find the price" in prompt
+        assert "[step 0] goto" in prompt
+        assert "$42.99" in prompt
+
+    def test_missing_answer_renders_placeholder(self) -> None:
+        # Mirror the bug pinned by `_judge`'s tests: `None`, empty string,
+        # and whitespace-only must all surface the same human-readable
+        # placeholder so the detector LLM doesn't see a literal empty
+        # answer (and a truthy whitespace string doesn't slip through the
+        # `if final_answer` check to be `.strip()`'d into nothing).
+        for missing in (None, "", "   "):
+            prompt = build_block_user_prompt("t", "trajectory", missing)
+            assert "(no final answer reported)" in prompt
+
+    def test_strips_whitespace_around_answer(self) -> None:
+        prompt = build_block_user_prompt("t", "trajectory", "  hello  \n")
+        assert "hello" in prompt
+        assert "  hello  " not in prompt


### PR DESCRIPTION
## Summary

Continues the strict ratchet from #97. `_blockcheck.py` was the second helper named in the audit's Phase-2 plan; deferred initially because `summarize_trajectory` walks `dict[str, Any]` returned from `build_traces.parse_events_file` and `correlate_steps` (a proper TypedDict refactor would touch ~1k lines of `build_traces.py`).

Resolved with the same boundary-cast pattern established in #97 for `_stagehand.py`: at each access of the untyped step dict, narrow via `cast("dict[str, Any]", …)` so strict mode sees concrete element types instead of Unknown. A small `step_tr_kind()` helper captures the "tool_result kind" access pattern used twice. Zero behavior change.

### Real defect caught (mirrors #94/#96)

`build_block_user_prompt` had the exact same whitespace-only-answer bug that #94's tests caught in `_judge.build_judge_user_prompt`:

```python
answer = final_answer.strip() if final_answer else "(no final answer reported)"
```

A whitespace-only `final_answer="   "` is truthy → `.strip()` → `""` → inserted into the detector LLM's prompt as nothing rather than the explicit placeholder. Fixed with the same one-line pattern used in #96:

```python
answer = (final_answer or "").strip() or "(no final answer reported)"
```

Three new tests in `test_blockcheck.py` cover the None / empty / whitespace cases plus whitespace stripping around real answers.

### Pattern note carried forward

The `cast()` approach in this PR (and #97) is good for files whose upstream shape is legitimately dynamic. A TypedDict refactor of `build_traces.parse_events_file` / `correlate_steps` would unlock stricter consumer-side typing but is a bigger lift — deferring.

## Test plan

- [x] `uvx pyright` — 0 errors, 0 warnings, 0 informations
- [x] `uvx --with pytest --with python-dotenv pytest` — 58 passed (was 55; added 3 prompt tests)
- [x] `uvx ruff check scripts/` + `ruff format --check` clean
- [x] `pre-commit run` on all changed files passes every hook
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)