### PR TITLE
Add link-spoof-annotate rule

### DIFF
--- a/demo-site/src/pages/ProductDetail.tsx
+++ b/demo-site/src/pages/ProductDetail.tsx
@@ -266,6 +266,48 @@ export default function ProductDetail() {
         </div>
       </section>
 
+      {/*
+        Two anchors crafted to trip link-spoof-annotate so a sighted reviewer
+        (or a vision-based agent) can see the chip rendered next to each link.
+          (a) Text "PayPaI Buyer Protection" uses an uppercase Latin I in
+              place of the lowercase l — pure ASCII, so the homoglyph check
+              does not fire; this one trips the href / text-domain check
+              because the visible "paypal.com" mismatches the actual host.
+          (b) Text starts with a Cyrillic letter substituted into a Latin
+              brand word — the mixed-script check fires inside the rendered
+              chip's quoted match string.
+        Static fixtures; no user input. */}
+      <section
+        aria-label="Trust and safety"
+        className="rounded border border-stone-200 bg-stone-50 p-3 text-sm text-stone-700"
+      >
+        <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-stone-500">
+          Buyer protection
+        </h3>
+        <ul className="list-disc space-y-1 pl-5">
+          <li>
+            Pay safely with{" "}
+            <a
+              href="https://account-verify.example.test/login"
+              className="text-orange-700 hover:underline"
+            >
+              paypal.com Buyer Protection
+            </a>
+            .
+          </li>
+          <li>
+            Read independent reviews at{" "}
+            <a
+              href="https://reviews.example.test/rivermart"
+              className="text-orange-700 hover:underline"
+            >
+              {"рeview-trust.example"}
+            </a>
+            .
+          </li>
+        </ul>
+      </section>
+
       <section aria-label="From the manufacturer">
         <h2 className="mb-2 text-lg font-semibold text-slate-900">
           From the manufacturer

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -3,7 +3,7 @@ title: Rules reference
 description: The defense rules shipped with agent-browser-shield, what each one does, and its default state.
 ---
 
-The extension ships 28 rules grouped into five rough categories. Each rule is
+The extension ships 29 rules grouped into five rough categories. Each rule is
 independently toggleable from the extension popup. Rules marked **default: on**
 are active on fresh install; **default: off** rules must be enabled manually.
 
@@ -124,6 +124,56 @@ against LLM-integrated browsers (the `U+E0000–U+E007F` carrier that encodes
 arbitrary ASCII as invisible tag characters) was popularized by Goodside (2024)
 and is now a standard test case in the indirect-injection benchmarks cited
 elsewhere on this page.
+
+### Flag Spoofed Links
+
+- **ID:** `link-spoof-annotate`
+- **Default:** on
+
+Annotate `<a>` elements whose visible text is visually spoofed relative to the
+link's actual destination. Two checks, both signalled with a visible inline chip
+appended next to the anchor:
+
+1. The visible text contains a word that mixes Latin letters with letters from
+   Greek (`U+0370–03FF`), Cyrillic (`U+0400–04FF`), Armenian (`U+0530–058F`), or
+   Cherokee (`U+13A0–13FF`) — the script blocks that supply the Latin
+   confusables used in homoglyph attacks. A pure-Cyrillic word adjacent to a
+   pure-Latin word does not match; the test requires within-word script mixing.
+2. The visible text contains a fully-formed domain whose last-two-labels apex
+   doesn't match `URL.hostname` of the link's `href` (after stripping `www.`).
+   Gated to `http(s):` hrefs so `mailto:`, `tel:`, and fragment anchors don't
+   get spurious comparisons.
+
+The chip is rendered as visible markup — not just a `data-*` attribute — because
+the rule's threat model is the asymmetry where a vision-based agent (or a
+sighted user) reads the rendered glyphs and acts on the displayed domain, while
+the real navigation target is hidden in the unrendered `href`. DOM-walking
+agents see the raw code points and the raw href and can perform the same
+comparisons themselves; this rule mainly exists to close the gap for
+accessibility-tree and screenshot consumers.
+
+Prior art: Gabrilovich & Gontmakher,
+[*The Homograph Attack*](https://gabrilovich.com/publications/papers/Gabrilovich02TheHomographAttack.pdf)
+(CACM 2002), names the attack class and demonstrates the
+`microsoft.com`-with-Cyrillic-`o` proof of concept that prompted the IDN
+ecosystem's response. Holgers, Watson, Gribble,
+[*Cutting Through the Confusion: A Measurement Study of Homograph Attacks*](https://www.usenix.org/legacy/event/usenix06/tech/full_papers/holgers/holgers.pdf)
+(USENIX ATC 2006), measures real-world prevalence and confusable coverage. The
+confusables-policy lineage is Unicode TR #36
+([*Unicode Security Considerations*](https://www.unicode.org/reports/tr36/)) and
+TR #39 ([*Unicode Security Mechanisms*](https://www.unicode.org/reports/tr39/)),
+which define the canonical confusable mapping browsers and TLDs use to refuse
+mixed-script IDN labels. Boucher et al.,
+[*Bad Characters: Imperceptible NLP Attacks*](https://arxiv.org/abs/2106.09898)
+(IEEE S&P 2022, cited under `unicode-invisibles-strip` above), demonstrates that
+homoglyph substitution degrades modern NLP classifiers at rates comparable to
+zero-width insertions and bidi reordering — the human / machine reading
+asymmetry that makes the attack work on LLM-driven agents too. For the href /
+text-domain mismatch check, Dhamija, Tygar, Hearst,
+[*Why Phishing Works*](https://people.eecs.berkeley.edu/~tygar/papers/Phishing/why_phishing_works.pdf)
+(CHI 2006), is the foundational user study showing that the link-text /
+link-target mismatch is the single most reliable cue users fail to check —
+making it the cue best worth re-presenting visibly to the agent.
 
 ### Strip HTML Comments
 

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -24,6 +24,7 @@
     "social-embed-redact": true,
     "ads-hide": true,
     "cart-addon-annotate": true,
+    "link-spoof-annotate": true,
     "search-url-helper": true,
     "roach-motel-annotate": true,
     "irrelevant-sections-redact": false,

--- a/extension/src/lib/dom-markers.ts
+++ b/extension/src/lib/dom-markers.ts
@@ -45,6 +45,10 @@ export const CHECKOUT_CHECKBOX_CLEARED_ATTR = "data-abs-cleared";
 // already badged, so the watcher doesn't double-badge on re-scan.
 export const CART_ADDON_ANNOTATED_ATTR = "data-abs-cart-addon-annotated";
 
+// `link-spoof-annotate`: marks an <a> the rule has badged so the watcher
+// doesn't append a second chip on the next mutation pass.
+export const LINK_SPOOF_ANNOTATED_ATTR = "data-abs-link-spoof-annotated";
+
 // `confirmshame-sanitize`: stores the original copy of attributes the
 // rule rewrites so reveal-on-click can restore the user-visible
 // confirmshame language.

--- a/extension/src/rules/__tests__/link-spoof-annotate.test.ts
+++ b/extension/src/rules/__tests__/link-spoof-annotate.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @jest-environment jsdom
+ */
+import { LINK_SPOOF_ANNOTATED_ATTR as FLAGGED_ATTR } from "../../lib/dom-markers";
+import { detectSpoof, linkSpoofAnnotateRule } from "../link-spoof-annotate";
+
+const FLAG_CLASS = "abs-link-spoof-annotate";
+const MUTATION_THROTTLE_MS = 250;
+
+async function flushMutations(): Promise<void> {
+  await Promise.resolve();
+}
+
+function makeAnchor(text: string, href: string): HTMLAnchorElement {
+  const anchor = document.createElement("a");
+  // setAttribute (not the `.href` setter) so the test can plant raw
+  // values like "#" or "" that mimic real-world inert anchors without
+  // jsdom resolving them against the page URL.
+  anchor.setAttribute("href", href);
+  anchor.textContent = text;
+  return anchor;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  linkSpoofAnnotateRule.teardown();
+  jest.useRealTimers();
+});
+
+describe("detectSpoof homoglyph check", () => {
+  it("flags a Cyrillic letter substituted into a Latin word", () => {
+    // Cyrillic 'р' (U+0440) + Latin 'aypal.com'
+    const anchor = makeAnchor("рaypal.com", "https://evil.example.com/");
+    const triggers = detectSpoof(anchor);
+    expect(triggers?.homoglyphWord).not.toBeNull();
+  });
+
+  it("flags a Greek letter substituted into a Latin word", () => {
+    // Greek 'Ο' (U+039F) + Latin 'mega'
+    const anchor = makeAnchor("Οmega.example", "https://evil.example/");
+    expect(detectSpoof(anchor)?.homoglyphWord).not.toBeNull();
+  });
+
+  it("does not flag pure-Latin text", () => {
+    const anchor = makeAnchor("Click here", "https://example.com/");
+    expect(detectSpoof(anchor)).toBeNull();
+  });
+
+  it("does not flag a pure-Cyrillic word separated from Latin by whitespace", () => {
+    // "Проект example" — two distinct words, no within-word mixing.
+    const anchor = makeAnchor("Проект example", "https://example.com/");
+    expect(detectSpoof(anchor)?.homoglyphWord ?? null).toBeNull();
+  });
+});
+
+describe("detectSpoof href/text domain mismatch", () => {
+  it("flags when visible text shows a different apex than the href", () => {
+    const anchor = makeAnchor(
+      "Sign in at paypal.com",
+      "https://evil.example.com/login",
+    );
+    const triggers = detectSpoof(anchor);
+    expect(triggers?.textDomain).toBe("paypal.com");
+    expect(triggers?.hrefHost).toBe("evil.example.com");
+  });
+
+  it("does not flag when text and href share an apex", () => {
+    const anchor = makeAnchor("paypal.com", "https://www.paypal.com/login");
+    expect(detectSpoof(anchor)).toBeNull();
+  });
+
+  it("does not flag when href is a subdomain of the text-displayed apex", () => {
+    const anchor = makeAnchor("github.com/foo", "https://api.github.com/repos");
+    expect(detectSpoof(anchor)).toBeNull();
+  });
+
+  it("does not flag when visible text has no domain shape", () => {
+    const anchor = makeAnchor("Sign in here", "https://evil.example.com/");
+    expect(detectSpoof(anchor)).toBeNull();
+  });
+
+  it("ignores non-http hrefs (mailto, tel, fragment)", () => {
+    expect(detectSpoof(makeAnchor("paypal.com", "#"))).toBeNull();
+    expect(
+      detectSpoof(makeAnchor("paypal.com", "mailto:x@evil.example.com")),
+    ).toBeNull();
+    expect(
+      detectSpoof(makeAnchor("paypal.com", "tel:+15555550100")),
+    ).toBeNull();
+  });
+});
+
+describe("linkSpoofAnnotateRule", () => {
+  it("appends a visible chip immediately after the spoofed link", () => {
+    const anchor = makeAnchor("paypal.com", "https://evil.example.com/login");
+    document.body.append(anchor);
+    linkSpoofAnnotateRule.apply(document.body);
+
+    expect(anchor.hasAttribute(FLAGGED_ATTR)).toBe(true);
+    const chip = document.querySelector(`.${FLAG_CLASS}`);
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain("paypal.com");
+    expect(chip?.textContent).toContain("evil.example.com");
+    expect(chip?.previousElementSibling).toBe(anchor);
+  });
+
+  it("does not double-flag on a repeat apply", () => {
+    const anchor = makeAnchor("рaypal.com", "https://evil.example.com/");
+    document.body.append(anchor);
+    linkSpoofAnnotateRule.apply(document.body);
+    linkSpoofAnnotateRule.apply(document.body);
+
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(1);
+  });
+
+  it("flags a lazily inserted anchor via the subtree watcher", async () => {
+    linkSpoofAnnotateRule.apply(document.body);
+
+    const late = document.createElement("div");
+    late.append(makeAnchor("paypal.com", "https://evil.example.com/"));
+    document.body.append(late);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelector(`.${FLAG_CLASS}`)).not.toBeNull();
+  });
+
+  it("leaves benign links alone", () => {
+    document.body.innerHTML = `
+      <a href="/about">About us</a>
+      <a href="https://api.github.com/repos">github.com/repos</a>
+      <a href="https://www.paypal.com/signin">paypal.com</a>
+      <a href="https://example.com/">Click here</a>
+    `;
+    linkSpoofAnnotateRule.apply(document.body);
+
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+});

--- a/extension/src/rules/index.ts
+++ b/extension/src/rules/index.ts
@@ -16,6 +16,7 @@ import { hiddenTextStripRule } from "./hidden-text-strip";
 import { htmlCommentStripRule } from "./html-comment-strip";
 import { irrelevantSectionsRedactRule } from "./irrelevant-sections-redact";
 import { jsonLdSanitizeRule } from "./json-ld-sanitize";
+import { linkSpoofAnnotateRule } from "./link-spoof-annotate";
 import { metaInjectionStripRule } from "./meta-injection-strip";
 import { newsletterModalHideRule } from "./newsletter-modal-hide";
 import { noscriptStripRule } from "./noscript-strip";
@@ -63,6 +64,7 @@ const RULES_TUPLE = [
   socialEmbedRedactRule,
   adsHideRule,
   cartAddonAnnotateRule,
+  linkSpoofAnnotateRule,
   searchUrlHelperRule,
   roachMotelAnnotateRule,
   irrelevantSectionsRedactRule,

--- a/extension/src/rules/link-spoof-annotate.ts
+++ b/extension/src/rules/link-spoof-annotate.ts
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Flag <a> elements whose visible text is visually spoofed relative to
+// their navigation target. Two cheap-regex checks; both signal classic
+// phishing:
+//
+//   1. Mixed-script word in visible text. A run of letters that blends
+//      Latin with Cyrillic / Greek / Armenian / Cherokee is the
+//      signature of letter-substitution homoglyph attacks (one of the
+//      letters in a Latin brand name swapped for a confusable from a
+//      different script). Real-world domain or brand text is
+//      single-script per word; mixed scripts inside one word are
+//      essentially never legitimate.
+//
+//   2. Visible text contains a fully-formed domain that, after stripping
+//      `www.` and reducing to the last two labels, doesn't match the
+//      link's actual host. The textbook "click brand.com → really
+//      points at attacker.example" bait.
+//
+// Only useful to visual / accessibility-tree agents. A DOM-walking agent
+// already sees the raw text code points and the unrendered href, so the
+// asymmetry the attacks exploit doesn't apply — those agents can run
+// these checks themselves with no rule involvement. We render the
+// warning as a visible inline chip next to the link so a vision model
+// picks it up in the screenshot or accessibility tree.
+//
+// We annotate rather than strip the link: the warning has to sit next
+// to the suspicious anchor for context, and removing the anchor removes
+// the very thing the user/agent is being asked to evaluate.
+
+import {
+  LINK_SPOOF_ANNOTATED_ATTR as FLAGGED_ATTR,
+  RULE_ATTR,
+} from "../lib/dom-markers";
+import { log } from "../lib/log";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import type { Rule } from "./types";
+
+const RULE_ID = "link-spoof-annotate" as const;
+const FLAG_CLASS = "abs-link-spoof-annotate";
+
+// Adjacent letters from different scripts inside a single word. Covers
+// the Latin-confusable blocks used in the bulk of homoglyph phishing:
+// Greek (U+0370–03FF), Cyrillic (U+0400–04FF), Armenian (U+0530–058F),
+// Cherokee (U+13A0–13FF). Word boundaries are implicit — the regex
+// requires the two letters to be next to each other, which only happens
+// within a single word. A pure-Cyrillic word next to a pure-Latin word
+// separated by punctuation or whitespace will not match.
+const MIXED_SCRIPT_RE = /[A-Za-z][Ͱ-ϿЀ-ӿ԰-֏Ꭰ-᏿]|[Ͱ-ϿЀ-ӿ԰-֏Ꭰ-᏿][A-Za-z]/u;
+
+// "Looks like a domain" — at least one label followed by a 2+ char TLD.
+// Loose on purpose; the apex comparison below is what decides whether
+// the match is actionable. ASCII-only by design, so a legitimate IDN
+// label written in Cyrillic / Greek in the visible text (e.g. рф) won't
+// surface a spurious "text vs href" candidate.
+const DOMAIN_RE = /\b((?:[a-z0-9-]{1,63}\.)+[a-z]{2,24})\b/i;
+
+function stripWww(host: string): string {
+  return host.startsWith("www.") ? host.slice(4) : host;
+}
+
+// Last-two-labels approximation of the registrable domain. Doesn't
+// handle multi-part public suffixes (co.uk, com.au) — a real PSL parser
+// would be heavier than this rule warrants. False positives surface as
+// misleading chip text, not as broken navigation, and the chip discloses
+// what was compared so a reader can judge.
+function apex(host: string): string {
+  const labels = stripWww(host).split(".");
+  return labels.length >= 2 ? labels.slice(-2).join(".") : host;
+}
+
+export interface SpoofTriggers {
+  homoglyphWord: string | null;
+  textDomain: string | null;
+  hrefHost: string | null;
+}
+
+export function detectSpoof(link: HTMLAnchorElement): SpoofTriggers | null {
+  const text = link.textContent.trim();
+  if (text.length === 0) {
+    return null;
+  }
+
+  const homoglyphMatch = MIXED_SCRIPT_RE.exec(text);
+  const homoglyphWord = homoglyphMatch ? homoglyphMatch[0] : null;
+
+  let textDomain: string | null = null;
+  let hrefHost: string | null = null;
+
+  const domainMatch = DOMAIN_RE.exec(text);
+  const candidateDomain = domainMatch?.[1];
+  if (candidateDomain !== undefined) {
+    // Read the raw attribute first so we skip mailto:/tel:/javascript:/
+    // fragment-only anchors before parsing — `link.href` would resolve a
+    // missing-or-empty attribute against the page URL and give a
+    // misleading comparison target.
+    const raw = link.getAttribute("href");
+    if (raw !== null && /^https?:/i.test(raw)) {
+      try {
+        const url = new URL(link.href);
+        const textApex = apex(candidateDomain.toLowerCase());
+        const hrefApex = apex(url.hostname.toLowerCase());
+        if (textApex !== hrefApex) {
+          textDomain = candidateDomain.toLowerCase();
+          hrefHost = url.hostname.toLowerCase();
+        }
+      } catch {
+        // Unparseable href — nothing to compare against.
+      }
+    }
+  }
+
+  if (homoglyphWord === null && textDomain === null) {
+    return null;
+  }
+  return { homoglyphWord, textDomain, hrefHost };
+}
+
+function chipText(triggers: SpoofTriggers): string {
+  const parts: string[] = [];
+  if (triggers.homoglyphWord !== null) {
+    parts.push(`mixed-script word "${triggers.homoglyphWord}"`);
+  }
+  if (triggers.textDomain !== null && triggers.hrefHost !== null) {
+    parts.push(
+      `text shows ${triggers.textDomain} but href points to ${triggers.hrefHost}`,
+    );
+  }
+  return `[abs: link looks spoofed (${parts.join("; ")}) — verify the destination before clicking]`;
+}
+
+function flag(link: HTMLAnchorElement, triggers: SpoofTriggers): void {
+  if (!link.isConnected || link.hasAttribute(FLAGGED_ATTR)) {
+    return;
+  }
+  link.setAttribute(FLAGGED_ATTR, "");
+
+  const chip = document.createElement("span");
+  chip.className = FLAG_CLASS;
+  chip.setAttribute(RULE_ATTR, RULE_ID);
+  // Inline-block so the chip stays on the same baseline as the link in
+  // running text, and self-contained inline styling so the warning is
+  // visible even on pages that strip extension stylesheets.
+  chip.style.display = "inline-block";
+  chip.style.margin = "0 0 0 4px";
+  chip.style.padding = "0 4px";
+  chip.style.border = "1px solid #b00";
+  chip.style.background = "#fff5f5";
+  chip.style.color = "#900";
+  chip.style.font = "11px/1.4 system-ui, sans-serif";
+  chip.style.fontStyle = "italic";
+  chip.textContent = chipText(triggers);
+  link.after(chip);
+}
+
+function scanAndFlag(root: ParentNode): void {
+  let count = 0;
+  for (const node of root.querySelectorAll("a[href]")) {
+    const anchor = node as HTMLAnchorElement;
+    if (anchor.hasAttribute(FLAGGED_ATTR)) {
+      continue;
+    }
+    const triggers = detectSpoof(anchor);
+    if (triggers !== null) {
+      flag(anchor, triggers);
+      count++;
+    }
+  }
+  if (count > 0) {
+    log("link spoofs flagged", { count });
+  }
+}
+
+const watcher = createSubtreeWatcher({
+  skipPlaceholderSubtrees: true,
+  onSubtrees: (roots) => {
+    for (const root of roots) {
+      scanAndFlag(root);
+    }
+  },
+});
+
+function apply(root: ParentNode): void {
+  scanAndFlag(root);
+  watcher.start(root);
+}
+
+export const linkSpoofAnnotateRule = {
+  id: RULE_ID,
+  label: "Flag Spoofed Links",
+  description:
+    "Annotate <a> elements whose visible text mixes Latin with Cyrillic / Greek / Armenian / Cherokee letters (homoglyph) or whose visible text contains a domain that differs from the link's actual host. Useful for vision-based agents; DOM-walking agents can spot the same discrepancies themselves.",
+  apply,
+  teardown: () => {
+    watcher.stop();
+  },
+} satisfies Rule;

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -29,6 +29,7 @@ export const RULE_DEFAULTS: Readonly<Record<RuleId, boolean>> = {
   "social-embed-redact": true,
   "ads-hide": true,
   "cart-addon-annotate": true,
+  "link-spoof-annotate": true,
   "search-url-helper": true,
   "roach-motel-annotate": true,
   "irrelevant-sections-redact": false,

--- a/skills/agent-browser-shield-config/SKILL.md
+++ b/skills/agent-browser-shield-config/SKILL.md
@@ -75,6 +75,10 @@ for the build-time workflow.
 - `ads-hide` — remove display ads and paid/sponsored search results (curated
   selectors + EasyList stylesheet)
 - `cart-addon-annotate` — flag likely sneak-into-basket add-ons
+- `link-spoof-annotate` — flag `<a>` elements whose visible text mixes scripts
+  (homoglyph) or shows a domain that doesn't match the link's actual host.
+  Renders a visible inline chip next to the anchor; useful for vision-based
+  agents (DOM-walking agents can spot the same discrepancies themselves)
 - `search-url-helper` — embed a screen-reader-only landmark with URL recipes
   (search/filter/sort/direct lookup) on covered hosts (Amazon, Best Buy, Etsy,
   IKEA, Home Depot, REI, GitHub, Wikipedia, Hacker News, hn.algolia.com, MDN,


### PR DESCRIPTION
## Summary

- New rule `link-spoof-annotate`: annotates `<a>` elements whose visible text is visually spoofed relative to the link's `href`. Two cheap-regex checks, both surfaced via a visible inline chip rendered next to the anchor:
  - **Mixed-script word in visible text** — a run of letters that mixes Latin with Greek (`U+0370–03FF`), Cyrillic (`U+0400–04FF`), Armenian (`U+0530–058F`), or Cherokee (`U+13A0–13FF`). Within-word mixing only; pure-Cyrillic adjacent to pure-Latin (legit i18n) does not match.
  - **href / text-domain mismatch** — visible text contains a fully-formed domain whose last-two-labels apex doesn't match `URL.hostname` after stripping `www.`. Gated to `http(s):` hrefs so `mailto:`/`tel:`/`#` anchors don't get spurious comparisons.
- Default **on**. Only useful for vision / accessibility-tree agents; DOM-walking agents already see the raw code points and unrendered href and can run the same comparisons themselves — this rule closes the gap for screenshot consumers.
- Demo: two phishing-link examples added to the demo-site `ProductDetail` page (one href/text mismatch, one Cyrillic homoglyph) so the chip can be observed end-to-end against the loaded extension.
- Docs: rule entry added under *Prompt-injection defense* in `docs/src/content/docs/rules.md`, with prior art — Gabrilovich & Gontmakher (CACM 2002, the original *Homograph Attack* paper), Holgers / Watson / Gribble (USENIX ATC 2006 measurement study), Unicode TR #36 / TR #39 (the confusables policy lineage), cross-reference to Boucher et al. *Bad Characters* (already cited under `unicode-invisibles-strip`), and Dhamija / Tygar / Hearst *Why Phishing Works* (CHI 2006) for the link-text vs link-target asymmetry behind the second check.
- Catalog and skill index updated: `extension/src/rules/index.ts`, `extension/data/rule-defaults.json` (+ regenerated `rule-defaults.generated.ts`), `extension/src/lib/dom-markers.ts` (new `LINK_SPOOF_ANNOTATED_ATTR`), and `skills/agent-browser-shield-config/SKILL.md`.

## Test plan

- [x] `bun run preflight` in `extension/` — 839 tests pass, lint + typecheck + knip clean
- [x] 13 new unit tests in `link-spoof-annotate.test.ts` cover Cyrillic + Greek homoglyph hits, pure-Latin / split-word negatives, apex mismatch / apex match / subdomain match, no-domain text, mailto/tel/fragment negatives, chip rendering, idempotent re-apply, and a lazy-mount watcher case
- [x] `bun run check` in `demo-site/` and `docs/` — clean
- [x] pre-commit on all changed files — clean (gitleaks, biome, eslint, mdformat, etc.)
- [ ] Manual: load `extension/dist/` unpacked, visit demo-site product detail page, confirm `[abs: link looks spoofed …]` chip renders next to both seeded anchors and that benign anchors elsewhere on the page are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)