### PR TITLE
Link to Chrome Web Store listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/pixiebrix/agent-browser-shield/actions/workflows/ci.yml/badge.svg)](https://github.com/pixiebrix/agent-browser-shield/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/pixiebrix/agent-browser-shield)](https://github.com/pixiebrix/agent-browser-shield/releases/latest)
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/gnejacdioaelglahihpagpfjpddpnamd?label=Chrome%20Web%20Store)](https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd)
 [![License: PolyForm Shield 1.0.0](https://img.shields.io/badge/license-PolyForm--Shield--1.0.0-orange)](./LICENSE)
 
 > **Alpha prototype:** rulesets may change without notice
@@ -16,6 +17,11 @@ effective and secure:
   that could carry prompt-injection payloads.
 - **Accuracy:** block manipulative dark patterns and hide engagement rails and
   other content that could distract the model from the user's task.
+
+**[Install from the Chrome Web Store](https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd)**
+— works on any Chromium-based browser (Chrome, Edge, Brave, Arc, Opera). For
+agent runtimes that need an unpacked extension or a ZIP, see the
+[install guide](https://pixiebrix.github.io/agent-browser-shield/install/).
 
 **[Documentation](https://pixiebrix.github.io/agent-browser-shield/)** — install
 guide, rule reference, and configuration.

--- a/clawhub/agent-browser-shield/SKILL.md
+++ b/clawhub/agent-browser-shield/SKILL.md
@@ -12,22 +12,39 @@ engagement noise (ads, scarcity cues, social embeds).
 
 ## Install
 
-Hosted ZIP (used by both paths):
-`https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`
-— `manifest.json` is at the archive root; do not re-zip.
+Sources:
+
+- **Chrome Web Store** (preferred for Path 1; auto-updates, works on any
+  Chromium browser):
+  `https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd`
+- **Hosted ZIP** (required for Path 2; also for Path 1 when pinning a specific
+  build):
+  `https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`
+  — `manifest.json` is at the archive root; do not re-zip.
 
 ### Path 1 — Local Chrome via remote CDP (OpenClaw `remote` driver)
 
 Use when OpenClaw is connecting to a Chromium you launch yourself.
 
-1. Unzip `agent-browser-shield-extension.zip` to a stable directory (e.g.
-   `~/.cache/agent-browser-shield/extension/`).
+1. Install the extension into the dedicated profile you'll launch Chromium
+   against. Either:
 
-2. Launch Chromium **headed** with a dedicated profile and the extension loaded:
+   - **From the Chrome Web Store:** launch Chromium with the dedicated profile,
+     install from the store URL above, pin the shield icon, then close it. On
+     subsequent launches (step 2) skip the `--load-extension` /
+     `--disable-extensions-except` flags — the store install is persisted in
+     the profile.
+   - **Unpacked (when pinning a build):** unzip
+     `agent-browser-shield-extension.zip` to a stable directory (e.g.
+     `~/.cache/agent-browser-shield/extension/`) and pass `--load-extension`
+     and `--disable-extensions-except` in step 2.
+
+2. Launch Chromium **headed** with the dedicated profile and CDP enabled:
 
    ```text
    --remote-debugging-port=9222
    --user-data-dir=/abs/path/to/dedicated-profile
+   # Unpacked path only — omit when installed from the Chrome Web Store:
    --load-extension=/abs/path/to/extension
    --disable-extensions-except=/abs/path/to/extension
    ```

--- a/clawhub/agent-browser-shield/SKILL.md
+++ b/clawhub/agent-browser-shield/SKILL.md
@@ -32,12 +32,12 @@ Use when OpenClaw is connecting to a Chromium you launch yourself.
    - **From the Chrome Web Store:** launch Chromium with the dedicated profile,
      install from the store URL above, pin the shield icon, then close it. On
      subsequent launches (step 2) skip the `--load-extension` /
-     `--disable-extensions-except` flags — the store install is persisted in
-     the profile.
+     `--disable-extensions-except` flags — the store install is persisted in the
+     profile.
    - **Unpacked (when pinning a build):** unzip
      `agent-browser-shield-extension.zip` to a stable directory (e.g.
-     `~/.cache/agent-browser-shield/extension/`) and pass `--load-extension`
-     and `--disable-extensions-except` in step 2.
+     `~/.cache/agent-browser-shield/extension/`) and pass `--load-extension` and
+     `--disable-extensions-except` in step 2.
 
 2. Launch Chromium **headed** with the dedicated profile and CDP enabled:
 

--- a/docs/src/content/docs/hermes-agent.md
+++ b/docs/src/content/docs/hermes-agent.md
@@ -26,8 +26,8 @@ Two options, depending on whether you need a specific build:
   load that directory at `chrome://extensions` → **Developer mode** → **Load
   unpacked**.
 
-Either way, the extension must end up in the Chromium profile Hermes attaches
-to in step 3 — not your default Chrome profile.
+Either way, the extension must end up in the Chromium profile Hermes attaches to
+in step 3 — not your default Chrome profile.
 
 ### 2. Launch Chrome with remote debugging on a dedicated user-data-dir
 

--- a/docs/src/content/docs/hermes-agent.md
+++ b/docs/src/content/docs/hermes-agent.md
@@ -13,12 +13,21 @@ that Hermes *attaches* to.
 
 ### 1. Install the extension
 
-Get the extension directory — either build from source (follow
-[Install](/agent-browser-shield/install/) through `bun run build` for
-`extension/dist/`) or download and unzip the
-[prebuilt ZIP](/agent-browser-shield/install/#download-a-prebuilt-zip). You will
-load that directory into the Chromium profile that Hermes attaches to in step 3
-— not your default Chrome profile.
+Two options, depending on whether you need a specific build:
+
+- **Chrome Web Store** — install
+  [agent-browser-shield](https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd)
+  into the dedicated user-data-dir from step 2 (open `chrome://extensions` in
+  the launched browser and add it there, not from your default profile).
+- **Unpacked / from source** — build from source (follow
+  [Install](/agent-browser-shield/install/) through `bun run build` for
+  `extension/dist/`) or download and unzip the
+  [prebuilt ZIP](/agent-browser-shield/install/#download-a-prebuilt-zip), then
+  load that directory at `chrome://extensions` → **Developer mode** → **Load
+  unpacked**.
+
+Either way, the extension must end up in the Chromium profile Hermes attaches
+to in step 3 — not your default Chrome profile.
 
 ### 2. Launch Chrome with remote debugging on a dedicated user-data-dir
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -11,7 +11,8 @@ import afterImage from "../../assets/after.png";
 Prototype browser extension capabilities that make browser-use agents faster,
 safer, and more accurate.
 
-<LinkButton href="/agent-browser-shield/install/" icon="right-arrow" variant="primary">Install</LinkButton>
+<LinkButton href="https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd" icon="external" variant="primary">Install from Chrome Web Store</LinkButton>
+<LinkButton href="/agent-browser-shield/install/" icon="right-arrow">Other install paths</LinkButton>
 <LinkButton href="/agent-browser-shield/rules/" icon="open-book">Browse the rules</LinkButton>
 <LinkButton href="https://github.com/pixiebrix/agent-browser-shield" icon="external">View on GitHub</LinkButton>
 <LinkButton href="https://clawhub.ai/pixiebrix/agent-browser-shield" icon="external">Skill on ClawHub</LinkButton>

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -5,8 +5,20 @@ description: Build the agent-browser-shield extension and load it into Chromium.
 
 ## Prerequisites
 
-- **Chrome / Chromium 148+** — to load the extension.
+- **Chrome / Chromium 148+** — to load the extension. Any Chromium-based browser
+  works (Chrome, Edge, Brave, Arc, Opera).
 - **Node** ≥ 24 and **Bun** ≥ 1.3 — only needed if you're building from source.
+
+## Install from the Chrome Web Store
+
+The simplest path for everyday use. Install the published extension on any
+Chromium-based browser:
+
+[Add to Chrome — Chrome Web Store](https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd)
+
+Updates roll out automatically through the store. Skip the rest of this page
+unless you need an unpacked build (agent runtimes that load via
+`--load-extension`), a ZIP for Browserbase, or a build off a specific commit.
 
 ## Download a prebuilt ZIP
 

--- a/docs/src/content/docs/openclaw.md
+++ b/docs/src/content/docs/openclaw.md
@@ -37,16 +37,17 @@ attaches via CDP and inherits whatever's already loaded.
 
 ### 1. Install the extension into the profile
 
-Get the extension directory — either build from source (follow
-[Install](/agent-browser-shield/install/) through `bun run build` for
-`extension/dist/`) or download and unzip the
-[prebuilt ZIP](/agent-browser-shield/install/#download-a-prebuilt-zip). Then, in
-the Chromium-based browser whose profile OpenClaw will drive:
+In the Chromium-based browser whose profile OpenClaw will drive, install the
+extension from the
+[Chrome Web Store](https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd).
+Pin the shield icon so it's easy to confirm the extension is live.
 
-1. Open `chrome://extensions` (or `brave://extensions`, `edge://extensions`).
-2. Enable **Developer mode**.
-3. Click **Load unpacked** and select that directory.
-4. Pin the shield icon so it's easy to confirm the extension is live.
+If you need to pin a specific commit or rule set, follow
+[Install](/agent-browser-shield/install/) through `bun run build` for
+`extension/dist/` (or download and unzip the
+[prebuilt ZIP](/agent-browser-shield/install/#download-a-prebuilt-zip)), then
+load that directory at `chrome://extensions` → **Developer mode** → **Load
+unpacked**.
 
 Use a dedicated browser profile for agent runs if you don't want OpenClaw
 touching your everyday tabs and cookies — create one from the browser's profile

--- a/skills/agent-browser-shield-install/SKILL.md
+++ b/skills/agent-browser-shield-install/SKILL.md
@@ -139,6 +139,7 @@ attaches.
 
 1. Tell the user (once, then remember it's done). Prefer the Chrome Web Store —
    it auto-updates and works on any Chromium browser:
+
    - **Chrome Web Store (preferred):** install from
      `https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd`,
      then confirm the shield icon in the toolbar.
@@ -151,6 +152,7 @@ attaches.
    The floating on-page options button is off by default — see *Customizing
    build-time defaults* below to ship a build with it on (requires the unpacked
    path).
+
 2. Attach via your runtime's normal CDP / Chrome DevTools MCP mechanism. No
    per-session extension setup on the claw side.
 

--- a/skills/agent-browser-shield-install/SKILL.md
+++ b/skills/agent-browser-shield-install/SKILL.md
@@ -20,9 +20,16 @@ only covers getting the extension loaded.
 | Remote browser running on Browserbase                         | **Path B** |
 | Attaching via CDP / MCP to a Chrome the user already controls | **Path C** |
 
-The hosted ZIP is at
-`https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`
-and has `manifest.json` at the archive root. Do not re-zip it.
+Sources, in order of preference per path:
+
+- **Chrome Web Store** —
+  `https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd`.
+  Auto-updates, works on any Chromium browser. Use for Path C; not usable for
+  Paths A or B which need a local extension directory or ZIP.
+- **Hosted ZIP** —
+  `https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`.
+  `manifest.json` is at the archive root; do not re-zip it. Used by Paths A
+  (unzip → `--load-extension`) and B (upload as-is).
 
 ## Path A — Local headed Chromium, unpacked load
 
@@ -130,16 +137,20 @@ and has `manifest.json` at the archive root. Do not re-zip it.
 The user is responsible for installing the extension once; the claw only
 attaches.
 
-1. Tell the user (once, then remember it's done):
-   1. Download
-      `https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`
-      and unzip somewhere stable.
-   2. Open `chrome://extensions`, enable **Developer mode**, click **Load
-      unpacked**, select the unzipped directory.
-   3. Confirm the extension is loaded by visiting `chrome://extensions` (or by
-      checking the toolbar icon menu). The floating on-page options button is
-      off by default — see *Customizing build-time defaults* below to ship a
-      build with it on.
+1. Tell the user (once, then remember it's done). Prefer the Chrome Web Store —
+   it auto-updates and works on any Chromium browser:
+   - **Chrome Web Store (preferred):** install from
+     `https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd`,
+     then confirm the shield icon in the toolbar.
+   - **Unpacked (when a specific commit / build-time defaults are needed):**
+     download
+     `https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`,
+     unzip somewhere stable, then `chrome://extensions` → **Developer mode** →
+     **Load unpacked** → select the unzipped directory.
+
+   The floating on-page options button is off by default — see *Customizing
+   build-time defaults* below to ship a build with it on (requires the unpacked
+   path).
 2. Attach via your runtime's normal CDP / Chrome DevTools MCP mechanism. No
    per-session extension setup on the claw side.
 


### PR DESCRIPTION
## Summary

- Extension is now live at https://chromewebstore.google.com/detail/agent-browser-shield/gnejacdioaelglahihpagpfjpddpnamd. Promote the store listing as the primary install path on user-facing surfaces; keep prebuilt-ZIP and source-build instructions for runtimes that need an unpacked extension or a ZIP (Browserbase).
- README gets a shields.io Chrome Web Store badge and a store link above the docs/demo links. Docs landing leads with a "Install from Chrome Web Store" `LinkButton`; install doc adds CWS as the first install section above the prebuilt ZIP.
- OpenClaw and Hermes guides lead step 1 of the local-profile path with CWS, with unpacked kept as the fallback for build-pinning. Maintainer `agent-browser-shield-install` skill prefers CWS for Path C (CDP attach); ClawHub skill's Path 1 supports CWS (skip `--load-extension`) or unpacked.

Pattern modeled after Refined GitHub / Stylus / Tampermonkey: shields.io store badge + store-as-primary-install, with unpacked-from-source kept under build sections rather than the top install row.

## Test plan

- [ ] Verify the shields.io badge renders on github.com (note: the version may take a few hours to populate after first publish).
- [ ] Build the docs site locally and confirm the landing-page `LinkButton`s render, the new install.md anchors work, and the OpenClaw / Hermes pages still flow.
- [ ] Sanity-check that the ClawHub skill still validates with `clawhub skill publish ./agent-browser-shield --dry-run` (do not publish — bump skill version in a follow-up if shipping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)