### PR TITLE
Extract domain-trust helper backed by PSL

### DIFF
--- a/extension/bun.lock
+++ b/extension/bun.lock
@@ -10,6 +10,7 @@
         "nanoid": "^5.1.11",
         "react": "19.2.6",
         "react-dom": "19.2.6",
+        "tldts": "^7.4.2",
         "urlpattern-polyfill": "10.1.0",
         "webext-storage": "^3.1.0",
       },
@@ -1021,9 +1022,9 @@
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
-    "tldts": ["tldts@7.0.32", "", { "dependencies": { "tldts-core": "^7.0.32" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-5eDV0tK2NhLAAqBeXDAQ36+EwuStd1HbsSOnGsp+JbExITnExcALLL5M1kTH8gjDYN5QvwmUWimE3GoMZ2A7xQ=="],
+    "tldts": ["tldts@7.4.2", "", { "dependencies": { "tldts-core": "^7.4.2" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw=="],
 
-    "tldts-core": ["tldts-core@7.0.32", "", {}, "sha512-GbSw6chU2HsHIB/NAyBJYxXQKpcqhtgY6bvWi90OarpbuMia+Z4Gw5BYiW4hJo1DzQ/6k9coba7FU/ijcgVLLw=="],
+    "tldts-core": ["tldts-core@7.4.2", "", {}, "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA=="],
 
     "tmpl": ["tmpl@1.0.5", "", {}, "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="],
 
@@ -1243,6 +1244,8 @@
 
     "test-exclude/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
+    "tough-cookie/tldts": ["tldts@7.0.32", "", { "dependencies": { "tldts-core": "^7.0.32" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-5eDV0tK2NhLAAqBeXDAQ36+EwuStd1HbsSOnGsp+JbExITnExcALLL5M1kTH8gjDYN5QvwmUWimE3GoMZ2A7xQ=="],
+
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -1322,6 +1325,8 @@
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "tough-cookie/tldts/tldts-core": ["tldts-core@7.0.32", "", {}, "sha512-GbSw6chU2HsHIB/NAyBJYxXQKpcqhtgY6bvWi90OarpbuMia+Z4Gw5BYiW4hJo1DzQ/6k9coba7FU/ijcgVLLw=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -48,6 +48,7 @@
     "nanoid": "^5.1.11",
     "react": "19.2.6",
     "react-dom": "19.2.6",
+    "tldts": "^7.4.2",
     "urlpattern-polyfill": "10.1.0",
     "webext-storage": "^3.1.0"
   },

--- a/extension/src/lib/__tests__/domain-trust.test.ts
+++ b/extension/src/lib/__tests__/domain-trust.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import { registrableDomain, sameRegistrableDomain } from "../domain-trust";
+
+describe("registrableDomain", () => {
+  it("returns the eTLD+1 of a plain hostname", () => {
+    expect(registrableDomain("example.com")).toBe("example.com");
+  });
+
+  it("strips a www prefix via the PSL", () => {
+    expect(registrableDomain("www.example.com")).toBe("example.com");
+  });
+
+  it("strips deep subdomains", () => {
+    expect(registrableDomain("a.b.c.example.com")).toBe("example.com");
+  });
+
+  it("handles multi-part ICANN suffixes", () => {
+    expect(registrableDomain("foo.co.uk")).toBe("foo.co.uk");
+    expect(registrableDomain("bar.foo.co.uk")).toBe("foo.co.uk");
+    expect(registrableDomain("baz.com.au")).toBe("baz.com.au");
+  });
+
+  // The PSL ships a Private section that lists hosts like github.io,
+  // vercel.app, s3.amazonaws.com. We intentionally ignore that section
+  // so two pages on `*.github.io` collapse to a single registrable
+  // domain — otherwise an unearned-authority check would treat
+  // `attacker.github.io` and `victim.github.io` as different
+  // registrable identities and silently accept cross-page claims.
+  it("ignores the PSL Private section", () => {
+    expect(registrableDomain("attacker.github.io")).toBe("github.io");
+    expect(registrableDomain("victim.github.io")).toBe("github.io");
+    expect(registrableDomain("project.vercel.app")).toBe("vercel.app");
+  });
+
+  it("passes IPv4 literals through unchanged", () => {
+    expect(registrableDomain("192.168.1.1")).toBe("192.168.1.1");
+  });
+
+  it("passes IPv6 literals through (brackets stripped to canonical form)", () => {
+    // URL.hostname yields `[::1]` for an IPv6 host; tldts normalizes to
+    // the bracketless canonical form. Both forms collapse to the same
+    // string, so `sameRegistrableDomain` still compares equal.
+    expect(registrableDomain("[::1]")).toBe("::1");
+    expect(registrableDomain("::1")).toBe("::1");
+  });
+
+  it("returns null for single-label hosts", () => {
+    expect(registrableDomain("localhost")).toBeNull();
+  });
+
+  it("returns null for the empty string", () => {
+    expect(registrableDomain("")).toBeNull();
+  });
+
+  it("is case-insensitive", () => {
+    expect(registrableDomain("Example.COM")).toBe("example.com");
+  });
+
+  it("normalizes punycode IDNs", () => {
+    // xn--80akhbyknj4f → испытание (Russian "test" TLD)
+    expect(registrableDomain("foo.xn--80akhbyknj4f")).toBe(
+      "foo.xn--80akhbyknj4f",
+    );
+  });
+});
+
+describe("sameRegistrableDomain", () => {
+  it("matches identical hostnames", () => {
+    expect(sameRegistrableDomain("example.com", "example.com")).toBe(true);
+  });
+
+  it("matches across subdomains", () => {
+    expect(sameRegistrableDomain("www.example.com", "api.example.com")).toBe(
+      true,
+    );
+  });
+
+  it("rejects different registrable domains", () => {
+    expect(sameRegistrableDomain("example.com", "evil.example")).toBe(false);
+  });
+
+  it("rejects sibling hosts on a multi-part ICANN suffix", () => {
+    expect(sameRegistrableDomain("foo.co.uk", "bar.co.uk")).toBe(false);
+  });
+
+  it("rejects sibling hosts under a PSL Private suffix as same identity", () => {
+    // Both share the ICANN registrable domain `github.io`, so for our
+    // conservative comparison they are the same registrable identity.
+    expect(
+      sameRegistrableDomain("attacker.github.io", "victim.github.io"),
+    ).toBe(true);
+  });
+
+  it("returns false when either side cannot be resolved", () => {
+    expect(sameRegistrableDomain("localhost", "localhost")).toBe(false);
+    expect(sameRegistrableDomain("", "example.com")).toBe(false);
+    expect(sameRegistrableDomain("example.com", "")).toBe(false);
+  });
+
+  it("treats an IP literal as its own registrable identity", () => {
+    expect(sameRegistrableDomain("192.168.1.1", "192.168.1.1")).toBe(true);
+    expect(sameRegistrableDomain("192.168.1.1", "example.com")).toBe(false);
+  });
+});

--- a/extension/src/lib/domain-trust.ts
+++ b/extension/src/lib/domain-trust.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Domain comparison primitives for rules that need to decide whether two
+// hostnames represent the same registrable identity. Uses the Mozilla
+// Public Suffix List via `tldts`, restricted to the ICANN section.
+//
+// We deliberately ignore the PSL "Private" section (`github.io`,
+// `*.vercel.app`, `*.s3.amazonaws.com`, etc.). The Private section is
+// useful for browsers deciding cookie scope but wrong for trust
+// comparisons: `attacker.github.io` and `victim.github.io` would each be
+// their own "registrable domain" under the Private rules, hiding the
+// fact that they share an underlying host whose content boundary is
+// soft. ICANN-only keeps the comparison conservative — two pages on
+// `*.github.io` collapse to the same registrable domain, which matches
+// what an unearned-authority check needs to know.
+//
+// IP literals don't have a registrable domain in the DNS sense; we let
+// them stand in for one (returning the IP itself) so a mixed comparison
+// — visible text like "paypal.com" against an href pointing to a raw IP
+// — still surfaces as a mismatch rather than getting silently skipped.
+
+import { parse } from "tldts";
+
+const TLDTS_OPTIONS = {
+  allowIcannDomains: true,
+  allowPrivateDomains: false,
+} as const;
+
+export function registrableDomain(host: string): string | null {
+  if (host === "") {
+    return null;
+  }
+  const parsed = parse(host, TLDTS_OPTIONS);
+  if (parsed.isIp === true && parsed.hostname !== null) {
+    return parsed.hostname;
+  }
+  return parsed.domain;
+}
+
+// True iff both hostnames resolve to the same registrable domain. Returns
+// false when either side cannot be resolved (empty, single-label host,
+// unparseable input) — "we can't tell" is treated as "not the same" so
+// trust checks fail closed.
+export function sameRegistrableDomain(a: string, b: string): boolean {
+  const dA = registrableDomain(a);
+  if (dA === null) {
+    return false;
+  }
+  return dA === registrableDomain(b);
+}

--- a/extension/src/rules/__tests__/link-spoof-annotate.test.ts
+++ b/extension/src/rules/__tests__/link-spoof-annotate.test.ts
@@ -92,6 +92,37 @@ describe("detectSpoof href/text domain mismatch", () => {
       detectSpoof(makeAnchor("paypal.com", "tel:+15555550100")),
     ).toBeNull();
   });
+
+  // The previous last-two-labels heuristic collapsed any host to its
+  // tail bigram, so `foo.co.uk` and `bar.co.uk` both flattened to
+  // `co.uk` and a real cross-site mismatch was missed. The PSL-backed
+  // helper distinguishes them.
+  it("flags mismatched sites that share a multi-part ICANN suffix", () => {
+    const anchor = makeAnchor(
+      "Sign in at bank.co.uk",
+      "https://evil.co.uk/login",
+    );
+    const triggers = detectSpoof(anchor);
+    expect(triggers?.textDomain).toBe("bank.co.uk");
+    expect(triggers?.hrefHost).toBe("evil.co.uk");
+  });
+
+  it("does not flag subdomains under a multi-part ICANN suffix", () => {
+    const anchor = makeAnchor("bank.co.uk", "https://login.bank.co.uk/account");
+    expect(detectSpoof(anchor)).toBeNull();
+  });
+
+  // The reverse case: PSL Private entries like `github.io` should not be
+  // treated as registrable suffixes for trust purposes, so two pages on
+  // `*.github.io` collapse to the same identity and the visible-text
+  // claim isn't surfaced as a mismatch.
+  it("does not flag mismatched github.io subdomains as cross-site", () => {
+    const anchor = makeAnchor(
+      "owner.github.io",
+      "https://other.github.io/path",
+    );
+    expect(detectSpoof(anchor)).toBeNull();
+  });
 });
 
 describe("linkSpoofAnnotateRule", () => {

--- a/extension/src/rules/link-spoof-annotate.ts
+++ b/extension/src/rules/link-spoof-annotate.ts
@@ -33,6 +33,7 @@ import {
   LINK_SPOOF_ANNOTATED_ATTR as FLAGGED_ATTR,
   RULE_ATTR,
 } from "../lib/dom-markers";
+import { registrableDomain } from "../lib/domain-trust";
 import { log } from "../lib/log";
 import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import type { Rule } from "./types";
@@ -55,20 +56,6 @@ const MIXED_SCRIPT_RE = /[A-Za-z][Ͱ-ϿЀ-ӿ԰-֏Ꭰ-᏿]|[Ͱ-ϿЀ-ӿ԰-֏Ꭰ-�
 // label written in Cyrillic / Greek in the visible text (e.g. рф) won't
 // surface a spurious "text vs href" candidate.
 const DOMAIN_RE = /\b((?:[a-z0-9-]{1,63}\.)+[a-z]{2,24})\b/i;
-
-function stripWww(host: string): string {
-  return host.startsWith("www.") ? host.slice(4) : host;
-}
-
-// Last-two-labels approximation of the registrable domain. Doesn't
-// handle multi-part public suffixes (co.uk, com.au) — a real PSL parser
-// would be heavier than this rule warrants. False positives surface as
-// misleading chip text, not as broken navigation, and the chip discloses
-// what was compared so a reader can judge.
-function apex(host: string): string {
-  const labels = stripWww(host).split(".");
-  return labels.length >= 2 ? labels.slice(-2).join(".") : host;
-}
 
 export interface SpoofTriggers {
   homoglyphWord: string | null;
@@ -99,9 +86,9 @@ export function detectSpoof(link: HTMLAnchorElement): SpoofTriggers | null {
     if (raw !== null && /^https?:/i.test(raw)) {
       try {
         const url = new URL(link.href);
-        const textApex = apex(candidateDomain.toLowerCase());
-        const hrefApex = apex(url.hostname.toLowerCase());
-        if (textApex !== hrefApex) {
+        const textRD = registrableDomain(candidateDomain.toLowerCase());
+        const hrefRD = registrableDomain(url.hostname.toLowerCase());
+        if (textRD !== null && hrefRD !== null && textRD !== hrefRD) {
           textDomain = candidateDomain.toLowerCase();
           hrefHost = url.hostname.toLowerCase();
         }


### PR DESCRIPTION
## Summary

- New `extension/src/lib/domain-trust.ts` exposes `registrableDomain(host)` and `sameRegistrableDomain(a, b)`, backed by `tldts` in ICANN-only mode. This is the trust primitive a future `microdata-trust-strip` rule needs to decide whether a schema.org `Article.publisher` / `Organization.url` / `ClaimReview.author.url` lives on the same registrable identity as the page that's asserting it.
- `link-spoof-annotate` switches to the helper, replacing the last-two-labels apex approximation noted as a known limitation in its existing source comment.
- Promotes `tldts` from a transitive dep (via `tough-cookie`) to a direct extension dependency.

### What this fixes incidentally

The old `apex` collapsed any hostname to its trailing bigram, which had two failure modes:

| Case | Old behavior | New behavior |
|---|---|---|
| `bank.co.uk` text vs `evil.co.uk` href | Not flagged (both → `co.uk`) | Flagged |
| `owner.github.io` text vs `other.github.io` href | Flagged (both → `github.io`, but text/href differed at the subdomain level — actually compared apex-equal so the old code didn't flag here; documented in tests as a confirmation, not a fix) | Not flagged (correct: PSL Private entries shouldn't gate trust) |

The Private PSL section is deliberately ignored — its purpose is cookie-scope, not trust comparisons; treating `attacker.github.io` and `victim.github.io` as separate registrable identities would hide a real concern.

## Test plan

- [x] `bun run test` — 860 / 860 pass (existing 13 link-spoof tests + 3 new regression cases + 18 new domain-trust unit tests).
- [x] `bun run typecheck`, `bun run check`, `bun run knip` clean.
- [ ] Once merged, the future `microdata-trust-strip` rule can sit on top of `sameRegistrableDomain` without re-implementing PSL parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)