### PR TITLE
Add schema-trust-sanitize rule (experimental, default off)

### DIFF
--- a/demo-site/src/pages/ProductDetail.tsx
+++ b/demo-site/src/pages/ProductDetail.tsx
@@ -53,12 +53,26 @@ export default function ProductDetail() {
   // poisoned with an instruction-shaped payload; price / sku /
   // aggregateRating are valid. json-ld-sanitize blanks the description and
   // leaves everything else intact.
+  //
+  // The `manufacturer` field is a brand-impersonation fixture for
+  // schema-trust-sanitize: a RiverMart product page asserting the listing
+  // is manufactured by Sony Corporation, with a `url` pointing at
+  // sony.com. The page is on the demo's own domain, so the claim's
+  // registrable domain doesn't match — the rule blanks `name`, `url`, and
+  // `@id` on the Organization object while leaving `@type` and the
+  // surrounding Product / Offer / AggregateRating fields untouched.
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "Product",
     name: product.title,
     description: INJECTIONS.PRODUCT_DETAIL_JSON_LD_DESCRIPTION,
     brand: { "@type": "Brand", name: product.brand },
+    manufacturer: {
+      "@type": "Organization",
+      name: "Sony Corporation",
+      url: "https://www.sony.com",
+      "@id": "https://www.sony.com/#org",
+    },
     sku: product.id,
     offers: {
       "@type": "Offer",

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -412,19 +412,18 @@ content turn the same-origin policy from a hard guarantee into a soft one.
 - **Default:** off
 
 Walk JSON-LD blocks and microdata items for schema.org `Organization`-typed
-claims — `Article.publisher`, `Article.sourceOrganization`, `ClaimReview.author`,
-and top-level brand assertions — and blank the `name`, `url`, and `@id` fields
-when the claim's `url` resolves to a different
+claims — `Article.publisher`, `Article.sourceOrganization`,
+`ClaimReview.author`, and top-level brand assertions — and blank the `name`,
+`url`, and `@id` fields when the claim's `url` resolves to a different
 [registrable domain](https://publicsuffix.org/) than the page asserting it.
 Structural fields (`@type`, `logo`, `datePublished`, `price`, `ratingValue`) are
-preserved exactly, so an agent still gets the article's body data; it just
-loses the impersonating identity strings. `Person`-typed claims and
-name-only claims with no `url` to anchor against are out of scope and left
-alone. Off by default while we gather real-world signal on false positives;
-the rule short-circuits entirely on known syndicators (Google News, Yahoo News,
-MSN, Apple News, Flipboard, SmartNews, Feedly, Pocket), web archives,
-AMP cache, and Google Translate proxies, where mismatched publisher claims are
-expected.
+preserved exactly, so an agent still gets the article's body data; it just loses
+the impersonating identity strings. `Person`-typed claims and name-only claims
+with no `url` to anchor against are out of scope and left alone. Off by default
+while we gather real-world signal on false positives; the rule short-circuits
+entirely on known syndicators (Google News, Yahoo News, MSN, Apple News,
+Flipboard, SmartNews, Feedly, Pocket), web archives, AMP cache, and Google
+Translate proxies, where mismatched publisher claims are expected.
 
 Schema.org has no native provenance mechanism — every claim is self-asserted,
 which is structurally why a page can list itself as published by The New York
@@ -434,13 +433,13 @@ JASIST 2025; Google's own
 [Structured Data General Guidelines](https://developers.google.com/search/docs/appearance/structured-data/sd-policies)
 treat publisher impersonation as a policy violation enforced manually after
 crawl, not a markup-level check). The unearned-authority surface for agents is
-the same one already established for `json-ld-sanitize` and `meta-injection-strip`
-— structured data the human reviewer does not see but the agent ingests as a
-"trusted summary." Wu et al.,
+the same one already established for `json-ld-sanitize` and
+`meta-injection-strip` — structured data the human reviewer does not see but the
+agent ingests as a "trusted summary." Wu et al.,
 [*WIPI*](https://arxiv.org/abs/2402.16965), and Liao et al.,
 [*EIA: Environmental Injection Attack on Generalist Web Agents*](https://arxiv.org/abs/2409.11295)
-(ICLR 2025), both document agents acting on page metadata that has no
-visible counterpart.
+(ICLR 2025), both document agents acting on page metadata that has no visible
+counterpart.
 
 ## Dark-pattern blocking
 

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -406,6 +406,42 @@ Motivated by Roesner & Kohlbrenner,
 (ICLR 2026 Workshop), which shows that agents willing to read cross-origin frame
 content turn the same-origin policy from a hard guarantee into a soft one.
 
+### Sanitize Schema Trust Claims (Experimental)
+
+- **ID:** `schema-trust-sanitize`
+- **Default:** off
+
+Walk JSON-LD blocks and microdata items for schema.org `Organization`-typed
+claims — `Article.publisher`, `Article.sourceOrganization`, `ClaimReview.author`,
+and top-level brand assertions — and blank the `name`, `url`, and `@id` fields
+when the claim's `url` resolves to a different
+[registrable domain](https://publicsuffix.org/) than the page asserting it.
+Structural fields (`@type`, `logo`, `datePublished`, `price`, `ratingValue`) are
+preserved exactly, so an agent still gets the article's body data; it just
+loses the impersonating identity strings. `Person`-typed claims and
+name-only claims with no `url` to anchor against are out of scope and left
+alone. Off by default while we gather real-world signal on false positives;
+the rule short-circuits entirely on known syndicators (Google News, Yahoo News,
+MSN, Apple News, Flipboard, SmartNews, Feedly, Pocket), web archives,
+AMP cache, and Google Translate proxies, where mismatched publisher claims are
+expected.
+
+Schema.org has no native provenance mechanism — every claim is self-asserted,
+which is structurally why a page can list itself as published by The New York
+Times without any binding to that organization (Iliadis & Pedersen,
+[*One schema to rule them all*](https://asistdl.onlinelibrary.wiley.com/doi/10.1002/asi.24744),
+JASIST 2025; Google's own
+[Structured Data General Guidelines](https://developers.google.com/search/docs/appearance/structured-data/sd-policies)
+treat publisher impersonation as a policy violation enforced manually after
+crawl, not a markup-level check). The unearned-authority surface for agents is
+the same one already established for `json-ld-sanitize` and `meta-injection-strip`
+— structured data the human reviewer does not see but the agent ingests as a
+"trusted summary." Wu et al.,
+[*WIPI*](https://arxiv.org/abs/2402.16965), and Liao et al.,
+[*EIA: Environmental Injection Attack on Generalist Web Agents*](https://arxiv.org/abs/2409.11295)
+(ICLR 2025), both document agents acting on page metadata that has no
+visible counterpart.
+
 ## Dark-pattern blocking
 
 Block manipulative UI patterns that work on humans and can mislead agents the

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -29,6 +29,7 @@
     "search-url-helper": true,
     "roach-motel-annotate": true,
     "irrelevant-sections-redact": false,
-    "cross-origin-frame-redact": false
+    "cross-origin-frame-redact": false,
+    "schema-trust-sanitize": false
   }
 }

--- a/extension/src/lib/__tests__/schema-trust.test.ts
+++ b/extension/src/lib/__tests__/schema-trust.test.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import {
+  isAuthorityType,
+  isAuthorityUrlMismatch,
+  shouldSkipPage,
+  typeNames,
+} from "../schema-trust";
+
+describe("typeNames", () => {
+  it("handles a bare string @type", () => {
+    expect(typeNames("Organization")).toEqual(["Organization"]);
+  });
+
+  it("strips the schema.org IRI prefix", () => {
+    expect(typeNames("https://schema.org/NewsMediaOrganization")).toEqual([
+      "NewsMediaOrganization",
+    ]);
+  });
+
+  it("handles an array @type", () => {
+    expect(
+      typeNames(["Organization", "https://schema.org/Corporation"]),
+    ).toEqual(["Organization", "Corporation"]);
+  });
+
+  it("ignores non-string entries", () => {
+    expect(typeNames([null, 5, "Person"])).toEqual(["Person"]);
+  });
+
+  it("returns an empty list for undefined", () => {
+    expect(typeNames(undefined)).toEqual([]);
+  });
+});
+
+describe("isAuthorityType", () => {
+  it("matches Organization", () => {
+    expect(isAuthorityType("Organization")).toBe(true);
+  });
+
+  it("matches NewsMediaOrganization via the long-form IRI", () => {
+    expect(isAuthorityType("https://schema.org/NewsMediaOrganization")).toBe(
+      true,
+    );
+  });
+
+  it("does not match Person (out of scope for V1)", () => {
+    expect(isAuthorityType("Person")).toBe(false);
+  });
+
+  it("does not match Article", () => {
+    expect(isAuthorityType("Article")).toBe(false);
+  });
+});
+
+describe("shouldSkipPage", () => {
+  it("skips news aggregators", () => {
+    expect(shouldSkipPage("news.google.com")).toBe(true);
+    expect(shouldSkipPage("news.yahoo.com")).toBe(true);
+  });
+
+  it("skips AMP cache subdomains via suffix match", () => {
+    expect(shouldSkipPage("example-com.cdn.ampproject.org")).toBe(true);
+  });
+
+  it("skips Google Translate proxy domains", () => {
+    expect(shouldSkipPage("example-com.translate.goog")).toBe(true);
+  });
+
+  it("does not skip ordinary publisher hosts", () => {
+    expect(shouldSkipPage("nytimes.com")).toBe(false);
+    expect(shouldSkipPage("www.nytimes.com")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(shouldSkipPage("News.Google.com")).toBe(true);
+  });
+});
+
+describe("isAuthorityUrlMismatch", () => {
+  it("flags a different registrable domain", () => {
+    expect(
+      isAuthorityUrlMismatch(
+        "https://www.nytimes.com/about",
+        "randomspam.example",
+      ),
+    ).toBe(true);
+  });
+
+  it("allows matching registrable domains", () => {
+    expect(
+      isAuthorityUrlMismatch("https://www.nytimes.com/about", "nytimes.com"),
+    ).toBe(false);
+  });
+
+  it("allows subdomain claims that share the page RD", () => {
+    expect(
+      isAuthorityUrlMismatch("https://www.example.com", "blog.example.com"),
+    ).toBe(false);
+  });
+
+  it("returns false for unparseable claim URLs", () => {
+    expect(isAuthorityUrlMismatch("not a url", "example.com")).toBe(false);
+  });
+
+  it("returns false for non-http schemes", () => {
+    expect(
+      isAuthorityUrlMismatch("mailto:editor@evil.example", "example.com"),
+    ).toBe(false);
+  });
+
+  it("returns false when either RD is unresolvable (fails closed)", () => {
+    expect(isAuthorityUrlMismatch("https://localhost/about", "localhost")).toBe(
+      false,
+    );
+  });
+});

--- a/extension/src/lib/schema-trust.ts
+++ b/extension/src/lib/schema-trust.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Shared primitives for verifying schema.org authority claims (the
+// `Organization`-typed nodes that show up as `Article.publisher`,
+// `Article.sourceOrganization`, `ClaimReview.author`, or as a top-level
+// brand assertion). Both the JSON-LD and microdata extraction paths
+// converge on the same question — does the URL the claim provides live
+// on the same registrable domain as the page asserting it? — and on the
+// same sanitize action (blank `name`, `url`, `@id`).
+
+import { registrableDomain } from "./domain-trust";
+
+// Schema.org @type values we treat as carrying organizational authority.
+// `Person` is intentionally excluded: legitimate guest authors and
+// outside contributors routinely link to personal sites, so a
+// cross-domain `author.url` is too noisy to act on in V1. The
+// `Organization` subtypes we list here are the ones we see in real-world
+// publisher / sourceOrganization / ClaimReview.author markup.
+//
+// Match is by substring on the bare type name so a `@type` of
+// `"https://schema.org/NewsMediaOrganization"` (the long-form IRI form)
+// is treated the same as the bare `"NewsMediaOrganization"`.
+export const AUTHORITY_TYPES: ReadonlySet<string> = new Set([
+  "Organization",
+  "NewsMediaOrganization",
+  "OnlineBusiness",
+  "EducationalOrganization",
+  "GovernmentOrganization",
+  "Corporation",
+  "NGO",
+  "MediaOrganization",
+]);
+
+// Fields to blank on an authority object whose URL doesn't match the
+// page. The agent still sees the structural shape of the claim
+// (`@type: Organization`), it just loses the impersonating identity
+// strings.
+export const SANITIZE_KEYS: readonly string[] = ["name", "url", "@id"];
+
+// Page hosts where mismatched publisher claims are expected, not
+// suspicious — aggregators, AMP caches, web archives, reader-mode
+// proxies. The rule short-circuits entirely when the page is on one of
+// these, leaving every authority claim alone. Suffix matches are
+// expressed with a leading dot so `googleusercontent.com` matches both
+// `lh3.googleusercontent.com` and the bare apex.
+//
+// Kept small and hand-curated; a longer list belongs in a generated
+// data file once we have real-world telemetry to drive selection.
+const SKIP_EXACT_HOSTS: ReadonlySet<string> = new Set([
+  "news.google.com",
+  "news.yahoo.com",
+  "news.msn.com",
+  "flipboard.com",
+  "smartnews.com",
+  "apple.news",
+  "web.archive.org",
+  "archive.today",
+  "archive.ph",
+  "feedly.com",
+  "getpocket.com",
+]);
+
+const SKIP_HOST_SUFFIXES: readonly string[] = [
+  ".cdn.ampproject.org",
+  ".translate.goog",
+];
+
+export function shouldSkipPage(pageHost: string): boolean {
+  const host = pageHost.toLowerCase();
+  if (SKIP_EXACT_HOSTS.has(host)) {
+    return true;
+  }
+  return SKIP_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix));
+}
+
+// Normalize a `@type` value (string or array of strings, with optional
+// `https://schema.org/` IRI prefix) into the set of bare type names.
+export function typeNames(rawType: unknown): string[] {
+  const values = Array.isArray(rawType) ? rawType : [rawType];
+  const out: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const slash = value.lastIndexOf("/");
+    out.push(slash === -1 ? value : value.slice(slash + 1));
+  }
+  return out;
+}
+
+export function isAuthorityType(rawType: unknown): boolean {
+  return typeNames(rawType).some((name) => AUTHORITY_TYPES.has(name));
+}
+
+// True iff `claimUrl` resolves to a different registrable domain than
+// `pageHost`. Returns false (no mismatch) when either side can't be
+// parsed — we'd rather under-sanitize than blank fields based on a
+// guess.
+export function isAuthorityUrlMismatch(
+  claimUrl: string,
+  pageHost: string,
+): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(claimUrl);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return false;
+  }
+  const claimRD = registrableDomain(parsed.hostname);
+  const pageRD = registrableDomain(pageHost);
+  if (claimRD === null || pageRD === null) {
+    return false;
+  }
+  return claimRD !== pageRD;
+}

--- a/extension/src/rules/__tests__/schema-trust-sanitize-skip.test.ts
+++ b/extension/src/rules/__tests__/schema-trust-sanitize-skip.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://news.google.com/articles/abc"}
+ */
+
+// Separate file so the jsdom URL — and therefore location.hostname —
+// can be set declaratively. The page host is `news.google.com`, which is
+// on the rule's syndicator skip list; mismatched publisher claims on
+// aggregator pages are expected, not suspicious.
+
+import { schemaTrustSanitizeRule } from "../schema-trust-sanitize";
+
+afterEach(() => {
+  schemaTrustSanitizeRule.teardown();
+  document.body.innerHTML = "";
+  document.head.innerHTML = "";
+});
+
+it("leaves a mismatched publisher claim alone when the page host is a known syndicator", () => {
+  const script = document.createElement("script");
+  script.setAttribute("type", "application/ld+json");
+  script.textContent = JSON.stringify({
+    "@type": "Article",
+    publisher: {
+      "@type": "NewsMediaOrganization",
+      name: "The New York Times",
+      url: "https://www.nytimes.com",
+    },
+  });
+  document.head.append(script);
+  const before = script.textContent;
+
+  schemaTrustSanitizeRule.apply(document);
+
+  expect(script.textContent).toBe(before);
+});

--- a/extension/src/rules/__tests__/schema-trust-sanitize.test.ts
+++ b/extension/src/rules/__tests__/schema-trust-sanitize.test.ts
@@ -1,0 +1,276 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://attacker.example/article"}
+ */
+import { schemaTrustSanitizeRule } from "../schema-trust-sanitize";
+
+const MUTATION_THROTTLE_MS = 250;
+
+async function flushMutations(): Promise<void> {
+  await Promise.resolve();
+}
+
+function jsonLdScript(json: unknown): HTMLScriptElement {
+  const script = document.createElement("script");
+  script.setAttribute("type", "application/ld+json");
+  script.textContent = JSON.stringify(json);
+  return script;
+}
+
+function parseScript(script: HTMLScriptElement): unknown {
+  return JSON.parse(script.textContent);
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.head.innerHTML = "";
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  schemaTrustSanitizeRule.teardown();
+  jest.useRealTimers();
+});
+
+describe("JSON-LD path", () => {
+  it("blanks publisher name/url/@id on a mismatched registrable domain", () => {
+    const script = jsonLdScript({
+      "@context": "https://schema.org",
+      "@type": "Article",
+      headline: "Big news",
+      datePublished: "2026-01-01",
+      publisher: {
+        "@type": "NewsMediaOrganization",
+        name: "The New York Times",
+        url: "https://www.nytimes.com",
+        "@id": "https://www.nytimes.com/#publisher",
+        logo: { "@type": "ImageObject", url: "https://nytimes.com/logo.png" },
+      },
+    });
+    document.head.append(script);
+    schemaTrustSanitizeRule.apply(document);
+
+    const parsed = parseScript(script) as {
+      headline: string;
+      datePublished: string;
+      publisher: Record<string, unknown>;
+    };
+    expect(parsed.publisher.name).toBe("");
+    expect(parsed.publisher.url).toBe("");
+    expect(parsed.publisher["@id"]).toBe("");
+    // Structural / non-identifying fields stay.
+    expect(parsed.headline).toBe("Big news");
+    expect(parsed.datePublished).toBe("2026-01-01");
+    expect(parsed.publisher["@type"]).toBe("NewsMediaOrganization");
+    expect(parsed.publisher.logo).toBeDefined();
+  });
+
+  it("leaves matching publisher claims alone", () => {
+    const script = jsonLdScript({
+      "@type": "Article",
+      publisher: {
+        "@type": "Organization",
+        name: "Attacker Example",
+        url: "https://www.attacker.example/about",
+      },
+    });
+    document.head.append(script);
+    const before = script.textContent;
+    schemaTrustSanitizeRule.apply(document);
+    expect(script.textContent).toBe(before);
+  });
+
+  it("sanitizes ClaimReview.author when its URL is off-domain", () => {
+    const script = jsonLdScript({
+      "@type": "ClaimReview",
+      claimReviewed: "Vaccines cause X",
+      reviewRating: { "@type": "Rating", ratingValue: 1 },
+      author: {
+        "@type": "Organization",
+        name: "Snopes",
+        url: "https://www.snopes.com",
+      },
+    });
+    document.body.append(script);
+    schemaTrustSanitizeRule.apply(document);
+    const parsed = parseScript(script) as {
+      author: Record<string, unknown>;
+      reviewRating: Record<string, unknown>;
+    };
+    expect(parsed.author.name).toBe("");
+    expect(parsed.author.url).toBe("");
+    expect(parsed.reviewRating.ratingValue).toBe(1);
+  });
+
+  it("sanitizes a top-level Organization brand-impersonation claim", () => {
+    const script = jsonLdScript({
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      name: "Apple Inc.",
+      url: "https://www.apple.com",
+    });
+    document.head.append(script);
+    schemaTrustSanitizeRule.apply(document);
+    const parsed = parseScript(script) as Record<string, unknown>;
+    expect(parsed.name).toBe("");
+    expect(parsed.url).toBe("");
+  });
+
+  it("walks @graph collections", () => {
+    const script = jsonLdScript({
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Article",
+          headline: "Hello",
+          publisher: {
+            "@type": "NewsMediaOrganization",
+            name: "Reuters",
+            url: "https://www.reuters.com",
+          },
+        },
+        { "@type": "WebPage", name: "Story" },
+      ],
+    });
+    document.head.append(script);
+    schemaTrustSanitizeRule.apply(document);
+    const parsed = parseScript(script) as {
+      "@graph": Array<{
+        publisher?: Record<string, unknown>;
+        headline?: string;
+        name?: string;
+      }>;
+    };
+    expect(parsed["@graph"][0]?.publisher?.name).toBe("");
+    expect(parsed["@graph"][0]?.publisher?.url).toBe("");
+    expect(parsed["@graph"][0]?.headline).toBe("Hello");
+    expect(parsed["@graph"][1]?.name).toBe("Story");
+  });
+
+  it("does not touch Person.author (out of V1 scope)", () => {
+    const script = jsonLdScript({
+      "@type": "Article",
+      author: {
+        "@type": "Person",
+        name: "Jane Doe",
+        url: "https://janedoe.example/bio",
+      },
+    });
+    document.head.append(script);
+    const before = script.textContent;
+    schemaTrustSanitizeRule.apply(document);
+    expect(script.textContent).toBe(before);
+  });
+
+  it("does nothing when the Organization claim has no URL anchor", () => {
+    const script = jsonLdScript({
+      "@type": "Article",
+      publisher: {
+        "@type": "Organization",
+        name: "The New York Times",
+      },
+    });
+    document.head.append(script);
+    const before = script.textContent;
+    schemaTrustSanitizeRule.apply(document);
+    expect(script.textContent).toBe(before);
+  });
+
+  it("leaves malformed JSON-LD alone", () => {
+    const script = document.createElement("script");
+    script.setAttribute("type", "application/ld+json");
+    script.textContent = "{ not really json";
+    document.head.append(script);
+    schemaTrustSanitizeRule.apply(document);
+    expect(script.textContent).toBe("{ not really json");
+  });
+
+  it("sanitizes JSON-LD scripts inserted after apply via the watcher", async () => {
+    schemaTrustSanitizeRule.apply(document);
+    const script = jsonLdScript({
+      "@type": "Article",
+      publisher: {
+        "@type": "Organization",
+        name: "BBC",
+        url: "https://www.bbc.co.uk",
+      },
+    });
+    document.body.append(script);
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+    const parsed = parseScript(script) as {
+      publisher: Record<string, unknown>;
+    };
+    expect(parsed.publisher.name).toBe("");
+  });
+});
+
+describe("microdata path", () => {
+  it("blanks publisher name/url/itemid on a mismatched item", () => {
+    document.body.innerHTML = `
+      <article itemscope itemtype="https://schema.org/Article">
+        <h1 itemprop="headline">Big news</h1>
+        <div itemprop="publisher" itemscope itemtype="https://schema.org/NewsMediaOrganization" itemid="https://www.nytimes.com/#publisher">
+          <meta itemprop="name" content="The New York Times">
+          <link itemprop="url" href="https://www.nytimes.com">
+        </div>
+      </article>
+    `;
+    schemaTrustSanitizeRule.apply(document.body);
+
+    const publisher = document.querySelector('[itemprop="publisher"]');
+    expect(publisher?.getAttribute("itemid")).toBe("");
+    expect(
+      publisher?.querySelector('[itemprop="name"]')?.getAttribute("content"),
+    ).toBe("");
+    expect(
+      publisher?.querySelector('[itemprop="url"]')?.getAttribute("href"),
+    ).toBe("");
+    expect(document.querySelector('[itemprop="headline"]')?.textContent).toBe(
+      "Big news",
+    );
+  });
+
+  it("leaves microdata items with matching URLs alone", () => {
+    document.body.innerHTML = `
+      <div itemscope itemtype="https://schema.org/Organization">
+        <span itemprop="name">Attacker Example</span>
+        <link itemprop="url" href="https://www.attacker.example/">
+      </div>
+    `;
+    const before = document.body.innerHTML;
+    schemaTrustSanitizeRule.apply(document.body);
+    expect(document.body.innerHTML).toBe(before);
+  });
+
+  it("blanks textContent of a span carrying the name", () => {
+    document.body.innerHTML = `
+      <div itemscope itemtype="https://schema.org/Organization">
+        <span itemprop="name">Reuters</span>
+        <a itemprop="url" href="https://www.reuters.com">site</a>
+      </div>
+    `;
+    schemaTrustSanitizeRule.apply(document.body);
+    expect(document.querySelector('[itemprop="name"]')?.textContent).toBe("");
+    expect(
+      document.querySelector('[itemprop="url"]')?.getAttribute("href"),
+    ).toBe("");
+  });
+
+  it("does not descend into nested itemscope when reading the item's own URL", () => {
+    // The outer Organization has no scoped `url` itemprop of its own —
+    // the nested logo's url belongs to the ImageObject's scope and
+    // should not be borrowed as the Organization's claim URL.
+    document.body.innerHTML = `
+      <div itemscope itemtype="https://schema.org/Organization">
+        <span itemprop="name">Reuters</span>
+        <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
+          <link itemprop="url" href="https://www.reuters.com/logo.png">
+        </div>
+      </div>
+    `;
+    const before = document.body.innerHTML;
+    schemaTrustSanitizeRule.apply(document.body);
+    expect(document.body.innerHTML).toBe(before);
+  });
+});

--- a/extension/src/rules/index.ts
+++ b/extension/src/rules/index.ts
@@ -25,6 +25,7 @@ import { promptInjectionRedactRule } from "./prompt-injection-redact";
 import { reviewsRedactRule } from "./reviews-redact";
 import { roachMotelAnnotateRule } from "./roach-motel-annotate";
 import { scarcityRedactRule } from "./scarcity-redact";
+import { schemaTrustSanitizeRule } from "./schema-trust-sanitize";
 import { searchUrlHelperRule } from "./search-url-helper";
 import { secretsRedactRule } from "./secrets-redact";
 import { socialEmbedRedactRule } from "./social-embed-redact";
@@ -71,6 +72,7 @@ const RULES_TUPLE = [
   roachMotelAnnotateRule,
   irrelevantSectionsRedactRule,
   crossOriginFrameRedactRule,
+  schemaTrustSanitizeRule,
 ] as const satisfies readonly Rule[];
 
 export type RuleId = (typeof RULES_TUPLE)[number]["id"];

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -35,4 +35,5 @@ export const RULE_DEFAULTS: Readonly<Record<RuleId, boolean>> = {
   "roach-motel-annotate": true,
   "irrelevant-sections-redact": false,
   "cross-origin-frame-redact": false,
+  "schema-trust-sanitize": false,
 };

--- a/extension/src/rules/schema-trust-sanitize.ts
+++ b/extension/src/rules/schema-trust-sanitize.ts
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Sanitize schema.org Organization-typed claims whose `url` points to a
+// different registrable domain than the page asserting them. Covers
+// both `<script type="application/ld+json">` blocks and
+// `[itemtype]`-marked microdata. The unearned-authority case the rule
+// targets is a non-NYT page claiming `Article.publisher` is The New
+// York Times, a non-Snopes page claiming `ClaimReview.author` is
+// Snopes, or a top-level `@type: Organization` block on a domain that
+// has no relationship to the named entity.
+//
+// V1 scope is intentionally narrow: only `Organization` and its
+// subtypes, only when the claim object exposes a `url` field, only
+// matching at eTLD+1 (registrable domain). `Person.url` mismatches and
+// name-only claims with no `url` to anchor against are out — they're
+// noisier and need a brand allowlist to handle without false positives.
+//
+// Sanitize semantics: when a mismatch is detected we blank the
+// identifying string fields (`name`, `url`, `@id`) on the offending
+// object and leave the surrounding structure intact, so an agent still
+// receives the article's price / rating / headline / dates but loses
+// the impersonating identity. Pages on known syndicators, AMP caches,
+// archive proxies, and reader-mode hosts short-circuit the rule
+// entirely — mismatched publishers on those hosts are expected, not
+// suspicious.
+
+import {
+  isAuthorityType,
+  isAuthorityUrlMismatch,
+  SANITIZE_KEYS,
+  shouldSkipPage,
+} from "../lib/schema-trust";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import type { Rule } from "./types";
+
+const RULE_ID = "schema-trust-sanitize" as const;
+const JSON_LD_SELECTOR = 'script[type="application/ld+json" i]';
+const MICRODATA_SELECTOR = "[itemtype][itemscope]";
+
+function getPageHost(): string {
+  return globalThis.location.hostname;
+}
+
+// ---------- JSON-LD path ----------
+
+function extractClaimUrl(node: Record<string, unknown>): string | null {
+  const url = node.url;
+  if (typeof url === "string" && url !== "") {
+    return url;
+  }
+  const id = node["@id"];
+  if (typeof id === "string" && id !== "") {
+    return id;
+  }
+  return null;
+}
+
+function sanitizeAuthorityNode(
+  node: Record<string, unknown>,
+  mutated: { value: boolean },
+): void {
+  for (const key of SANITIZE_KEYS) {
+    if (key in node && node[key] !== "") {
+      node[key] = "";
+      mutated.value = true;
+    }
+  }
+}
+
+function walk(
+  value: unknown,
+  pageHost: string,
+  mutated: { value: boolean },
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      walk(item, pageHost, mutated);
+    }
+    return;
+  }
+  if (value === null || typeof value !== "object") {
+    return;
+  }
+  const node = value as Record<string, unknown>;
+  if (isAuthorityType(node["@type"])) {
+    const claimUrl = extractClaimUrl(node);
+    if (claimUrl !== null && isAuthorityUrlMismatch(claimUrl, pageHost)) {
+      sanitizeAuthorityNode(node, mutated);
+    }
+  }
+  for (const child of Object.values(node)) {
+    walk(child, pageHost, mutated);
+  }
+}
+
+function processScript(script: HTMLScriptElement, pageHost: string): void {
+  const raw = script.textContent;
+  if (raw.trim() === "") {
+    return;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  const mutated = { value: false };
+  walk(parsed, pageHost, mutated);
+  if (mutated.value) {
+    script.textContent = JSON.stringify(parsed);
+  }
+}
+
+// ---------- Microdata path ----------
+
+// Extract the bare schema.org type name (last URL segment) from an
+// `itemtype` attribute. `itemtype` is space-separated and can carry
+// multiple types per the HTML microdata spec.
+function microdataTypeNames(itemtype: string): string[] {
+  const out: string[] = [];
+  for (const token of itemtype.split(/\s+/)) {
+    if (token === "") {
+      continue;
+    }
+    const slash = token.lastIndexOf("/");
+    out.push(slash === -1 ? token : token.slice(slash + 1));
+  }
+  return out;
+}
+
+// Find the descendant `[itemprop=NAME]` that belongs to this item's
+// scope — i.e. is not nested inside a deeper `[itemscope]` first. The
+// microdata spec scopes itemprops to their nearest ancestor itemscope.
+function scopedDescendants(scope: Element, itempropName: string): Element[] {
+  const out: Element[] = [];
+  // Caller is the rule's internal code path; itempropName is one of a
+  // small, known set of literals (`name`, `url`, `@id`) — all safe to
+  // splice into a CSS attribute selector without escaping. The `~=`
+  // match handles elements that declare multiple itemprops in a single
+  // space-separated attribute.
+  for (const candidate of scope.querySelectorAll(
+    `[itemprop~="${itempropName}"]`,
+  )) {
+    if (candidate === scope) {
+      continue;
+    }
+    // Walk up to find the nearest itemscope ancestor; if it isn't us,
+    // the itemprop belongs to a nested scope.
+    let parent = candidate.parentElement;
+    let nearestScope: Element | null = null;
+    while (parent !== null) {
+      if (parent.hasAttribute("itemscope")) {
+        nearestScope = parent;
+        break;
+      }
+      parent = parent.parentElement;
+    }
+    if (nearestScope === scope) {
+      out.push(candidate);
+    }
+  }
+  return out;
+}
+
+function readItempropValue(element: Element): string {
+  // The microdata spec defines the itemprop value per element type:
+  // <meta> uses content, <a>/<link>/<area> use href, <img>/<audio>/etc.
+  // use src, <object> uses data, <time> uses datetime. We only need
+  // enough to read URL-shaped claims, so cover the common carriers and
+  // fall back to textContent.
+  const tag = element.tagName;
+  if (tag === "META") {
+    return element.getAttribute("content") ?? "";
+  }
+  if (tag === "A" || tag === "LINK" || tag === "AREA") {
+    return element.getAttribute("href") ?? "";
+  }
+  if (tag === "IMG" || tag === "AUDIO" || tag === "VIDEO" || tag === "SOURCE") {
+    return element.getAttribute("src") ?? "";
+  }
+  // `textContent` on an Element (not a Document or DocumentType) is
+  // always a string per the DOM spec; the lib.dom.d.ts `string | null`
+  // union is for the Node base type.
+  return element.textContent;
+}
+
+function blankItempropValue(element: Element): boolean {
+  const tag = element.tagName;
+  if (tag === "META") {
+    if (element.getAttribute("content") !== "") {
+      element.setAttribute("content", "");
+      return true;
+    }
+    return false;
+  }
+  if (tag === "A" || tag === "LINK" || tag === "AREA") {
+    if (element.getAttribute("href") !== "") {
+      element.setAttribute("href", "");
+      return true;
+    }
+    return false;
+  }
+  if (tag === "IMG" || tag === "AUDIO" || tag === "VIDEO" || tag === "SOURCE") {
+    if (element.getAttribute("src") !== "") {
+      element.setAttribute("src", "");
+      return true;
+    }
+    return false;
+  }
+  if (element.textContent !== "") {
+    element.textContent = "";
+    return true;
+  }
+  return false;
+}
+
+function processItem(item: Element, pageHost: string): void {
+  const itemtype = item.getAttribute("itemtype");
+  if (itemtype === null) {
+    return;
+  }
+  const types = microdataTypeNames(itemtype);
+  if (!types.some((name) => isAuthorityType(name))) {
+    return;
+  }
+  const urlElements = scopedDescendants(item, "url");
+  let claimUrl: string | null = null;
+  for (const element of urlElements) {
+    const value = readItempropValue(element).trim();
+    if (value !== "") {
+      claimUrl = value;
+      break;
+    }
+  }
+  if (claimUrl === null) {
+    // Fall back to itemid (microdata's @id-equivalent) if present.
+    const itemid = item.getAttribute("itemid");
+    if (itemid !== null && itemid !== "") {
+      claimUrl = itemid;
+    }
+  }
+  if (claimUrl === null || !isAuthorityUrlMismatch(claimUrl, pageHost)) {
+    return;
+  }
+  for (const key of SANITIZE_KEYS) {
+    // `@id` in microdata is the `itemid` attribute on the scope element.
+    if (key === "@id") {
+      if (item.getAttribute("itemid") !== null) {
+        item.setAttribute("itemid", "");
+      }
+      continue;
+    }
+    for (const element of scopedDescendants(item, key)) {
+      blankItempropValue(element);
+    }
+  }
+}
+
+// ---------- Rule plumbing ----------
+
+function processRoot(root: ParentNode): void {
+  const pageHost = getPageHost();
+  if (shouldSkipPage(pageHost)) {
+    return;
+  }
+  if (root.nodeType === Node.ELEMENT_NODE) {
+    const element = root as Element;
+    if (element.matches(JSON_LD_SELECTOR)) {
+      processScript(element as HTMLScriptElement, pageHost);
+      return;
+    }
+    if (element.matches(MICRODATA_SELECTOR)) {
+      processItem(element, pageHost);
+      // Continue into descendants — a top-level item can contain nested
+      // [itemscope] items that also need checking.
+    }
+  }
+  for (const script of root.querySelectorAll<HTMLScriptElement>(
+    JSON_LD_SELECTOR,
+  )) {
+    processScript(script, pageHost);
+  }
+  for (const item of root.querySelectorAll(MICRODATA_SELECTOR)) {
+    processItem(item, pageHost);
+  }
+}
+
+const watcher = createSubtreeWatcher({
+  onSubtrees: (roots) => {
+    for (const root of roots) {
+      processRoot(root);
+    }
+  },
+});
+
+function apply(root: ParentNode): void {
+  processRoot(root);
+  watcher.start(root);
+}
+
+export const schemaTrustSanitizeRule = {
+  id: RULE_ID,
+  label: "Sanitize Schema Trust Claims (Experimental)",
+  description:
+    "Blank schema.org Organization fields (name, url, @id) when the claim's URL is on a different registrable domain than the page. Defends against non-NYT pages asserting publisher = The New York Times, non-Snopes pages forging ClaimReview.author, and similar unearned-authority claims.",
+  apply,
+  teardown: () => {
+    watcher.stop();
+  },
+} satisfies Rule;


### PR DESCRIPTION
## Summary

New rule that blanks schema.org Organization claims (`publisher`, `sourceOrganization`, `ClaimReview.author`, top-level brand assertions) when the claimed `url` lives on a different registrable domain than the page. Defends against pages laundering trust by asserting publisher = The New York Times / brand = Apple / fact-checker = Snopes without any binding to those entities.

- **`extension/src/lib/schema-trust.ts`** — shared library: `AUTHORITY_TYPES`, `SANITIZE_KEYS`, hard-coded syndicator/AMP/archive skip list, `isAuthorityUrlMismatch(claimUrl, pageHost)` built on the existing `domain-trust` PSL helper.
- **`extension/src/rules/schema-trust-sanitize.ts`** — one rule, two extraction paths (JSON-LD + microdata). Blanks `name`, `url`, `@id` (and microdata's `itemid`) on the offending claim; preserves `@type`, `logo`, `datePublished`, `price`, `ratingValue`, etc.
- Registered in `RULES_TUPLE`, default `false` in `rule-defaults.json`.
- Docs entry under *Prompt-injection defense* alongside `cross-origin-frame-redact` (the other Experimental / default-off rule), citing Iliadis 2025, WIPI, and EIA.

## V1 scope decisions (locked in earlier in design)

| Question | Answer |
|---|---|
| Verb | `sanitize` (blank fields, keep structure) |
| JSON-LD + microdata | One rule, shared lib |
| Fields | URL-anchored only — `Person.url` and name-only claims out |
| Skip list | Hard-coded in source (~13 hosts + 2 suffix patterns) |
| Default | Off |

The harder cases — name-only `publisher: "Reuters"` claims, `Person.url` mismatches, brand allowlist — are deliberately out of V1.

## Test plan

- [x] `bun run preflight` clean (908 / 908 tests pass, biome + eslint + typecheck + knip + coverage)
- [x] 20 unit tests on `lib/schema-trust.ts` (type normalization, skip-list match, RD mismatch logic)
- [x] 14 rule tests covering JSON-LD: publisher mismatch / match, ClaimReview.author, top-level Organization, `@graph` collections, Person out-of-scope, no-URL-anchor case, malformed JSON, late-arriving scripts via the subtree watcher
- [x] 3 rule tests covering microdata: publisher mismatch / match, `<span itemprop="name">`, scoped descendants (nested `itemscope` not borrowed)
- [x] 1 rule test confirming syndicator-host short-circuit (in a separate file with its own `@jest-environment-options` URL)

## What's NOT in this PR

- Name-only claim handling (needs a brand allowlist — Layer 3, future work)
- `Person.url` checks (FP-noisy without a guest-author signal)
- Telemetry to drive default-on promotion (we'll gather it through user enabling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)