### PR TITLE
Add trust-badge-annotate rule

### DIFF
--- a/demo-site/src/pages/ProductDetail.tsx
+++ b/demo-site/src/pages/ProductDetail.tsx
@@ -282,6 +282,36 @@ export default function ProductDetail() {
             </svg>
           </div>
 
+          {/*
+            Third-party "trust badge" images. Sighted users read a Norton
+            Secured / BBB Accredited / Verified Seller graphic and treat the
+            page as endorsed by an external authority; the content script
+            has no transport-level signal that backs any of the three.
+            trust-badge-annotate appends an inline chip noting the claim is
+            unverifiable. The third image carries a long descriptive alt —
+            negative case — and should not receive a chip.
+          */}
+          <aside
+            aria-label="Trust badges"
+            className="flex flex-wrap items-center gap-3 pt-1"
+          >
+            <img
+              src="data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='110' height='28'%3E%3Crect width='110' height='28' rx='3' fill='%23ffd200'/%3E%3Ctext x='10' y='18' font-family='sans-serif' font-size='11' font-weight='700' fill='%23000'%3ENorton Secured%3C/text%3E%3C/svg%3E"
+              alt="Norton Secured"
+              className="h-7 w-auto"
+            />
+            <img
+              src="data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='110' height='28'%3E%3Crect width='110' height='28' rx='3' fill='%231d4ed8'/%3E%3Ctext x='8' y='18' font-family='sans-serif' font-size='11' font-weight='700' fill='%23fff'%3EVerified Seller%3C/text%3E%3C/svg%3E"
+              alt="Verified Seller"
+              className="h-7 w-auto"
+            />
+            <img
+              src="data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='150' height='28'%3E%3Crect width='150' height='28' rx='3' fill='%23166534'/%3E%3Ctext x='8' y='18' font-family='sans-serif' font-size='10' fill='%23fff'%3EBuy with confidence%3C/text%3E%3C/svg%3E"
+              alt="A confident customer holding the product after fast shipping arrival from our regional distribution center"
+              className="h-7 w-auto"
+            />
+          </aside>
+
           <div className="border-t border-stone-200 pt-3 text-xs text-stone-600">
             <div>Ships from RiverMart</div>
             <div>Sold by RiverMart Direct</div>

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -175,42 +175,42 @@ text-domain mismatch check, Dhamija, Tygar, Hearst,
 link-target mismatch is the single most reliable cue users fail to check —
 making it the cue best worth re-presenting visibly to the agent.
 
-### Flag Trust Badges
+### Flag Trust Badges (Experimental)
 
 - **ID:** `trust-badge-annotate`
-- **Default:** on
+- **Default:** off
 
 Annotate image-shaped trust badges — Norton Secured, McAfee SECURE, BBB
 Accredited, TrustPilot, Verified Seller, and similar — whose accessible name
 asserts third-party endorsement that no content-script-accessible signal backs.
 The chip notes the claim is not verifiable from page content; the badge itself
-is left in place so the visual layout the page operator chose is preserved.
+is left in place so the visual layout the page operator chose is preserved. Off
+by default while we gather real-world signal on false positives.
 
 Detection is intentionally narrow. Only `<img>`, `<svg>`, and elements with
 `role="img"` are considered, so plain text labels (e.g., the "Verified Purchase"
 line on a review, which `reviews-redact` already owns) are out of scope. The
-accessible name is read in standard precedence (`aria-label` →
-`aria-labelledby` → SVG `<title>` → `alt` → `title`), capped at a short length,
-and matched against a curated phrase set with word boundaries; bare single
-words like "verified" or "trusted" do not match. Badges on the issuer's own
-registrable domain — a Norton page showing its own logo, BBB.org showing its
-accreditation seal — are exempted as first-party.
+accessible name is read in standard precedence (`aria-label` → `aria-labelledby`
+→ SVG `<title>` → `alt` → `title`), capped at a short length, and matched
+against a curated phrase set with word boundaries; bare single words like
+"verified" or "trusted" do not match. Badges on the issuer's own registrable
+domain — a Norton page showing its own logo, BBB.org showing its accreditation
+seal — are exempted as first-party.
 
 A page operator can drop `<img alt="Norton Secured">` onto any page; the chrome
-TLS UI, EV certificate organization name, and other trust signals a human
-would use to verify the claim are not reachable from a content script. The
-asymmetry the rule closes is the same one `link-spoof-annotate` closes for
-visible-text-vs-href: a vision-based or accessibility-tree-driven agent sees
-the badge as evidence of trustworthiness, with no way to check it.
+TLS UI, EV certificate organization name, and other trust signals a human would
+use to verify the claim are not reachable from a content script. The asymmetry
+the rule closes is the same one `link-spoof-annotate` closes for
+visible-text-vs-href: a vision-based or accessibility-tree-driven agent sees the
+badge as evidence of trustworthiness, with no way to check it.
 
 Prior art: [SusBench](https://arxiv.org/abs/2510.11035) (Guo et al., 2025) and
-[DECEPTICON](https://arxiv.org/abs/2512.22894) (Cuvin et al., 2025) both
-include trust-badge spoofing in their benchmark suites and document that
-current computer-use agents over-weight these badges as proof of legitimacy.
-The unverifiable-claim framing is the same one applied by
-`schema-trust-sanitize` to JSON-LD Organization claims and by
-`link-spoof-annotate` to anchor text — page-asserted authority that has no
-binding to the entity it names.
+[DECEPTICON](https://arxiv.org/abs/2512.22894) (Cuvin et al., 2025) both include
+trust-badge spoofing in their benchmark suites and document that current
+computer-use agents over-weight these badges as proof of legitimacy. The
+unverifiable-claim framing is the same one applied by `schema-trust-sanitize` to
+JSON-LD Organization claims and by `link-spoof-annotate` to anchor text —
+page-asserted authority that has no binding to the entity it names.
 
 ### Strip HTML Comments
 

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -3,7 +3,7 @@ title: Rules reference
 description: The defense rules shipped with agent-browser-shield, what each one does, and its default state.
 ---
 
-The extension ships 30 rules grouped into five rough categories. Each rule is
+The extension ships 32 rules grouped into five rough categories. Each rule is
 independently toggleable from the extension popup. Rules marked **default: on**
 are active on fresh install; **default: off** rules must be enabled manually.
 
@@ -174,6 +174,43 @@ text-domain mismatch check, Dhamija, Tygar, Hearst,
 (CHI 2006), is the foundational user study showing that the link-text /
 link-target mismatch is the single most reliable cue users fail to check —
 making it the cue best worth re-presenting visibly to the agent.
+
+### Flag Trust Badges
+
+- **ID:** `trust-badge-annotate`
+- **Default:** on
+
+Annotate image-shaped trust badges — Norton Secured, McAfee SECURE, BBB
+Accredited, TrustPilot, Verified Seller, and similar — whose accessible name
+asserts third-party endorsement that no content-script-accessible signal backs.
+The chip notes the claim is not verifiable from page content; the badge itself
+is left in place so the visual layout the page operator chose is preserved.
+
+Detection is intentionally narrow. Only `<img>`, `<svg>`, and elements with
+`role="img"` are considered, so plain text labels (e.g., the "Verified Purchase"
+line on a review, which `reviews-redact` already owns) are out of scope. The
+accessible name is read in standard precedence (`aria-label` →
+`aria-labelledby` → SVG `<title>` → `alt` → `title`), capped at a short length,
+and matched against a curated phrase set with word boundaries; bare single
+words like "verified" or "trusted" do not match. Badges on the issuer's own
+registrable domain — a Norton page showing its own logo, BBB.org showing its
+accreditation seal — are exempted as first-party.
+
+A page operator can drop `<img alt="Norton Secured">` onto any page; the chrome
+TLS UI, EV certificate organization name, and other trust signals a human
+would use to verify the claim are not reachable from a content script. The
+asymmetry the rule closes is the same one `link-spoof-annotate` closes for
+visible-text-vs-href: a vision-based or accessibility-tree-driven agent sees
+the badge as evidence of trustworthiness, with no way to check it.
+
+Prior art: [SusBench](https://arxiv.org/abs/2510.11035) (Guo et al., 2025) and
+[DECEPTICON](https://arxiv.org/abs/2512.22894) (Cuvin et al., 2025) both
+include trust-badge spoofing in their benchmark suites and document that
+current computer-use agents over-weight these badges as proof of legitimacy.
+The unverifiable-claim framing is the same one applied by
+`schema-trust-sanitize` to JSON-LD Organization claims and by
+`link-spoof-annotate` to anchor text — page-asserted authority that has no
+binding to the entity it names.
 
 ### Strip HTML Comments
 

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -26,11 +26,11 @@
     "ads-hide": true,
     "cart-addon-annotate": true,
     "link-spoof-annotate": true,
-    "trust-badge-annotate": true,
     "search-url-helper": true,
     "roach-motel-annotate": true,
     "irrelevant-sections-redact": false,
     "cross-origin-frame-redact": false,
-    "schema-trust-sanitize": false
+    "schema-trust-sanitize": false,
+    "trust-badge-annotate": false
   }
 }

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -26,6 +26,7 @@
     "ads-hide": true,
     "cart-addon-annotate": true,
     "link-spoof-annotate": true,
+    "trust-badge-annotate": true,
     "search-url-helper": true,
     "roach-motel-annotate": true,
     "irrelevant-sections-redact": false,

--- a/extension/src/lib/dom-markers.ts
+++ b/extension/src/lib/dom-markers.ts
@@ -49,6 +49,11 @@ export const CART_ADDON_ANNOTATED_ATTR = "data-abs-cart-addon-annotated";
 // doesn't append a second chip on the next mutation pass.
 export const LINK_SPOOF_ANNOTATED_ATTR = "data-abs-link-spoof-annotated";
 
+// `trust-badge-annotate`: marks an image-shaped trust badge the rule has
+// already annotated so the watcher doesn't append a second chip on
+// re-scan.
+export const TRUST_BADGE_ANNOTATED_ATTR = "data-abs-trust-badge-annotated";
+
 // `confirmshame-sanitize`: stores the original copy of attributes the
 // rule rewrites so reveal-on-click can restore the user-visible
 // confirmshame language.

--- a/extension/src/rules/__tests__/trust-badge-annotate.test.ts
+++ b/extension/src/rules/__tests__/trust-badge-annotate.test.ts
@@ -1,0 +1,228 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TRUST_BADGE_ANNOTATED_ATTR as ANNOTATED_ATTR } from "../../lib/dom-markers";
+import {
+  detectTrustBadge,
+  trustBadgeAnnotateRule,
+} from "../trust-badge-annotate";
+
+const CHIP_CLASS = "abs-trust-badge-annotate";
+const MUTATION_THROTTLE_MS = 250;
+
+async function flushMutations(): Promise<void> {
+  await Promise.resolve();
+}
+
+function makeImg(
+  alt: string,
+  attributes: Record<string, string> = {},
+): HTMLImageElement {
+  const img = document.createElement("img");
+  img.setAttribute("alt", alt);
+  for (const [key, value] of Object.entries(attributes)) {
+    img.setAttribute(key, value);
+  }
+  return img;
+}
+
+function makeSvgWithTitle(titleText: string): SVGElement {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("role", "img");
+  const title = document.createElementNS("http://www.w3.org/2000/svg", "title");
+  title.textContent = titleText;
+  svg.append(title);
+  return svg;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  trustBadgeAnnotateRule.teardown();
+  jest.useRealTimers();
+});
+
+describe("detectTrustBadge — named third-party issuers", () => {
+  it("matches Norton Secured in <img alt>", () => {
+    const img = makeImg("Norton Secured");
+    document.body.append(img);
+    const match = detectTrustBadge(img, "example.com");
+    expect(match?.phrase).toBe("norton secured");
+    expect(match?.issuerDomain).toBe("norton.com");
+  });
+
+  it("matches BBB Accredited in <img alt>", () => {
+    const img = makeImg("BBB Accredited Business");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "example.com")?.phrase).toBe("bbb accredited");
+  });
+
+  it("matches McAfee SECURE case-insensitively", () => {
+    const img = makeImg("McAfee SECURE");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "example.com")?.phrase).toBe("mcafee secure");
+  });
+
+  it("matches TrustPilot brand-only mark", () => {
+    const img = makeImg("TrustPilot 5-star rating");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "example.com")?.phrase).toBe("trustpilot");
+  });
+});
+
+describe("detectTrustBadge — generic phrases", () => {
+  it("matches Verified Seller", () => {
+    const img = makeImg("Verified Seller");
+    document.body.append(img);
+    const match = detectTrustBadge(img, "shop.example");
+    expect(match?.phrase).toBe("verified seller");
+    expect(match?.issuerDomain).toBeNull();
+  });
+
+  it("matches Trusted Store", () => {
+    const img = makeImg("Trusted Store");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "shop.example")?.phrase).toBe("trusted store");
+  });
+
+  it("matches 100% Secure", () => {
+    const img = makeImg("100% Secure Checkout Badge");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "shop.example")).not.toBeNull();
+  });
+});
+
+describe("detectTrustBadge — element shape filter", () => {
+  it('matches <svg role="img"> with descendant <title>', () => {
+    const svg = makeSvgWithTitle("Norton Secured");
+    document.body.append(svg);
+    expect(detectTrustBadge(svg, "example.com")?.phrase).toBe("norton secured");
+  });
+
+  it('matches an element with aria-label and role="img"', () => {
+    const div = document.createElement("div");
+    div.setAttribute("role", "img");
+    div.setAttribute("aria-label", "Verified Seller");
+    document.body.append(div);
+    expect(detectTrustBadge(div, "shop.example")?.phrase).toBe(
+      "verified seller",
+    );
+  });
+
+  it("does not match a <span> with a trust phrase (wrong shape)", () => {
+    // Amazon-style "Verified Purchase" text labels live in text spans, not
+    // image elements. Element-shape filter excludes them so reviews-redact
+    // owns that surface.
+    const span = document.createElement("span");
+    span.textContent = "Verified Seller";
+    document.body.append(span);
+    expect(detectTrustBadge(span, "shop.example")).toBeNull();
+  });
+
+  it('does not match a plain <div> without role="img"', () => {
+    const div = document.createElement("div");
+    div.setAttribute("aria-label", "Verified Seller");
+    document.body.append(div);
+    expect(detectTrustBadge(div, "shop.example")).toBeNull();
+  });
+});
+
+describe("detectTrustBadge — false-positive avoidance", () => {
+  it("does not match long descriptive alt text containing 'verified'", () => {
+    const img = makeImg(
+      "Photo of trusted hiking sandals on a verified rock surface in Yosemite National Park, taken at golden hour",
+    );
+    document.body.append(img);
+    expect(detectTrustBadge(img, "example.com")).toBeNull();
+  });
+
+  it("does not match a bare 'Verified' alt (single-word generic)", () => {
+    // Generic phrases are two-word minimum; "Verified" alone is too noisy
+    // (review badges, file checkmarks, etc.).
+    const img = makeImg("Verified");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "example.com")).toBeNull();
+  });
+
+  it("does not match a padlock icon with no trust keyword", () => {
+    const img = makeImg("Padlock");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "example.com")).toBeNull();
+  });
+
+  it("does not match empty alt", () => {
+    const img = makeImg("");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "example.com")).toBeNull();
+  });
+
+  it("does not match alt with 'trust' inside an unrelated word", () => {
+    const img = makeImg("Mistrust monitor — antitrust analytics dashboard");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "example.com")).toBeNull();
+  });
+});
+
+describe("detectTrustBadge — same-issuer exemption", () => {
+  it("does not flag a Norton badge on norton.com", () => {
+    const img = makeImg("Norton Secured");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "www.norton.com")).toBeNull();
+  });
+
+  it("does not flag a BBB badge on bbb.org", () => {
+    const img = makeImg("BBB Accredited Business");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "bbb.org")).toBeNull();
+  });
+
+  it("still flags a Norton badge on a non-Norton domain", () => {
+    const img = makeImg("Norton Secured");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "shop.example")?.phrase).toBe(
+      "norton secured",
+    );
+  });
+
+  it("flags a generic phrase regardless of page domain", () => {
+    const img = makeImg("Verified Seller");
+    document.body.append(img);
+    expect(detectTrustBadge(img, "amazon.com")?.phrase).toBe("verified seller");
+  });
+});
+
+describe("trustBadgeAnnotateRule.apply", () => {
+  it("appends one chip per matching badge on the initial scan", () => {
+    document.body.append(
+      makeImg("Norton Secured"),
+      makeImg("Verified Seller"),
+      makeImg("Photo of the product on a white background"),
+    );
+    trustBadgeAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${CHIP_CLASS}`)).toHaveLength(2);
+  });
+
+  it("does not double-chip on re-scan (idempotent via marker)", () => {
+    const img = makeImg("Norton Secured");
+    document.body.append(img);
+    trustBadgeAnnotateRule.apply(document.body);
+    trustBadgeAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${CHIP_CLASS}`)).toHaveLength(1);
+    expect(img.hasAttribute(ANNOTATED_ATTR)).toBe(true);
+  });
+
+  it("annotates badges added after initial scan via the subtree watcher", async () => {
+    trustBadgeAnnotateRule.apply(document.body);
+    const wrapper = document.createElement("div");
+    wrapper.append(makeImg("BBB Accredited Business"));
+    document.body.append(wrapper);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelectorAll(`.${CHIP_CLASS}`)).toHaveLength(1);
+  });
+});

--- a/extension/src/rules/index.ts
+++ b/extension/src/rules/index.ts
@@ -31,6 +31,7 @@ import { secretsRedactRule } from "./secrets-redact";
 import { socialEmbedRedactRule } from "./social-embed-redact";
 import { svgSpriteStripRule } from "./svg-sprite-strip";
 import { svgTextStripRule } from "./svg-text-strip";
+import { trustBadgeAnnotateRule } from "./trust-badge-annotate";
 import type { Rule } from "./types";
 import { unicodeInvisiblesStripRule } from "./unicode-invisibles-strip";
 
@@ -68,6 +69,7 @@ const RULES_TUPLE = [
   adsHideRule,
   cartAddonAnnotateRule,
   linkSpoofAnnotateRule,
+  trustBadgeAnnotateRule,
   searchUrlHelperRule,
   roachMotelAnnotateRule,
   irrelevantSectionsRedactRule,

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -31,6 +31,7 @@ export const RULE_DEFAULTS: Readonly<Record<RuleId, boolean>> = {
   "ads-hide": true,
   "cart-addon-annotate": true,
   "link-spoof-annotate": true,
+  "trust-badge-annotate": true,
   "search-url-helper": true,
   "roach-motel-annotate": true,
   "irrelevant-sections-redact": false,

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -31,7 +31,7 @@ export const RULE_DEFAULTS: Readonly<Record<RuleId, boolean>> = {
   "ads-hide": true,
   "cart-addon-annotate": true,
   "link-spoof-annotate": true,
-  "trust-badge-annotate": true,
+  "trust-badge-annotate": false,
   "search-url-helper": true,
   "roach-motel-annotate": true,
   "irrelevant-sections-redact": false,

--- a/extension/src/rules/trust-badge-annotate.ts
+++ b/extension/src/rules/trust-badge-annotate.ts
@@ -298,9 +298,9 @@ function apply(root: ParentNode): void {
 
 export const trustBadgeAnnotateRule = {
   id: RULE_ID,
-  label: "Flag Trust Badges",
+  label: "Flag Trust Badges (Experimental)",
   description:
-    "Annotate image-shaped trust badges (Norton Secured, McAfee SECURE, BBB Accredited, Verified Seller, and similar) whose accessible name carries a self-asserted trust claim that no transport-level signal backs. Useful for vision- and accessibility-tree-driven agents, which over-weight these badges as evidence of trustworthiness.",
+    "Annotate image-shaped trust badges (Norton Secured, McAfee SECURE, BBB Accredited, Verified Seller, and similar) whose accessible name carries a self-asserted trust claim that no transport-level signal backs. Useful for vision- and accessibility-tree-driven agents, which over-weight these badges as evidence of trustworthiness. Off by default while we gather real-world signal on false positives.",
   apply,
   teardown: () => {
     watcher.stop();

--- a/extension/src/rules/trust-badge-annotate.ts
+++ b/extension/src/rules/trust-badge-annotate.ts
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Annotate image-shaped trust badges — "Norton Secured", "McAfee SECURE",
+// "BBB Accredited", "Verified Seller" — that aren't backed by any
+// content-script-accessible transport-level signal. Any operator can drop
+// an <img alt="Norton Secured"> onto any page; the chrome's TLS UI, EV cert
+// org name, and other trust signals aren't reachable from a content script,
+// so the badge image is functionally a self-asserted claim. Computer-use
+// agents (SusBench, DECEPTICON) over-weight these badges as proof of
+// trustworthiness; the chip re-presents the claim as "not verifiable from
+// page content" so the agent can discount it.
+//
+// V1 scope is intentionally narrow:
+//   - Element shape must be <img>, <svg>, or [role="img"]. Text spans
+//     saying "Verified Purchase" (Amazon-style review labels) are handled
+//     by reviews-redact, not this rule.
+//   - Accessible name (aria-label > aria-labelledby > <title> > alt > title)
+//     must match a curated, word-boundary phrase set. Two-word phrases for
+//     the generic tier — bare "verified" / "trusted" are too noisy alone.
+//   - Same-issuer pages are exempt: a BBB badge on bbb.org is first-party.
+//
+// We annotate rather than strip because removing the badge would leave a
+// gap in product layouts that a sighted user expects to see filled, while
+// the chip preserves the visual element and warns the agent in band.
+
+import {
+  TRUST_BADGE_ANNOTATED_ATTR as ANNOTATED_ATTR,
+  RULE_ATTR,
+} from "../lib/dom-markers";
+import { registrableDomain } from "../lib/domain-trust";
+import { log } from "../lib/log";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import type { Rule } from "./types";
+
+const RULE_ID = "trust-badge-annotate" as const;
+const CHIP_CLASS = "abs-trust-badge-annotate";
+
+// Hard cap on the accessible-name length we'll consider. Real badges carry
+// short labels — "Norton Secured", "BBB Accredited Business". Long alt
+// sentences that happen to contain "verified" or "trusted" as ordinary
+// adjectives ("Photo of trusted hiking sandals on a verified rock") are
+// not badges, and the cap is the cheapest way to exclude them.
+const MAX_ACCESSIBLE_NAME_LENGTH = 120;
+
+// Named third-party issuer phrases. Whole-phrase, case-insensitive,
+// word-boundary matches; each phrase is paired with the issuer's
+// registrable domain for the same-issuer exemption below. Phrasing
+// follows what appears in real badges (per SusBench / DECEPTICON
+// fixtures); extend by adding entries here rather than broadening the
+// regex shape.
+const NAMED_ISSUERS: readonly { phrase: string; domain: string }[] = [
+  { phrase: "bbb accredited", domain: "bbb.org" },
+  { phrase: "better business bureau", domain: "bbb.org" },
+  { phrase: "norton secured", domain: "norton.com" },
+  { phrase: "norton by symantec", domain: "norton.com" },
+  { phrase: "mcafee secure", domain: "mcafee.com" },
+  { phrase: "trustpilot", domain: "trustpilot.com" },
+  { phrase: "trustwave", domain: "trustwave.com" },
+  { phrase: "godaddy verified", domain: "godaddy.com" },
+  { phrase: "godaddy secured", domain: "godaddy.com" },
+  { phrase: "digicert", domain: "digicert.com" },
+  { phrase: "comodo secure", domain: "comodo.com" },
+  { phrase: "geotrust", domain: "geotrust.com" },
+  { phrase: "symantec secured", domain: "symantec.com" },
+  { phrase: "verisign secured", domain: "verisign.com" },
+  { phrase: "sectigo", domain: "sectigo.com" },
+  { phrase: "truste certified", domain: "truste.com" },
+  { phrase: "globalsign", domain: "globalsign.com" },
+  { phrase: "authorize.net", domain: "authorize.net" },
+  { phrase: "paypal verified", domain: "paypal.com" },
+  { phrase: "shopify secure", domain: "shopify.com" },
+];
+
+// Generic trust phrases with no specific issuer — every match is treated
+// as unverifiable regardless of page host. Two-word minimum to keep the
+// set tight; single words like "verified" or "trusted" are too noisy.
+const GENERIC_PHRASES: readonly string[] = [
+  "verified seller",
+  "trusted seller",
+  "verified store",
+  "trusted store",
+  "certified seller",
+  "official store",
+  "verified merchant",
+  "trusted merchant",
+  "secure checkout",
+  "ssl secured",
+  "100% secure",
+  "safe shopping guarantee",
+];
+
+function escapeRegex(literal: string): string {
+  return literal.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+// A single alternation across both phrase sets. Word boundaries are
+// applied on the outside; `.` in literals like `authorize.net` is escaped
+// individually so it doesn't match arbitrary characters.
+const ALL_PHRASES = [
+  ...NAMED_ISSUERS.map((entry) => entry.phrase),
+  ...GENERIC_PHRASES,
+];
+const PHRASE_RE = new RegExp(
+  String.raw`\b(?:${ALL_PHRASES.map(escapeRegex).join("|")})\b`,
+  "i",
+);
+
+function getPageHost(): string {
+  return globalThis.location.hostname;
+}
+
+function isBadgeShape(element: Element): boolean {
+  // SVG elements (XML namespace) preserve case in `tagName`, returning
+  // `"svg"` lowercase; HTML elements uppercase it. `localName` is always
+  // lowercase per spec, which sidesteps the asymmetry.
+  const name = element.localName;
+  if (name === "img" || name === "svg") {
+    return true;
+  }
+  return element.getAttribute("role") === "img";
+}
+
+// Accessible-name resolution in priority order: aria-label,
+// aria-labelledby (resolved against the document), an SVG <title> child,
+// the <img> alt attribute, then the title attribute as a last resort.
+function readAccessibleName(element: Element): string {
+  const ariaLabel = element.getAttribute("aria-label");
+  if (ariaLabel !== null && ariaLabel.trim() !== "") {
+    return ariaLabel.trim();
+  }
+
+  const labelledBy = element.getAttribute("aria-labelledby");
+  if (labelledBy !== null && labelledBy.trim() !== "") {
+    const parts: string[] = [];
+    for (const id of labelledBy.split(/\s+/)) {
+      if (id === "") {
+        continue;
+      }
+      const referent = element.ownerDocument.querySelector(
+        `#${CSS.escape(id)}`,
+      );
+      if (referent !== null) {
+        parts.push(referent.textContent.trim());
+      }
+    }
+    const joined = parts
+      .filter((part) => part !== "")
+      .join(" ")
+      .trim();
+    if (joined !== "") {
+      return joined;
+    }
+  }
+
+  const localName = element.localName;
+  if (localName === "svg") {
+    // Iterate direct children rather than `querySelector(":scope > title")`
+    // because the SVG <title> sits in the SVG XML namespace, where CSS
+    // selector matching by bare tag name is not portable across DOM
+    // implementations.
+    for (const child of element.children) {
+      if (child.localName === "title") {
+        const text = child.textContent.trim();
+        if (text !== "") {
+          return text;
+        }
+        break;
+      }
+    }
+  }
+
+  if (localName === "img") {
+    const alt = element.getAttribute("alt");
+    if (alt !== null && alt.trim() !== "") {
+      return alt.trim();
+    }
+  }
+
+  const title = element.getAttribute("title");
+  if (title !== null && title.trim() !== "") {
+    return title.trim();
+  }
+
+  return "";
+}
+
+export interface TrustBadgeMatch {
+  // The phrase that triggered the match, lowercased and as it appears in
+  // the curated phrase list — used in the chip text so the agent and a
+  // reviewing human can see exactly what was matched.
+  phrase: string;
+  // The issuer's registrable domain, when the matched phrase is a named
+  // third-party issuer. `null` for generic phrases that have no specific
+  // issuer.
+  issuerDomain: string | null;
+}
+
+function lookupIssuer(phrase: string): string | null {
+  const lowered = phrase.toLowerCase();
+  for (const entry of NAMED_ISSUERS) {
+    if (entry.phrase === lowered) {
+      return entry.domain;
+    }
+  }
+  return null;
+}
+
+export function detectTrustBadge(
+  element: Element,
+  pageHost: string,
+): TrustBadgeMatch | null {
+  if (!isBadgeShape(element)) {
+    return null;
+  }
+  const name = readAccessibleName(element);
+  if (name === "" || name.length > MAX_ACCESSIBLE_NAME_LENGTH) {
+    return null;
+  }
+  const match = PHRASE_RE.exec(name);
+  if (match === null) {
+    return null;
+  }
+  const phrase = match[0].toLowerCase();
+  const issuerDomain = lookupIssuer(phrase);
+  if (issuerDomain !== null) {
+    const pageRD = registrableDomain(pageHost);
+    if (pageRD !== null && pageRD === issuerDomain) {
+      // First-party badge on the issuer's own domain — not the threat
+      // model. A Norton page showing a Norton badge is the issuer
+      // asserting their own brand, which has whatever trust the visit
+      // to that page already established.
+      return null;
+    }
+  }
+  return { phrase, issuerDomain };
+}
+
+function chipText(name: string): string {
+  return `[abs: trust badge ("${name}") is not backed by a verifiable transport signal — verify the issuer independently before trusting]`;
+}
+
+function annotate(element: Element, name: string): void {
+  if (!element.isConnected || element.hasAttribute(ANNOTATED_ATTR)) {
+    return;
+  }
+  element.setAttribute(ANNOTATED_ATTR, "");
+
+  const chip = element.ownerDocument.createElement("span");
+  chip.className = CHIP_CLASS;
+  chip.setAttribute(RULE_ATTR, RULE_ID);
+  // Inline styling so the warning is visible even on pages that strip
+  // extension stylesheets. Mirrors the chip style used by
+  // link-spoof-annotate for consistency.
+  chip.style.display = "inline-block";
+  chip.style.margin = "0 0 0 4px";
+  chip.style.padding = "0 4px";
+  chip.style.border = "1px solid #b00";
+  chip.style.background = "#fff5f5";
+  chip.style.color = "#900";
+  chip.style.font = "11px/1.4 system-ui, sans-serif";
+  chip.style.fontStyle = "italic";
+  chip.textContent = chipText(name);
+  element.after(chip);
+}
+
+function scanAndAnnotate(root: ParentNode): void {
+  const pageHost = getPageHost();
+  let count = 0;
+  for (const node of root.querySelectorAll('img, svg, [role="img"]')) {
+    if (node.hasAttribute(ANNOTATED_ATTR)) {
+      continue;
+    }
+    const match = detectTrustBadge(node, pageHost);
+    if (match !== null) {
+      annotate(node, readAccessibleName(node));
+      count++;
+    }
+  }
+  if (count > 0) {
+    log("trust badges annotated", { count });
+  }
+}
+
+const watcher = createSubtreeWatcher({
+  skipPlaceholderSubtrees: true,
+  onSubtrees: (roots) => {
+    for (const root of roots) {
+      scanAndAnnotate(root);
+    }
+  },
+});
+
+function apply(root: ParentNode): void {
+  scanAndAnnotate(root);
+  watcher.start(root);
+}
+
+export const trustBadgeAnnotateRule = {
+  id: RULE_ID,
+  label: "Flag Trust Badges",
+  description:
+    "Annotate image-shaped trust badges (Norton Secured, McAfee SECURE, BBB Accredited, Verified Seller, and similar) whose accessible name carries a self-asserted trust claim that no transport-level signal backs. Useful for vision- and accessibility-tree-driven agents, which over-weight these badges as evidence of trustworthiness.",
+  apply,
+  teardown: () => {
+    watcher.stop();
+  },
+} satisfies Rule;

--- a/extension/src/rules/trust-badge-annotate.ts
+++ b/extension/src/rules/trust-badge-annotate.ts
@@ -194,6 +194,10 @@ export interface TrustBadgeMatch {
   // third-party issuer. `null` for generic phrases that have no specific
   // issuer.
   issuerDomain: string | null;
+  // The accessible name the matcher computed, returned so the caller can
+  // pass it into the chip without recomputing aria-labelledby / SVG-title
+  // resolution.
+  accessibleName: string;
 }
 
 function lookupIssuer(phrase: string): string | null {
@@ -233,7 +237,7 @@ export function detectTrustBadge(
       return null;
     }
   }
-  return { phrase, issuerDomain };
+  return { phrase, issuerDomain, accessibleName: name };
 }
 
 function chipText(name: string): string {
@@ -273,7 +277,7 @@ function scanAndAnnotate(root: ParentNode): void {
     }
     const match = detectTrustBadge(node, pageHost);
     if (match !== null) {
-      annotate(node, readAccessibleName(node));
+      annotate(node, match.accessibleName);
       count++;
     }
   }


### PR DESCRIPTION
## Summary

- New `trust-badge-annotate` rule annotates image-shaped trust badges (Norton Secured, McAfee SECURE, BBB Accredited, TrustPilot, Verified Seller, and similar) whose accessible name asserts third-party endorsement that no content-script-accessible signal backs. Mirrors the chip pattern from `link-spoof-annotate`.
- SusBench and DECEPTICON both probe this deception class — current computer-use agents over-weight badge images as proof of legitimacy; the chip re-presents the claim as "not verifiable from page content."
- Default: **off** (Experimental, while we gather real-world signal on false positives). Layered false-positive filters: element-shape filter (excludes text spans, so Amazon-style "Verified Purchase" labels stay with `reviews-redact`), 120-char accessible-name cap, curated word-boundary phrase set (two-word minimum for the generic tier), and a same-issuer exemption (BBB badge on bbb.org is first-party, skipped).
- Demo site grows three trust-badge fixtures on the product detail page — two positive (Norton Secured, Verified Seller) and one negative (long descriptive alt that should not flag).
- Docs add a "Flag Trust Badges" section under the prompt-injection defenses, alongside `link-spoof-annotate`.

## Test plan

- [x] `bun run check` (biome + eslint) clean in extension, demo-site
- [x] `bun run typecheck` clean
- [x] `bun run knip` clean
- [x] `bun test` — 45 suites, 932 tests pass (23 new tests for `trust-badge-annotate` covering positive matches, element-shape filter, length cap, single-word-rejection, same-issuer exemption, idempotency, and the subtree-watcher path)
- [x] `bun run build` on `demo-site` and `docs` both succeed
- [ ] Manual smoke test: enable the rule from the popup, load the demo product page, confirm the two positive badges receive `[abs: …]` chips and the descriptive-alt fixture does not, then toggle the rule off and confirm chips disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)