### PR TITLE
Group popup and options rules by docs threat/pattern categories

### DIFF
--- a/extension/src/lib/RuleList.tsx
+++ b/extension/src/lib/RuleList.tsx
@@ -1,12 +1,31 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
+import type { Rule, RuleId } from "../rules";
 import { RULES } from "../rules";
 import type { RuleAvailabilityStates } from "./availability";
+import { RULE_GROUPS } from "./rule-groups";
 import type { RuleStates } from "./storage";
 import { setRuleEnabled } from "./storage";
 
+const RULES_BY_ID = new Map<RuleId, Rule>(RULES.map((rule) => [rule.id, rule]));
+
+// The catalog invariant test (`places every rule in exactly one group`)
+// guarantees every group id resolves; this throws loudly if anyone ever
+// breaks that invariant by adding a rule without updating `RULE_GROUPS`.
+function ruleById(id: RuleId): Rule {
+  const rule = RULES_BY_ID.get(id);
+  if (!rule) {
+    throw new Error(`Rule ${id} listed in RULE_GROUPS but not in RULES`);
+  }
+  return rule;
+}
+
 // Shared per-rule checkbox list rendered by both the popup and options page.
+// Rules are grouped by the same top-level threat/pattern categories used on
+// the docs Rules reference page; the catalog test enforces every rule belongs
+// to exactly one group.
+//
 // Pass `disabledByEnforcement` when the surface should grey out every rule
 // (popup, when global enforcement is off); the options page omits it because
 // the user can still edit preferences while enforcement is paused.
@@ -21,47 +40,57 @@ export function RuleList({
   disabledByEnforcement?: boolean;
   className?: string;
 }) {
-  const listClass = className ? `rules ${className}` : "rules";
+  const rootClass = className ? `rule-groups ${className}` : "rule-groups";
   return (
-    <ul
+    <div
       className={
         disabledByEnforcement
-          ? `${listClass} rules--enforcement-off`
-          : listClass
+          ? `${rootClass} rule-groups--enforcement-off`
+          : rootClass
       }
     >
-      {RULES.map((rule) => {
-        const snapshot = availability[rule.id];
-        const unavailable = !snapshot?.available;
-        const disabled = unavailable || disabledByEnforcement;
-        return (
-          <li
-            key={rule.id}
-            className={unavailable ? "rule rule--unavailable" : "rule"}
-          >
-            <label>
-              <input
-                type="checkbox"
-                checked={unavailable ? false : states[rule.id]}
-                disabled={disabled}
-                onChange={(event) => {
-                  void setRuleEnabled(rule.id, event.target.checked);
-                }}
-              />
-              <div>
-                <strong>
-                  {rule.label}
-                  {unavailable && <span className="badge">Unavailable</span>}
-                </strong>
-                {unavailable && snapshot?.reason && (
-                  <p className="unavailable-reason">{snapshot.reason}</p>
-                )}
-                <p>{rule.description}</p>
-              </div>
-            </label>
-          </li>
-        );
-      })}
-    </ul>
+      {RULE_GROUPS.map((group) => (
+        <section key={group.id} className="rule-group">
+          <h3 className="rule-group__heading">{group.label}</h3>
+          <ul className="rules">
+            {group.ruleIds.map((ruleId) => {
+              const rule = ruleById(ruleId);
+              const snapshot = availability[rule.id];
+              const unavailable = !snapshot?.available;
+              const disabled = unavailable || disabledByEnforcement;
+              return (
+                <li
+                  key={rule.id}
+                  className={unavailable ? "rule rule--unavailable" : "rule"}
+                >
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={unavailable ? false : states[rule.id]}
+                      disabled={disabled}
+                      onChange={(event) => {
+                        void setRuleEnabled(rule.id, event.target.checked);
+                      }}
+                    />
+                    <div>
+                      <strong>
+                        {rule.label}
+                        {unavailable && (
+                          <span className="badge">Unavailable</span>
+                        )}
+                      </strong>
+                      {unavailable && snapshot?.reason && (
+                        <p className="unavailable-reason">{snapshot.reason}</p>
+                      )}
+                      <p>{rule.description}</p>
+                    </div>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
   );
 }

--- a/extension/src/lib/rule-groups.ts
+++ b/extension/src/lib/rule-groups.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import type { RuleId } from "../rules";
+
+// Top-level categories used by the popup and options page to organize the
+// rule list. They mirror the H2 headings in `docs/src/content/docs/rules.md`
+// — when adding a rule, append its id to whichever group matches the doc
+// section it lives under. The catalog invariant test enforces that every
+// rule belongs to exactly one group.
+export type RuleGroupId =
+  | "indirect-prompt-injection"
+  | "dark-patterns"
+  | "sensitive-data-masking"
+  | "boilerplate-and-affordances";
+
+export interface RuleGroup {
+  id: RuleGroupId;
+  label: string;
+  ruleIds: readonly RuleId[];
+}
+
+export const RULE_GROUPS: readonly RuleGroup[] = [
+  {
+    id: "indirect-prompt-injection",
+    label: "Indirect prompt injection",
+    ruleIds: [
+      "prompt-injection-redact",
+      "comments-redact",
+      "reviews-redact",
+      "social-embed-redact",
+      "html-comment-strip",
+      "noscript-strip",
+      "hidden-text-strip",
+      "unicode-invisibles-strip",
+      "meta-injection-strip",
+      "attribute-injection-sanitize",
+      "json-ld-sanitize",
+      "svg-text-strip",
+      "schema-trust-sanitize",
+      "cross-origin-frame-redact",
+      "link-spoof-annotate",
+      "trust-badge-annotate",
+    ],
+  },
+  {
+    id: "dark-patterns",
+    label: "Dark patterns",
+    ruleIds: [
+      "countdown-timer-redact",
+      "scarcity-redact",
+      "cart-addon-annotate",
+      "checkout-checkbox-sanitize",
+      "confirmshame-sanitize",
+      "roach-motel-annotate",
+      "newsletter-modal-hide",
+      "irrelevant-sections-redact",
+    ],
+  },
+  {
+    id: "sensitive-data-masking",
+    label: "Sensitive-data masking",
+    ruleIds: ["pii-redact", "secrets-redact"],
+  },
+  {
+    id: "boilerplate-and-affordances",
+    label: "Boilerplate and agent affordances",
+    ruleIds: [
+      "footer-redact",
+      "cookie-banner-hide",
+      "chat-widget-hide",
+      "ads-hide",
+      "svg-sprite-strip",
+      "search-url-helper",
+    ],
+  },
+];

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -73,6 +73,21 @@
         color: #666;
         line-height: 1.4;
       }
+      .rule-groups {
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+      .rule-group__heading {
+        margin: 0 0 8px;
+        padding-bottom: 4px;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #555;
+        border-bottom: 1px solid #e4e4e7;
+      }
       .rules {
         list-style: none;
         margin: 0;

--- a/extension/src/options/Options.tsx
+++ b/extension/src/options/Options.tsx
@@ -227,6 +227,19 @@ export function Options() {
       </Section>
 
       <Section id="rules" title="Rules">
+        <p className="hint">
+          Grouped by the threat or pattern each rule defends against. The full
+          per-rule reference — what each rule does, defaults, and prior art —
+          lives on the{" "}
+          <a
+            href="https://pixiebrix.github.io/agent-browser-shield/rules/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Rules reference page
+          </a>
+          .
+        </p>
         <RuleList states={states} availability={availability} />
       </Section>
 

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -110,6 +110,24 @@
         outline: 2px solid #2563eb;
         outline-offset: 2px;
       }
+      .rule-groups {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+      }
+      .rule-groups--enforcement-off {
+        opacity: 0.55;
+      }
+      .rule-group__heading {
+        margin: 0 0 6px;
+        padding-bottom: 4px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #555;
+        border-bottom: 1px solid #e4e4e7;
+      }
       .rules {
         list-style: none;
         margin: 0;
@@ -117,9 +135,6 @@
         display: flex;
         flex-direction: column;
         gap: 8px;
-      }
-      .rules--enforcement-off {
-        opacity: 0.55;
       }
       .rules label {
         display: flex;

--- a/extension/src/rules/__tests__/catalog.test.ts
+++ b/extension/src/rules/__tests__/catalog.test.ts
@@ -24,6 +24,7 @@ jest.mock("abort-utils", () => ({
   },
 }));
 
+import { RULE_GROUPS } from "../../lib/rule-groups";
 import { RULE_IDS, RULES } from "..";
 import { RULE_DEFAULTS } from "../rule-defaults.generated";
 
@@ -81,6 +82,24 @@ describe("rule catalog invariants", () => {
           rule.unavailableReason.length === 0),
     ).map((rule) => rule.id);
     expect(offenders).toEqual([]);
+  });
+
+  // Group membership drives the popup and options-page rule-list layout.
+  // Every rule must appear in exactly one group so the UI doesn't drop or
+  // double-count any. RULE_GROUPS is the source for the H2 sections in
+  // docs/src/content/docs/rules.md; the same buckets are used in-product.
+  it("places every rule in exactly one group, with no unknown ids", () => {
+    const grouped = RULE_GROUPS.flatMap((group) => group.ruleIds);
+    const duplicates = grouped.filter(
+      (id, index) => grouped.indexOf(id) !== index,
+    );
+    expect(duplicates).toEqual([]);
+    expect([...grouped].toSorted()).toEqual([...RULE_IDS].toSorted());
+  });
+
+  it("group ids are unique", () => {
+    const ids = RULE_GROUPS.map((group) => group.id);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 
   // Reactive availability accessors must expose both `get` and `subscribe`


### PR DESCRIPTION
## Summary

- Replace the flat rule list in the popup and options page with the same four top-level groupings used on the docs Rules reference page: **Indirect prompt injection**, **Dark patterns**, **Sensitive-data masking**, and **Boilerplate and agent affordances**.
- Add a `RULE_GROUPS` source (in `extension/src/lib/rule-groups.ts`) wired up to a catalog invariant test — if a rule is missing from a group or appears in more than one, CI fails.
- Link the options page Rules section out to https://pixiebrix.github.io/agent-browser-shield/rules/ for the per-rule reference (descriptions, defaults, prior art).

Headings use `<h3 class="rule-group__heading">` so they slot under the options page's existing Rules `<h2>` section without breaking heading hierarchy; the popup gets a slightly tighter gap (14px) than options (18px). Style matches the existing `.toc` / Section heading treatment.

## Test plan

- [x] `bun run preflight` (build-site-data, biome, eslint, tsc ×2, knip, jest with coverage) clean — 934 tests pass.
- [x] New catalog invariants exercised:
  - "places every rule in exactly one group, with no unknown ids"
  - "group ids are unique"
- [ ] Load the unpacked build, open the popup, confirm rules appear under the four group headers in the same order as the docs.
- [ ] Open the options page, confirm the "Rules reference page" link opens https://pixiebrix.github.io/agent-browser-shield/rules/ in a new tab, and rules appear under the same headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)