### PR TITLE
Add disguised-ad-flag rule for native advertorials

### DIFF
--- a/demo-site/src/components/AdvertorialCard.tsx
+++ b/demo-site/src/components/AdvertorialCard.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Native advertorial fixture for demoing the `disguised-ad-flag` rule.
+// Renders an article-shaped card (heading + image + body prose + read-more
+// link) with a visible disclosure label, deliberately *without* the
+// network-level markers (`adsbygoogle`, `data-ad-slot`) that `ads-hide`
+// would catch. The whole point of the rule is to handle these
+// publisher-rendered advertorials that EasyList can't see.
+
+interface AdvertorialCardProps {
+  // Label text rendered above the headline. Provide the exact phrasing
+  // (case included) so the demo exercises each detection branch:
+  //   - "Sponsored"                          standalone form
+  //   - "[Ad]"                                bracket form
+  //   - "Paid for and presented by <brand>"  suffix form
+  label: string;
+  headline: string;
+  body: string;
+  brand: string;
+}
+
+export default function AdvertorialCard({
+  label,
+  headline,
+  body,
+  brand,
+}: AdvertorialCardProps) {
+  return (
+    <article className="advertorial-card flex flex-col rounded border border-stone-200 bg-white p-4">
+      <span className="mb-1 inline-block w-fit text-[10px] font-semibold uppercase tracking-wider text-stone-500">
+        {label}
+      </span>
+      <h3 className="text-base font-semibold text-slate-900">{headline}</h3>
+      <img
+        src="https://placehold.co/600x320/eef2f7/64748b?text=Article+Hero"
+        alt=""
+        loading="lazy"
+        className="mt-2 aspect-[16/9] w-full rounded object-cover"
+      />
+      <p className="mt-2 text-sm text-stone-700">{body}</p>
+      <a
+        href={`https://example.com/partner/${encodeURIComponent(brand)}`}
+        className="mt-2 text-sm font-medium text-orange-700 hover:text-orange-800"
+      >
+        Read more from {brand}
+      </a>
+    </article>
+  );
+}

--- a/demo-site/src/pages/Home.tsx
+++ b/demo-site/src/pages/Home.tsx
@@ -2,6 +2,7 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import AdSlot from "../components/AdSlot";
+import AdvertorialCard from "../components/AdvertorialCard";
 import CountdownBadge from "../components/CountdownBadge";
 import ProductCard from "../components/ProductCard";
 import { products } from "../data/products";
@@ -76,6 +77,53 @@ export default function Home() {
           ))}
         </div>
       </section>
+
+      <section aria-label="From our partners">
+        <h2 className="mb-3 text-xl font-semibold text-slate-900">
+          From Our Partners
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <AdvertorialCard
+            label="Sponsored"
+            headline="Why this commuter e-bike is the upgrade your morning needs"
+            body="Northwind's new urban e-bike combines a torque-sensing motor with a removable battery so you can charge it at your desk. Riders in city pilots report cutting their commute by 22 minutes on average."
+            brand="Northwind Cycles"
+          />
+          <AdvertorialCard
+            label="[Ad]"
+            headline="The five-minute breakfast that's quietly taking over Brooklyn"
+            body="Made with overnight oats, fresh stone fruit, and a single-origin cold brew, Vellichor's grab-and-go cups have a cult following in coffee shops from Greenpoint to Park Slope."
+            brand="Vellichor Foods"
+          />
+          <AdvertorialCard
+            label="Paid for and presented by Aperture Home"
+            headline="Renovating a kitchen on a weekend timeline: it's possible"
+            body="Aperture's modular cabinet system installs without a contractor, ships flat-packed, and includes a guided AR planner so you can confirm fit before the truck arrives."
+            brand="Aperture Home"
+          />
+        </div>
+      </section>
+
+      <article
+        aria-label="Editorial article — should remain visible"
+        className="editorial-card rounded border border-stone-200 bg-white p-4"
+      >
+        <h2 className="text-base font-semibold text-slate-900">
+          Local roads team takes silver in regional championship
+        </h2>
+        <p className="mt-2 text-sm text-stone-700">
+          The Riverside cycling club placed second overall this weekend. The
+          team is sponsored by Adidas this season under a three-year
+          partnership, but the win was earned on the strength of a late-stage
+          breakaway by junior rider Mia Chen.
+        </p>
+        <a
+          href="https://example.com/news/riverside-silver"
+          className="mt-2 inline-block text-sm font-medium text-orange-700 hover:text-orange-800"
+        >
+          Read the full recap
+        </a>
+      </article>
     </div>
   );
 }

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -3,7 +3,7 @@ title: Rules reference
 description: The defense rules shipped with agent-browser-shield, what each one does, and its default state.
 ---
 
-The extension ships 32 rules, each independently toggleable from the extension
+The extension ships 33 rules, each independently toggleable from the extension
 popup. Rules marked **default: on** are active on fresh install; **default:
 off** rules must be enabled manually.
 
@@ -702,13 +702,13 @@ require publishers to render prominently.
 Detection works on the visible label — not network selectors — and only fires
 when the label sits inside an article-shaped container (heading, image or
 outbound link, body prose). Filter chips, navigation links, and editorial
-paragraphs that mention sponsorship in passing are excluded by that shape
-check, by an interactive-ancestor guard, and by a whole-string regex on the
-label element. Matching cards are replaced with a click-to-reveal placeholder
-in the same style as `ads-hide` and `irrelevant-sections-redact`.
+paragraphs that mention sponsorship in passing are excluded by that shape check,
+by an interactive-ancestor guard, and by a whole-string regex on the label
+element. Matching cards are replaced with a click-to-reveal placeholder in the
+same style as `ads-hide` and `irrelevant-sections-redact`.
 
-The label-only approach is the boilerplate-detection counterpart to
-Kohlschütter et al. [[13]](#ref-kohlschutter-boilerplate) and
+The label-only approach is the boilerplate-detection counterpart to Kohlschütter
+et al. [[13]](#ref-kohlschutter-boilerplate) and
 [Readability.js](https://github.com/mozilla/readability), narrowed to the
 disclosure signal that paid content must carry by law.
 

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -684,6 +684,34 @@ that powers [uBlock Origin](https://github.com/gorhill/uBlock), Adblock Plus,
 and most other consumer ad blockers — over a decade of community-maintained ad
 and tracker selector patterns.
 
+### Hide Disguised Ads (Native Advertorials)
+
+- **ID:** `disguised-ad-flag`
+- **Default:** on
+
+Hide article-shaped blocks that carry a visible disclosure label — "Sponsored",
+"Promoted", "Advertorial", "Paid Post", "Partner Content", or the bracketed
+variants common in social feeds — but are rendered by the publisher's own CMS
+rather than served from an ad network. Native advertorials bypass the
+infrastructure-level selectors that power `ads-hide` because they share class
+names and DOM shape with editorial articles; the only signal that distinguishes
+them is the disclosure label itself, which the
+[FTC's `.com Disclosures`](https://www.ftc.gov/business-guidance/resources/com-disclosures-how-make-effective-disclosures-digital-advertising)
+require publishers to render prominently.
+
+Detection works on the visible label — not network selectors — and only fires
+when the label sits inside an article-shaped container (heading, image or
+outbound link, body prose). Filter chips, navigation links, and editorial
+paragraphs that mention sponsorship in passing are excluded by that shape
+check, by an interactive-ancestor guard, and by a whole-string regex on the
+label element. Matching cards are replaced with a click-to-reveal placeholder
+in the same style as `ads-hide` and `irrelevant-sections-redact`.
+
+The label-only approach is the boilerplate-detection counterpart to
+Kohlschütter et al. [[13]](#ref-kohlschutter-boilerplate) and
+[Readability.js](https://github.com/mozilla/readability), narrowed to the
+disclosure signal that paid content must carry by law.
+
 ### Remove Unused SVG Sprites
 
 - **ID:** `svg-sprite-strip`

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -31,6 +31,7 @@
     "irrelevant-sections-redact": false,
     "cross-origin-frame-redact": false,
     "schema-trust-sanitize": false,
-    "trust-badge-annotate": false
+    "trust-badge-annotate": false,
+    "disguised-ad-flag": true
   }
 }

--- a/extension/src/lib/dom-markers.ts
+++ b/extension/src/lib/dom-markers.ts
@@ -54,6 +54,13 @@ export const LINK_SPOOF_ANNOTATED_ATTR = "data-abs-link-spoof-annotated";
 // re-scan.
 export const TRUST_BADGE_ANNOTATED_ATTR = "data-abs-trust-badge-annotated";
 
+// `disguised-ad-flag`: marks a label element that the rule has already
+// considered and rejected (no article-shaped ancestor, in a filter chip,
+// inside an existing ad-hide region, etc.), so subtree-watcher re-scans
+// don't re-evaluate the same negative case on every mutation burst.
+export const DISGUISED_AD_FLAG_CONSIDERED_ATTR =
+  "data-abs-disguised-ad-considered";
+
 // `confirmshame-sanitize`: stores the original copy of attributes the
 // rule rewrites so reveal-on-click can restore the user-visible
 // confirmshame language.

--- a/extension/src/lib/rule-groups.ts
+++ b/extension/src/lib/rule-groups.ts
@@ -70,6 +70,7 @@ export const RULE_GROUPS: readonly RuleGroup[] = [
       "cookie-banner-hide",
       "chat-widget-hide",
       "ads-hide",
+      "disguised-ad-flag",
       "svg-sprite-strip",
       "irrelevant-sections-redact",
     ],

--- a/extension/src/rules/__tests__/disguised-ad-flag.test.ts
+++ b/extension/src/rules/__tests__/disguised-ad-flag.test.ts
@@ -207,7 +207,9 @@ describe("disguisedAdFlagRule false-positive guards", () => {
     disguisedAdFlagRule.apply(document.body);
 
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
-    expect(document.querySelector('[data-fixture="loose-label"]')).not.toBeNull();
+    expect(
+      document.querySelector('[data-fixture="loose-label"]'),
+    ).not.toBeNull();
     // Negative caches the decision so re-scans don't re-evaluate.
     const span = document
       .querySelector('[data-fixture="loose-label"]')
@@ -237,7 +239,9 @@ describe("disguisedAdFlagRule false-positive guards", () => {
     disguisedAdFlagRule.apply(document.body);
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
     // The ads-hide-marked wrapper still exists; we didn't touch it.
-    expect(document.querySelector(`[${HIDDEN_ATTR}="ads-hide"]`)).not.toBeNull();
+    expect(
+      document.querySelector(`[${HIDDEN_ATTR}="ads-hide"]`),
+    ).not.toBeNull();
   });
 
   it("skips an article without a heading even if labeled 'Sponsored'", () => {

--- a/extension/src/rules/__tests__/disguised-ad-flag.test.ts
+++ b/extension/src/rules/__tests__/disguised-ad-flag.test.ts
@@ -1,0 +1,267 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import {
+  DISGUISED_AD_FLAG_CONSIDERED_ATTR,
+  HIDDEN_ATTR,
+  RULE_ATTR,
+} from "../../lib/dom-markers";
+import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
+import { disguisedAdFlagRule } from "../disguised-ad-flag";
+
+const RULE_ID = "disguised-ad-flag";
+
+function articleCard({
+  label,
+  heading = "Acme energy drinks are the future of hydration",
+  body = "A long-form look at how Acme reformulated its flagship beverage to taste less metallic while keeping the same caffeine load and electrolyte balance.",
+  href = "https://example.com/article",
+}: {
+  label: string;
+  heading?: string;
+  body?: string;
+  href?: string;
+}): string {
+  return `
+    <article class="post" data-fixture="card">
+      <span class="label">${label}</span>
+      <h2><a href="${href}">${heading}</a></h2>
+      <img src="hero.jpg" alt="" />
+      <p>${body}</p>
+      <a href="${href}">Read more</a>
+    </article>
+  `;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  disguisedAdFlagRule.teardown();
+});
+
+describe("disguisedAdFlagRule positive cases", () => {
+  it("hides an article-shaped card with a 'Sponsored' label", () => {
+    document.body.innerHTML = articleCard({ label: "Sponsored" });
+    disguisedAdFlagRule.apply(document.body);
+
+    expect(document.querySelector('[data-fixture="card"]')).toBeNull();
+    const placeholder = document.querySelector(`.${PLACEHOLDER_CLASS}`);
+    expect(placeholder).not.toBeNull();
+    expect(placeholder?.getAttribute(RULE_ATTR)).toBe(RULE_ID);
+  });
+
+  it.each([
+    "Promoted",
+    "Advertorial",
+    "Paid Post",
+    "Partner Content",
+    "Sponsored Content",
+    "Sponsored Post",
+    "Branded Content",
+  ])("hides a card labeled '%s'", (label) => {
+    document.body.innerHTML = articleCard({ label });
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+  });
+
+  it("hides a card with a bracket-form '[Ad]' label", () => {
+    document.body.innerHTML = articleCard({ label: "[Ad]" });
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+  });
+
+  it("hides a card with a bracket-form '[AD]' label", () => {
+    document.body.innerHTML = articleCard({ label: "[AD]" });
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+  });
+
+  it("hides a card with a parenthesized '(promoted)' label", () => {
+    document.body.innerHTML = articleCard({ label: "(promoted)" });
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+  });
+
+  it("hides a card labeled 'Paid for and presented by Acme'", () => {
+    document.body.innerHTML = articleCard({
+      label: "Paid for and presented by Acme",
+    });
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+  });
+
+  it("hides a card labeled 'Sponsored by Acme'", () => {
+    document.body.innerHTML = articleCard({ label: "Sponsored by Acme" });
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+  });
+
+  it("hides a card labeled 'Sponsored — Acme Energy'", () => {
+    document.body.innerHTML = articleCard({ label: "Sponsored — Acme Energy" });
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+  });
+
+  it("includes the matched phrase in the placeholder label", () => {
+    document.body.innerHTML = articleCard({ label: "Sponsored" });
+    disguisedAdFlagRule.apply(document.body);
+    const placeholder = document.querySelector(`.${PLACEHOLDER_CLASS}`);
+    const announcement = placeholder
+      ?.querySelector("button")
+      ?.getAttribute("aria-label");
+    expect(announcement).toContain("sponsored content");
+    expect(announcement).toContain("Sponsored");
+  });
+
+  it("hides each of several advertorial cards interleaved with editorial cards", () => {
+    document.body.innerHTML = `
+      ${articleCard({ label: "Sponsored", heading: "Ad card 1" })}
+      <article class="post" data-fixture="editorial">
+        <h2>Real editorial story</h2>
+        <img src="x.jpg" alt="" />
+        <p>This is editorial copy about an unrelated topic.</p>
+        <a href="/a">Read more</a>
+      </article>
+      ${articleCard({ label: "[Ad]", heading: "Ad card 2" })}
+    `;
+    disguisedAdFlagRule.apply(document.body);
+
+    expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(2);
+    expect(document.querySelector('[data-fixture="editorial"]')).not.toBeNull();
+  });
+
+  it("dedupes when a card carries both a badge and a 'Paid for' caption", () => {
+    document.body.innerHTML = `
+      <article class="post" data-fixture="dual-label">
+        <span class="badge">Sponsored</span>
+        <h2>Headline</h2>
+        <img src="x.jpg" alt="" />
+        <p>Body copy that runs long enough to satisfy the prose-length check on the surrounding article ancestor when scanned.</p>
+        <span class="caption">Paid for and presented by Acme</span>
+      </article>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+
+    expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
+    expect(document.querySelector('[data-fixture="dual-label"]')).toBeNull();
+  });
+});
+
+describe("disguisedAdFlagRule false-positive guards", () => {
+  it("leaves editorial prose mentioning 'sponsored by' alone", () => {
+    document.body.innerHTML = `
+      <article class="post" data-fixture="editorial">
+        <h2>Acme signs new sponsorship deal</h2>
+        <img src="x.jpg" alt="" />
+        <p>The team is sponsored by Adidas this season, but the announcement was not received warmly by long-time fans of the franchise.</p>
+        <a href="/full-story">Read more</a>
+      </article>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+    expect(document.querySelector('[data-fixture="editorial"]')).not.toBeNull();
+  });
+
+  it("leaves a sort-by filter button labeled 'Sponsored' alone", () => {
+    document.body.innerHTML = `
+      <div class="filters">
+        <button type="button" data-fixture="filter">Sponsored</button>
+        <button type="button">Organic</button>
+      </div>
+      <article class="post" data-fixture="real">
+        <h2>Editorial headline</h2>
+        <img src="x.jpg" alt="" />
+        <p>Editorial body copy without any disclosure label.</p>
+        <a href="/a">Read more</a>
+      </article>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+    expect(document.querySelector('[data-fixture="filter"]')).not.toBeNull();
+  });
+
+  it("leaves a nav link 'Sponsored Content' alone", () => {
+    document.body.innerHTML = `
+      <nav data-fixture="nav">
+        <a href="/sponsored">Sponsored Content</a>
+        <a href="/news">News</a>
+      </nav>
+      <article class="post"><h2>x</h2><img alt=""/><p>body</p></article>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+    expect(document.querySelector('[data-fixture="nav"]')).not.toBeNull();
+  });
+
+  it("leaves a label with no article-shaped ancestor alone", () => {
+    document.body.innerHTML = `
+      <aside data-fixture="loose-label">
+        <span>Sponsored</span>
+      </aside>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+    expect(document.querySelector('[data-fixture="loose-label"]')).not.toBeNull();
+    // Negative caches the decision so re-scans don't re-evaluate.
+    const span = document
+      .querySelector('[data-fixture="loose-label"]')
+      ?.querySelector("span");
+    expect(span?.hasAttribute(DISGUISED_AD_FLAG_CONSIDERED_ATTR)).toBe(true);
+  });
+
+  it("does not match the English preposition 'ad' in '[ad hoc]'", () => {
+    document.body.innerHTML = `
+      <article class="post" data-fixture="latin">
+        <h2>An [ad hoc] committee was convened</h2>
+        <img src="x.jpg" alt="" />
+        <p>The committee was assembled to investigate the matter without delay.</p>
+        <a href="/a">Read more</a>
+      </article>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+
+  it("skips a label inside an ads-hide-marked ancestor", () => {
+    document.body.innerHTML = `
+      <div data-abs-hidden="ads-hide" style="display:none">
+        ${articleCard({ label: "Sponsored", heading: "Hidden by ads-hide" })}
+      </div>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+    // The ads-hide-marked wrapper still exists; we didn't touch it.
+    expect(document.querySelector(`[${HIDDEN_ATTR}="ads-hide"]`)).not.toBeNull();
+  });
+
+  it("skips an article without a heading even if labeled 'Sponsored'", () => {
+    document.body.innerHTML = `
+      <article class="post" data-fixture="no-heading">
+        <span class="label">Sponsored</span>
+        <p>Just a paragraph without a heading.</p>
+        <a href="/a">Read more</a>
+      </article>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+
+  it("skips a card with too-short prose body", () => {
+    document.body.innerHTML = `
+      <article class="post" data-fixture="thin">
+        <span class="label">Sponsored</span>
+        <h2>Title</h2>
+        <img alt="" src="x.jpg" />
+        <p>Short.</p>
+      </article>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+});

--- a/extension/src/rules/__tests__/disguised-ad-flag.test.ts
+++ b/extension/src/rules/__tests__/disguised-ad-flag.test.ts
@@ -256,6 +256,31 @@ describe("disguisedAdFlagRule false-positive guards", () => {
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 
+  it("does not double-count nested prose elements toward the body length", () => {
+    // The card's actual prose ("forty-two chars of nested text here") is
+    // ~37 chars, well below MIN_ARTICLE_PROSE_LENGTH (80). If the prose
+    // counter walked every <div>/<p>/<span> match, the same text would be
+    // counted three times (~111 chars) and the card would be falsely
+    // hidden. Leaf-ish filtering keeps that from happening.
+    document.body.innerHTML = `
+      <article class="post" data-fixture="nested-prose">
+        <span class="label">Sponsored</span>
+        <h2>Headline</h2>
+        <img alt="" src="x.jpg" />
+        <div class="body">
+          <p>
+            <span>forty-two chars of nested text here.</span>
+          </p>
+        </div>
+      </article>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+    expect(
+      document.querySelector('[data-fixture="nested-prose"]'),
+    ).not.toBeNull();
+  });
+
   it("skips a card with too-short prose body", () => {
     document.body.innerHTML = `
       <article class="post" data-fixture="thin">

--- a/extension/src/rules/disguised-ad-flag.ts
+++ b/extension/src/rules/disguised-ad-flag.ts
@@ -1,0 +1,387 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Hide native advertorials — paid content rendered by the publisher's own
+// CMS as article-shaped blocks, distinguishable from editorial only by a
+// small "Sponsored" / "Promoted" / "Advertorial" label. `ads-hide` catches
+// infrastructure-level ads (iframes, IAB `data-ad-slot`, named vendor
+// classes) via EasyList; this rule fills the gap for publisher-rendered
+// advertorials that bypass those selectors.
+//
+// Detection uses the *visible disclosure label* — not network selectors.
+// Per FTC `.com Disclosures`, advertorials must carry a reasonably
+// prominent label, so we can rely on it being present. The whole-string
+// regex on a small leaf-ish text element keeps editorial prose mentioning
+// sponsorship ("the team is sponsored by Adidas") from matching.
+
+import {
+  DISGUISED_AD_FLAG_CONSIDERED_ATTR as CONSIDERED_ATTR,
+  HIDDEN_ATTR,
+  REVEALED_ATTR,
+} from "../lib/dom-markers";
+import {
+  filterToOutermost,
+  findInnermostMatches,
+  isInsidePlaceholder,
+} from "../lib/dom-utils";
+import { log } from "../lib/log";
+import { replaceWithBlockPlaceholder } from "../lib/placeholder";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import type { Rule } from "./types";
+
+const RULE_ID = "disguised-ad-flag" as const;
+
+// Cap on the trimmed text length of the *label* element. Real disclosure
+// labels are short — "Sponsored", "Paid for and presented by Acme", a
+// bracketed "[Ad]". Editorial paragraphs that happen to contain the word
+// "sponsored" are far longer.
+const MAX_LABEL_TEXT_LENGTH = 80;
+
+// Cap on direct children of the label element. The label sits in a small
+// `<span>` / `<p>` / `<div>` — typically with no children or a single
+// styling wrapper. A multi-child container is a card, not a label.
+const MAX_LABEL_DESCENDANTS = 3;
+
+// Limit how far we walk up looking for an article-shaped container. Going
+// further is almost always overreach into page chrome (sections, mains,
+// bodies). Eight hops covers reasonable card → wrapper → grid-cell nesting
+// without licensing us to climb to <main>.
+const MAX_ANCESTOR_HOPS = 8;
+
+// Minimum prose-text length the article-shape ancestor must carry, in
+// characters, after excluding the label itself and any headings. Filters
+// out "card-shaped" UI like sort-control rows where there's a label but no
+// editorial body to confuse an agent with.
+const MIN_ARTICLE_PROSE_LENGTH = 80;
+
+// Core whole-string label phrases (case-insensitive, word-boundaried at
+// the ends of the trimmed text). The matcher requires the *entire* trimmed
+// `textContent` of the candidate to be one of these phrases (with an
+// optional " by <issuer>" suffix where allowed), so editorial prose
+// containing the word in passing doesn't match.
+const STANDALONE_PHRASES: readonly string[] = [
+  "sponsored",
+  "promoted",
+  "advertorial",
+  "paid post",
+  "partner content",
+  "sponsored content",
+  "sponsored post",
+  "branded content",
+];
+
+// Suffix-form phrases — "Sponsored by Acme", "Presented by Acme", "Paid
+// for and presented by Acme". The trailing brand is matched as `.+` so
+// the rule doesn't depend on a brand allowlist, but the prefix is fixed.
+const SUFFIX_PHRASES: readonly string[] = [
+  "sponsored by",
+  "presented by",
+  "paid for and presented by",
+];
+
+function escapeRegex(literal: string): string {
+  return literal.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+// Optional trailing separator + brand allows " — Acme", ": Acme", "| Acme".
+// Trailing brand is capped at 60 chars to keep "Sponsored by X" from
+// chewing through a misclassified prose paragraph.
+const STANDALONE_RE = new RegExp(
+  String.raw`^(?:${STANDALONE_PHRASES.map(escapeRegex).join(
+    "|",
+  )})(?:\s*[:\-—–|·]\s*.{1,60})?$`,
+  "i",
+);
+const SUFFIX_RE = new RegExp(
+  String.raw`^(?:${SUFFIX_PHRASES.map(escapeRegex).join("|")})\s+.{1,60}$`,
+  "i",
+);
+
+// Bracket / parenthesized labels common in social feeds and mobile apps.
+// Case-sensitive on the "A" so the English preposition "ad" in
+// "[ad hoc]" / "[ad lib]" doesn't trigger.
+const BRACKET_RE = /^(?:\[Ad\]|\[AD\]|\(promoted\)|\(sponsored\))$/;
+
+interface LabelMatch {
+  // The phrase form that matched, used in the placeholder copy so a
+  // reviewer / agent can see which signal fired.
+  phrase: string;
+}
+
+function matchLabel(text: string): LabelMatch | null {
+  // Bracket form is case-sensitive on `Ad`, so check it before the
+  // case-insensitive regexes.
+  if (BRACKET_RE.test(text)) {
+    return { phrase: text };
+  }
+  if (STANDALONE_RE.test(text)) {
+    return { phrase: text };
+  }
+  if (SUFFIX_RE.test(text)) {
+    return { phrase: text };
+  }
+  return null;
+}
+
+// Interactive / form-control ancestors indicate the candidate is a filter
+// chip, sort option, or button — not an advertorial label. Stop walking
+// upward as soon as one of these is hit.
+function isInteractiveAncestor(element: Element): boolean {
+  const name = element.localName;
+  if (
+    name === "button" ||
+    name === "select" ||
+    name === "option" ||
+    name === "input" ||
+    name === "textarea" ||
+    name === "label"
+  ) {
+    return true;
+  }
+  const role = element.getAttribute("role");
+  if (
+    role === "button" ||
+    role === "tab" ||
+    role === "menuitem" ||
+    role === "option" ||
+    role === "checkbox" ||
+    role === "radio" ||
+    role === "switch"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// Navigation / landmark ancestors — labels here are nav links to the
+// publisher's branded-content hub, not embedded advertorials. Removing the
+// containing card would punch a hole in the nav.
+function isNavigationAncestor(element: Element): boolean {
+  const name = element.localName;
+  if (name === "nav" || name === "header") {
+    return true;
+  }
+  const role = element.getAttribute("role");
+  return role === "navigation" || role === "banner";
+}
+
+// Boundary tags we treat as "you've walked too far". Once we reach <main>,
+// <body>, or <html>, the label isn't sitting on an article card.
+// `<section>` is intentionally not a boundary — it's the natural wrapper
+// for an advertorial.
+function isPageBoundary(element: Element): boolean {
+  const name = element.localName;
+  if (name === "main" || name === "body" || name === "html") {
+    return true;
+  }
+  return element.getAttribute("role") === "main";
+}
+
+// True if `element` looks like an article card: contains a heading, plus
+// at least one of an image or an outgoing link, plus enough prose text to
+// be confusable with editorial. The label text itself and headings are
+// excluded from the prose count so a label-only row doesn't qualify.
+function isArticleShaped(element: Element, labelElement: Element): boolean {
+  const heading = element.querySelector("h1, h2, h3, h4, h5, h6");
+  if (heading === null) {
+    return false;
+  }
+  const hasImage = element.querySelector("img, picture") !== null;
+  const hasLink = element.querySelector("a[href]") !== null;
+  if (!hasImage && !hasLink) {
+    return false;
+  }
+  // Tally text content excluding the label itself and any headings — the
+  // remainder is the prose body. Card-shaped UI chrome (sort headers,
+  // facet rows) has a label and maybe a heading but nothing substantial
+  // after that.
+  let proseLength = 0;
+  for (const child of element.querySelectorAll("p, span, div, li")) {
+    if (child === labelElement || labelElement.contains(child)) {
+      continue;
+    }
+    if (child.querySelector("h1, h2, h3, h4, h5, h6") !== null) {
+      continue;
+    }
+    if (
+      child.localName === "h1" ||
+      child.localName === "h2" ||
+      child.localName === "h3" ||
+      child.localName === "h4" ||
+      child.localName === "h5" ||
+      child.localName === "h6"
+    ) {
+      continue;
+    }
+    proseLength += child.textContent.trim().length;
+    if (proseLength >= MIN_ARTICLE_PROSE_LENGTH) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Walk up from a matched label element looking for an article-shaped
+// container. Returns the container, or null if no suitable ancestor is
+// reachable within the hop budget (most often because the label is sitting
+// on a filter chip / nav link / standalone disclosure).
+export function findArticleAncestor(label: Element): HTMLElement | null {
+  let cursor: Element | null = label.parentElement;
+  let hops = 0;
+  while (cursor !== null && hops < MAX_ANCESTOR_HOPS) {
+    if (isInteractiveAncestor(cursor) || isNavigationAncestor(cursor)) {
+      return null;
+    }
+    if (isPageBoundary(cursor)) {
+      return null;
+    }
+    if (
+      cursor instanceof HTMLElement &&
+      cursor.isConnected &&
+      isArticleShaped(cursor, label)
+    ) {
+      return cursor;
+    }
+    cursor = cursor.parentElement;
+    hops++;
+  }
+  return null;
+}
+
+function isInsideHiddenAd(element: Element): boolean {
+  // `ads-hide`'s curated selectors stamp HIDDEN_ATTR on display:none nodes
+  // (see selector-hide-rule). Any ancestor with that attribute means the
+  // surrounding region is already an ad; we'd be double-flagging.
+  return element.closest(`[${HIDDEN_ATTR}="ads-hide"]`) !== null;
+}
+
+function isCandidateSkipped(element: HTMLElement): boolean {
+  if (element.hasAttribute(CONSIDERED_ATTR)) {
+    return true;
+  }
+  if (element.hasAttribute(REVEALED_ATTR)) {
+    return true;
+  }
+  if (isInsidePlaceholder(element)) {
+    return true;
+  }
+  if (isInsideHiddenAd(element)) {
+    return true;
+  }
+  // If any ancestor up to a navigation / interactive boundary is itself
+  // nav / interactive, the candidate can't be an advertorial. We do the
+  // cheap structural check here so findInnermostMatches doesn't return
+  // matches we'll immediately throw away.
+  let cursor: Element | null = element.parentElement;
+  let hops = 0;
+  while (cursor !== null && hops < MAX_ANCESTOR_HOPS) {
+    if (isInteractiveAncestor(cursor) || isNavigationAncestor(cursor)) {
+      return true;
+    }
+    if (isPageBoundary(cursor)) {
+      return false;
+    }
+    cursor = cursor.parentElement;
+    hops++;
+  }
+  return false;
+}
+
+function placeholderLabel(phrase: string): string {
+  return `[hidden: sponsored content ("${phrase}") — click to reveal]`;
+}
+
+interface Candidate {
+  label: HTMLElement;
+  article: HTMLElement;
+  phrase: string;
+}
+
+function collectCandidates(root: ParentNode): Candidate[] {
+  const labelMatches = findInnermostMatches<LabelMatch>(root, {
+    maxTextLength: MAX_LABEL_TEXT_LENGTH,
+    maxDescendants: MAX_LABEL_DESCENDANTS,
+    isSkipped: isCandidateSkipped,
+    match: (text) => matchLabel(text),
+  });
+
+  // Dedupe by article identity first — two labels inside the same card
+  // (e.g., a small "Sponsored" badge plus a "Paid for and presented by"
+  // caption) resolve to the same article container, and we should hide it
+  // exactly once. `filterToOutermost` after that handles the rarer case
+  // where an advertorial card is itself nested inside an outer
+  // article-shaped container that also matched.
+  const byArticle = new Map<HTMLElement, Candidate>();
+  for (const { element, match } of labelMatches) {
+    const article = findArticleAncestor(element);
+    if (article === null) {
+      // Mark the label so we don't re-evaluate the same negative case on
+      // every mutation burst. The marker is per-rule so other rules are
+      // unaffected.
+      element.setAttribute(CONSIDERED_ATTR, "no-article-ancestor");
+      continue;
+    }
+    if (!byArticle.has(article)) {
+      byArticle.set(article, {
+        label: element,
+        article,
+        phrase: match.phrase,
+      });
+    }
+  }
+  return filterToOutermost([...byArticle.values()], (c) => c.article);
+}
+
+function hideCandidate(candidate: Candidate): void {
+  if (!candidate.article.isConnected) {
+    return;
+  }
+  const placeholder = replaceWithBlockPlaceholder(
+    candidate.article,
+    RULE_ID,
+    placeholderLabel(candidate.phrase),
+  );
+  // Same height-cap pattern as irrelevant-sections-redact so a tall
+  // advertorial doesn't blow out the layout when collapsed.
+  placeholder.style.maxHeight = "200px";
+  placeholder.style.overflow = "hidden";
+}
+
+function scanAndHide(root: ParentNode): void {
+  const candidates = collectCandidates(root);
+  if (candidates.length === 0) {
+    return;
+  }
+  for (const candidate of candidates) {
+    hideCandidate(candidate);
+  }
+  log("disguised ad placeholders inserted", {
+    count: candidates.length,
+    phrases: candidates.map((c) => c.phrase),
+  });
+}
+
+const watcher = createSubtreeWatcher({
+  skipPlaceholderSubtrees: true,
+  onSubtrees: (roots) => {
+    for (const root of roots) {
+      scanAndHide(root);
+    }
+  },
+});
+
+function apply(root: ParentNode): void {
+  scanAndHide(root);
+  watcher.start(root);
+}
+
+export const disguisedAdFlagRule = {
+  id: RULE_ID,
+  label: "Hide Disguised Ads (Native Advertorials)",
+  description:
+    "Hide article-shaped blocks that carry a visible 'Sponsored', 'Promoted', 'Advertorial', or 'Paid Post' disclosure label. Catches native advertorials that bypass network-level ad selectors (EasyList) because the publisher's own CMS renders them. Replaces the card with a click-to-reveal placeholder.",
+  apply,
+  teardown: () => {
+    watcher.stop();
+  },
+} satisfies Rule;

--- a/extension/src/rules/disguised-ad-flag.ts
+++ b/extension/src/rules/disguised-ad-flag.ts
@@ -195,22 +195,29 @@ function isArticleShaped(element: Element, labelElement: Element): boolean {
   // remainder is the prose body. Card-shaped UI chrome (sort headers,
   // facet rows) has a label and maybe a heading but nothing substantial
   // after that.
+  //
+  // We only count "leaf-ish" candidates — those that don't themselves
+  // contain another selector match. `<div><p><span>X</span></p></div>`
+  // would otherwise count the same characters three times (div, p, span)
+  // and let a 40-char card slip past an 80-char minimum.
+  const proseCandidates = element.querySelectorAll("p, span, div, li");
+  const candidateSet = new Set(proseCandidates);
   let proseLength = 0;
-  for (const child of element.querySelectorAll("p, span, div, li")) {
+  for (const child of proseCandidates) {
     if (child === labelElement || labelElement.contains(child)) {
       continue;
     }
     if (child.querySelector("h1, h2, h3, h4, h5, h6") !== null) {
       continue;
     }
-    if (
-      child.localName === "h1" ||
-      child.localName === "h2" ||
-      child.localName === "h3" ||
-      child.localName === "h4" ||
-      child.localName === "h5" ||
-      child.localName === "h6"
-    ) {
+    let hasNestedCandidate = false;
+    for (const nested of child.querySelectorAll("p, span, div, li")) {
+      if (candidateSet.has(nested)) {
+        hasNestedCandidate = true;
+        break;
+      }
+    }
+    if (hasNestedCandidate) {
       continue;
     }
     proseLength += child.textContent.trim().length;

--- a/extension/src/rules/index.ts
+++ b/extension/src/rules/index.ts
@@ -11,6 +11,7 @@ import { confirmshameSanitizeRule } from "./confirmshame-sanitize";
 import { cookieBannerHideRule } from "./cookie-banner-hide";
 import { countdownTimerRedactRule } from "./countdown-timer-redact";
 import { crossOriginFrameRedactRule } from "./cross-origin-frame-redact";
+import { disguisedAdFlagRule } from "./disguised-ad-flag";
 import { footerRedactRule } from "./footer-redact";
 import { hiddenTextStripRule } from "./hidden-text-strip";
 import { htmlCommentStripRule } from "./html-comment-strip";
@@ -75,6 +76,7 @@ const RULES_TUPLE = [
   irrelevantSectionsRedactRule,
   crossOriginFrameRedactRule,
   schemaTrustSanitizeRule,
+  disguisedAdFlagRule,
 ] as const satisfies readonly Rule[];
 
 export type RuleId = (typeof RULES_TUPLE)[number]["id"];

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -37,4 +37,5 @@ export const RULE_DEFAULTS: Readonly<Record<RuleId, boolean>> = {
   "irrelevant-sections-redact": false,
   "cross-origin-frame-redact": false,
   "schema-trust-sanitize": false,
+  "disguised-ad-flag": true,
 };

--- a/skills/agent-browser-shield-config/SKILL.md
+++ b/skills/agent-browser-shield-config/SKILL.md
@@ -77,6 +77,12 @@ for the build-time workflow.
 - `social-embed-redact` — strip social media embeds
 - `ads-hide` — remove display ads and paid/sponsored search results (curated
   selectors + EasyList stylesheet)
+- `disguised-ad-flag` — hide article-shaped blocks carrying a visible
+  "Sponsored" / "Promoted" / "Advertorial" / "Paid Post" / "Partner Content"
+  disclosure label (plus bracket forms like `[Ad]` and suffix forms like "Paid
+  for and presented by X"). Catches native advertorials rendered by the
+  publisher's CMS that bypass the network-level selectors in `ads-hide`.
+  Replaces matching cards with click-to-reveal placeholders.
 - `cart-addon-annotate` — flag likely sneak-into-basket add-ons
 - `link-spoof-annotate` — flag `<a>` elements whose visible text mixes scripts
   (homoglyph) or shows a domain that doesn't match the link's actual host.

--- a/skills/agent-browser-shield/SKILL.md
+++ b/skills/agent-browser-shield/SKILL.md
@@ -19,9 +19,13 @@ surfaces **before you see the page**.
   `irrelevant-sections-redact` rule embeds an AI-generated one-sentence summary
   instead: `[hidden: <summary> — click to reveal]` (e.g.
   `[hidden: Carousel of 6 related kitchen knives with prices and ratings — click to reveal]`).
-  Use that descriptor to decide whether to reveal. The same string appears as
-  visible button text only when the user has selected "Button with label" on the
-  options page; in the default "Icon only" display mode the button shows just a
+  `disguised-ad-flag` uses the same `[hidden: …]` shape with the matched
+  disclosure label quoted in place of the summary (e.g.
+  `[hidden: sponsored content ("Sponsored") — click to reveal]`); the revealed
+  content is a paid advertorial — treat it as advertising even if revealed. Use
+  the descriptor to decide whether to reveal. The same string appears as visible
+  button text only when the user has selected "Button with label" on the options
+  page; in the default "Icon only" display mode the button shows just a
   rule-specific shield-style SVG icon and the visible text is hidden by CSS, so
   always read the descriptor from `aria-label`, not `textContent`.
 - `.abs-cart-addon-annotate` — warning chip prepended into a cart line item


### PR DESCRIPTION
## Summary

- New `disguised-ad-flag` rule (Context pollution group, default on) that hides article-shaped blocks carrying a visible "Sponsored" / "Promoted" / "Advertorial" / "Paid Post" / "Partner Content" disclosure label. Fills the gap left by `ads-hide`: EasyList catches infrastructure-level ads via network selectors, but native advertorials rendered by the publisher's own CMS share DOM shape with editorial articles and slip through.
- False-positive guards: whole-string regex on a leaf-ish label element (≤80 chars, ≤3 children) keeps editorial prose ("the team is sponsored by Adidas") from matching; an interactive-ancestor walk excludes filter chips, nav links, and form controls; `data-abs-hidden="ads-hide"` ancestors are skipped to avoid double-flagging; bracket form `[Ad]` is case-sensitive on the `A` so Latin "[ad hoc]" doesn't trigger.
- Replaces matched cards with the standard click-to-reveal placeholder (200 px height cap, same pattern as `irrelevant-sections-redact`). Subtree-watched so lazy-injected advertorials (Outbrain/Taboola native, infinite scroll feeds) get caught after document_idle.
- Docs section under Context pollution explains the label-only detection, the FTC `.com Disclosures` rationale, and the Kohlschütter/Readability prior art.
- New `AdvertorialCard` demo fixture with three label variants (`Sponsored`, `[Ad]`, `Paid for and presented by Acme`) interleaved with real product cards, plus an editorial negative fixture whose body contains "sponsored by Adidas" as prose. Lets a reviewer toggle the rule in the popup and watch the advertorials collapse while the editorial card stays put.

## Test plan

- [ ] `bun --filter extension run test` — 960 tests pass (25 new in `disguised-ad-flag.test.ts`)
- [ ] `bun --filter extension run lint` clean
- [ ] `bun --filter extension run typecheck` clean
- [ ] `bun --filter demo-site run check` clean
- [ ] `bun --filter demo-site run build` clean
- [ ] `bun --filter docs run build` clean (8 pages built)
- [ ] Load the unpacked extension against the demo site, toggle `disguised-ad-flag` on in the popup, and visually confirm: the three advertorial cards in "From Our Partners" collapse to placeholders; the editorial article mentioning "sponsored by Adidas" stays visible; existing product cards are untouched.
- [ ] Spot-check on a real NYT T Brand Studio / BuzzFeed branded post / Atlantic Re:Think page — the advertorial card replaces with the placeholder.
- [ ] Spot-check that pages with a "Sponsored" link in the nav and Google Shopping pages with a "Sponsored" filter are NOT affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)