### PR TITLE
Nudge users to star the repo, sharpen docs tagline

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -12,7 +12,10 @@ export default defineConfig({
     starlight({
       title: "agent-browser-shield",
       description:
-        "Browser extension prototypes for improving browser-use agent performance.",
+        "Browser extension with 30+ rules for keeping your AI agent safe while browsing.",
+      components: {
+        SocialIcons: "./src/components/SocialIcons.astro",
+      },
       social: [
         {
           icon: "github",

--- a/docs/src/components/SocialIcons.astro
+++ b/docs/src/components/SocialIcons.astro
@@ -1,0 +1,46 @@
+---
+import { Icon } from "@astrojs/starlight/components";
+import Default from "@astrojs/starlight/components/SocialIcons.astro";
+---
+
+<a
+  class="star-cta"
+  href="https://github.com/pixiebrix/agent-browser-shield"
+  target="_blank"
+  rel="noopener noreferrer"
+>
+  <Icon name="star" size="1em" />
+  <span>Star on GitHub</span>
+</a>
+<Default><slot /></Default>
+
+<style>
+  .star-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.3rem 0.65rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 999px;
+    font-size: var(--sl-text-xs);
+    font-weight: 600;
+    line-height: 1;
+    color: var(--sl-color-white);
+    text-decoration: none;
+    background: var(--sl-color-gray-6, transparent);
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+  }
+  .star-cta:hover {
+    background: var(--sl-color-gray-5);
+    border-color: var(--sl-color-gray-4);
+  }
+  @media (max-width: 50rem) {
+    .star-cta span {
+      display: none;
+    }
+    .star-cta {
+      padding: 0.3rem;
+      border-radius: 999px;
+    }
+  }
+</style>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: agent-browser-shield
-description: Browser extension prototypes for improving browser-use agent performance.
+description: Browser extension with 30+ rules for keeping your AI agent safe while browsing.
 ---
 
 import { Aside, Card, CardGrid, LinkButton } from "@astrojs/starlight/components";
@@ -49,6 +49,12 @@ safer, and more accurate.
 
 For the full project overview, see the
 [repository README](https://github.com/pixiebrix/agent-browser-shield#readme).
+
+<Aside type="tip">
+  Find this useful? [Give it a star on
+  GitHub](https://github.com/pixiebrix/agent-browser-shield) to help others
+  discover it.
+</Aside>
 
 <Aside type="caution" title="Disclaimer">
   `agent-browser-shield` reduces the threats a browser-use agent faces on a


### PR DESCRIPTION
## Summary
- Adds a Starlight `SocialIcons` override that renders a "★ Star on GitHub" pill in the docs header on every page, collapsing to icon-only on narrow viewports. No live star count is fetched.
- Updates the Starlight `description` (used for SEO/metadata) and the home page frontmatter tagline to "Browser extension with 30+ rules for keeping your AI agent safe while browsing."
- Adds a tip-style `<Aside>` under "Ideas in the repo" inviting readers to star the repo.

## Test plan
- [ ] `cd docs && bun run check` passes.
- [ ] `cd docs && bun run dev` — visit `http://localhost:4321/agent-browser-shield/` and confirm the star pill appears in the header next to the GitHub icon, and shrinks to icon-only on a narrow viewport.
- [ ] Confirm the tip Aside appears beneath the "Ideas in the repo" section on the home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)