### PR TITLE
Tighten newsletter-modal-hide to require an email input

### DIFF
--- a/extension/src/rules/__tests__/newsletter-modal-hide.test.ts
+++ b/extension/src/rules/__tests__/newsletter-modal-hide.test.ts
@@ -83,6 +83,40 @@ describe("newsletterModalHideRule", () => {
     expect(document.querySelector("section")).not.toBeNull();
   });
 
+  // Regression for #126: GitHub's "Create new issue" template chooser is a
+  // fixed-position dialog with a <form> wrapping the template-selection
+  // buttons, but no <input type="email">. Under the old filter, any
+  // newsletter-keyword text anywhere in the dialog (a "Sign up for GitHub"
+  // CTA, a "Subscribe to release notifications" template description, the
+  // contributor-prompt copy that GitHub appends to issue templates, etc.)
+  // was enough to trigger removal because the form-only branch admitted
+  // the dialog. Requiring a real email input keeps coverage on actual
+  // signup popups while letting application dialogs through.
+  it("leaves a template-chooser dialog alone when there is no email input", () => {
+    document.body.innerHTML = `
+      <div role="dialog" aria-label="Create new issue" style="position: fixed">
+        <header>
+          <h2>Create new issue</h2>
+          <button aria-label="Close">×</button>
+        </header>
+        <form>
+          <ul>
+            <li><a href="/o/r/issues/new?template=bug">Bug report — Report a defect</a></li>
+            <li><a href="/o/r/issues/new?template=feat">Feature request — Suggest a new capability</a></li>
+            <li><a href="/o/r/issues/new">Blank issue — Create a new issue from scratch</a></li>
+          </ul>
+          <footer>Sign up for release notifications to follow updates.</footer>
+        </form>
+      </div>
+    `;
+    newsletterModalHideRule.apply(document.body);
+
+    const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.getAttribute(HIDDEN_ATTR)).toBeNull();
+    expect(dialog?.style.display).not.toBe("none");
+  });
+
   it("does not remove content nested inside an existing placeholder", () => {
     document.body.innerHTML = `
       <div class="${PLACEHOLDER_CLASS}">

--- a/extension/src/rules/newsletter-modal-hide.ts
+++ b/extension/src/rules/newsletter-modal-hide.ts
@@ -10,8 +10,11 @@
 //   1. fixed/sticky positioning (real overlays, not in-flow forms)
 //   2. covers ≥25% of the viewport (filters out small toasts)
 //   3. contains signup-language ("subscribe", "newsletter", etc.)
-//   4. contains an <input type="email"> or a <form> descendant
-// The combination keeps login modals, paywalls, and age-gates visible.
+//   4. contains an <input type="email">
+// The combination keeps login modals, paywalls, age-gates, and application
+// dialogs (GitHub's issue-template chooser, search, command palette) visible
+// — they have forms but no email field, which the email-input gate filters
+// out cleanly.
 //
 // Newsletter modals commonly inject after a 5–30s timer or scroll-depth
 // trigger, so the rule subscribes to the subtree watcher to re-scan added
@@ -47,10 +50,7 @@ function looksLikeNewsletterModal(element: HTMLElement): boolean {
     return false;
   }
 
-  if (
-    !element.querySelector('input[type="email"]') &&
-    !element.querySelector("form")
-  ) {
+  if (!element.querySelector('input[type="email"]')) {
     return false;
   }
   return true;


### PR DESCRIPTION
## Summary
- Drops the form-only branch of the `newsletter-modal-hide` candidate filter; now requires an `<input type="email">` descendant for generic `[role="dialog"]` matches to fire. Vendor-specific selectors (Sumo, OptinMonster, Privy, Mailchimp, Klaviyo, etc.) still go through the same gate.
- Adds a regression test that mirrors GitHub's "Create new issue" template chooser shape — a fixed-position `role="dialog"` with a `<form>` wrapping template links, no email input, and incidental signup-keyword copy. Test fails on `main` and passes after the fix.

## Why this rule

Of the default-on rules that hide DOM, `newsletter-modal-hide` is the only one whose generic surface (`[role="dialog"]`, `[role="alertdialog"]`, `.modal.show`, `.popup`) could catch GitHub's chooser. `cookie-banner-hide` requires `aria-label*="cookie|consent"`; `chat-widget-hide` is vendor-id only; `ads-hide`'s EasyList list has no generic dialog/overlay selectors (I grepped). Threading the issue through this rule's filter is the narrowest fix.

The form-only branch was redundant for real-world coverage: every newsletter popup that's also worth firing on collects an email, so requiring `input[type="email"]` doesn't lose vendors. It does close the door on a class of false positives — any application dialog (issue chooser, search, command palette, comment form) whose textContent happens to include "subscribe" / "sign up" / "stay updated" was previously eligible.

## Test plan
- [x] `bun run test` — 992 passing, including the new regression case.
- [x] `bun run check` + `bun run typecheck`.
- [ ] **Manual (you):** load this branch as an unpacked extension in Chrome with the default rules enabled, visit `https://github.com/pixiebrix/agent-browser-shield/issues`, click **New issue**, confirm the template chooser modal appears.
- [ ] **Manual (you):** if the chooser still doesn't appear, the culprit is a different rule — toggle `newsletter-modal-hide` back on and bisect from the Options page. The new test still adds defensive coverage for the false-positive class.

Closes #126 if manual verification confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)