### PR TITLE
Skip opacity:0 strip when the element is animating opacity

### DIFF
--- a/extension/src/rules/__tests__/hidden-text-strip.test.ts
+++ b/extension/src/rules/__tests__/hidden-text-strip.test.ts
@@ -84,6 +84,36 @@ describe("hiddenTextStripRule", () => {
     expect(document.querySelector("#x")).toBeNull();
   });
 
+  it("still strips opacity:0 when the transition duration is zero", () => {
+    // A `transition: opacity 0s` is instantaneous — the text never becomes
+    // visible. Without this case, an attacker could declare a zero-duration
+    // opacity transition to bypass the strip.
+    document.body.innerHTML = `
+      <div id="x" style="opacity: 0; transition: opacity 0s">${FIXTURES.HIDDEN_IGNORE_PRIOR}</div>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#x")).toBeNull();
+  });
+
+  it("still strips opacity:0 when the animation duration is zero", () => {
+    document.body.innerHTML = `
+      <div id="x" style="opacity: 0; animation: fadeIn 0s">${FIXTURES.HIDDEN_IGNORE_PRIOR}</div>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#x")).toBeNull();
+  });
+
+  it("still strips opacity:0 when the transition targets a non-opacity property", () => {
+    document.body.innerHTML = `
+      <div id="x" style="opacity: 0; transition: transform 150ms">${FIXTURES.HIDDEN_IGNORE_PRIOR}</div>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#x")).toBeNull();
+  });
+
   it("removes text positioned off-screen", () => {
     document.body.innerHTML = `
       <div id="x" style="position: absolute; left: -10000px">hidden text</div>

--- a/extension/src/rules/__tests__/hidden-text-strip.test.ts
+++ b/extension/src/rules/__tests__/hidden-text-strip.test.ts
@@ -34,6 +34,56 @@ describe("hiddenTextStripRule", () => {
     expect(document.querySelector("#x")).toBeNull();
   });
 
+  // Regression for #126: Primer's <dialog> backdrop renders at opacity:0
+  // with an opacity transition, then animates to 1 once the dialog opens.
+  // The subtree watcher catches the wrapper mid-transition. The opacity:0
+  // is transient (the user will see it within ~150ms), not a hidden-text
+  // injection signal, so the rule must let transitioning elements through.
+  it("does not strip an element fading in via opacity transition", () => {
+    document.body.innerHTML = `
+      <div id="backdrop" style="opacity: 0; transition: opacity 150ms ease-out">
+        <h2>Create new issue</h2>
+        <p>Bug report</p>
+      </div>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#backdrop")).not.toBeNull();
+  });
+
+  it("does not strip an element fading in via a transition on `all`", () => {
+    document.body.innerHTML = `
+      <div id="x" style="opacity: 0; transition: all 200ms">
+        modal contents
+      </div>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#x")).not.toBeNull();
+  });
+
+  it("does not strip an element with a running opacity keyframe animation", () => {
+    document.body.innerHTML = `
+      <div id="x" style="opacity: 0; animation: fadeIn 150ms ease-out">
+        modal contents
+      </div>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#x")).not.toBeNull();
+  });
+
+  it("still strips opacity:0 when no transition or animation is set", () => {
+    // Guards against making the transition check too permissive — a plain
+    // opacity:0 with no animation is the classic hidden-injection signal.
+    document.body.innerHTML = `
+      <div id="x" style="opacity: 0">${FIXTURES.HIDDEN_IGNORE_PRIOR}</div>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#x")).toBeNull();
+  });
+
   it("removes text positioned off-screen", () => {
     document.body.innerHTML = `
       <div id="x" style="position: absolute; left: -10000px">hidden text</div>

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -195,55 +195,74 @@ function hasStructuralSrOnlyPattern(style: CSSStyleDeclaration): boolean {
 // poor injection carrier: by definition the text will become visible to
 // sighted users when the animation completes, so the asymmetry the rule
 // defends against doesn't hold.
-const NONZERO_DURATION_PATTERN = /\b\d*\.?\d+(?:m?s)\b/;
+// Match a single CSS time literal (`0`, `0.5`, `150` …) followed by `s` or
+// `ms`. Used to walk a shorthand string and pick out the numeric magnitude;
+// the caller decides whether the magnitude is non-zero.
+const DURATION_TOKEN_PATTERN = /\b(\d*\.?\d+)(ms|s)\b/g;
 
 function hasNonzeroDuration(value: string | null | undefined): boolean {
-  return (
-    value !== null &&
-    value !== undefined &&
-    value !== "" &&
-    value !== "0s" &&
-    value !== "0ms"
-  );
+  if (!value) {
+    return false;
+  }
+  const numeric = Number.parseFloat(value);
+  return Number.isFinite(numeric) && numeric > 0;
+}
+
+// True if any time literal in the shorthand string has a non-zero magnitude.
+// Reject the `transition: opacity 0s` bypass — a zero-duration transition is
+// instantaneous, so the text would remain permanently invisible to sighted
+// users and is still injection-shaped.
+function shorthandHasNonzeroDuration(shorthand: string): boolean {
+  DURATION_TOKEN_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null = DURATION_TOKEN_PATTERN.exec(shorthand);
+  while (match !== null) {
+    if (Number.parseFloat(match[1] ?? "") > 0) {
+      return true;
+    }
+    match = DURATION_TOKEN_PATTERN.exec(shorthand);
+  }
+  return false;
 }
 
 function hasOpacityAnimationInFlight(style: CSSStyleDeclaration): boolean {
-  // Real browsers expand the `transition`/`animation` shorthand into the
-  // longhand properties checked here. jsdom keeps only the shorthand, so we
-  // fall back to a substring scan on the shorthand string. Both paths matter:
-  // the longhand is the production check; the shorthand fallback keeps unit
-  // tests honest.
-  const transitionProperty = style.transitionProperty;
-  if (
-    hasNonzeroDuration(style.transitionDuration) &&
-    transitionProperty &&
-    /\b(?:opacity|all)\b/.test(transitionProperty)
+  // Production path: real browsers expand the `transition`/`animation`
+  // shorthand into the longhand getters, so `transitionProperty` is always
+  // populated (default `"all"`) and `transitionDuration` is always `"0s"` for
+  // unset transitions. The longhand check is canonical there.
+  //
+  // The shorthand check is a jsdom-only fallback: jsdom keeps the shorthand
+  // verbatim and leaves the longhand getters empty, so `!transitionProperty`
+  // distinguishes the test environment from production. Gating the fallback
+  // this way means the shorthand parser can never weaken the longhand
+  // check — `transition: opacity 0s` in a real browser fails the longhand
+  // duration check and the shorthand block is never reached.
+  if (style.transitionProperty) {
+    if (
+      /\b(?:opacity|all)\b/.test(style.transitionProperty) &&
+      hasNonzeroDuration(style.transitionDuration)
+    ) {
+      return true;
+    }
+  } else if (
+    style.transition &&
+    /\b(?:opacity|all)\b/.test(style.transition) &&
+    shorthandHasNonzeroDuration(style.transition)
   ) {
     return true;
   }
-  const transitionShorthand = style.transition;
-  if (
-    transitionShorthand &&
-    /\b(?:opacity|all)\b/.test(transitionShorthand) &&
-    NONZERO_DURATION_PATTERN.test(transitionShorthand)
+
+  if (style.animationName && style.animationName !== "none") {
+    if (hasNonzeroDuration(style.animationDuration)) {
+      return true;
+    }
+  } else if (
+    style.animation &&
+    style.animation !== "none" &&
+    shorthandHasNonzeroDuration(style.animation)
   ) {
     return true;
   }
-  if (
-    style.animationName &&
-    style.animationName !== "none" &&
-    hasNonzeroDuration(style.animationDuration)
-  ) {
-    return true;
-  }
-  const animationShorthand = style.animation;
-  if (
-    animationShorthand &&
-    animationShorthand !== "none" &&
-    NONZERO_DURATION_PATTERN.test(animationShorthand)
-  ) {
-    return true;
-  }
+
   return false;
 }
 

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -186,6 +186,67 @@ function hasStructuralSrOnlyPattern(style: CSSStyleDeclaration): boolean {
   return true;
 }
 
+// True if the element's opacity is currently being animated — either via a
+// CSS transition whose property list includes `opacity` (or `all`), or via
+// a keyframe animation. Dialogs, popovers, and toasts routinely render at
+// opacity:0 for a single frame before transitioning to 1; the subtree
+// watcher catches them mid-animation and previously stripped the whole
+// subtree before the user ever saw it (#126). Animating opacity is also a
+// poor injection carrier: by definition the text will become visible to
+// sighted users when the animation completes, so the asymmetry the rule
+// defends against doesn't hold.
+const NONZERO_DURATION_PATTERN = /\b\d*\.?\d+(?:m?s)\b/;
+
+function hasNonzeroDuration(value: string | null | undefined): boolean {
+  return (
+    value !== null &&
+    value !== undefined &&
+    value !== "" &&
+    value !== "0s" &&
+    value !== "0ms"
+  );
+}
+
+function hasOpacityAnimationInFlight(style: CSSStyleDeclaration): boolean {
+  // Real browsers expand the `transition`/`animation` shorthand into the
+  // longhand properties checked here. jsdom keeps only the shorthand, so we
+  // fall back to a substring scan on the shorthand string. Both paths matter:
+  // the longhand is the production check; the shorthand fallback keeps unit
+  // tests honest.
+  const transitionProperty = style.transitionProperty;
+  if (
+    hasNonzeroDuration(style.transitionDuration) &&
+    transitionProperty &&
+    /\b(?:opacity|all)\b/.test(transitionProperty)
+  ) {
+    return true;
+  }
+  const transitionShorthand = style.transition;
+  if (
+    transitionShorthand &&
+    /\b(?:opacity|all)\b/.test(transitionShorthand) &&
+    NONZERO_DURATION_PATTERN.test(transitionShorthand)
+  ) {
+    return true;
+  }
+  if (
+    style.animationName &&
+    style.animationName !== "none" &&
+    hasNonzeroDuration(style.animationDuration)
+  ) {
+    return true;
+  }
+  const animationShorthand = style.animation;
+  if (
+    animationShorthand &&
+    animationShorthand !== "none" &&
+    NONZERO_DURATION_PATTERN.test(animationShorthand)
+  ) {
+    return true;
+  }
+  return false;
+}
+
 function detectHiddenByCss(
   element: Element,
   style: CSSStyleDeclaration,
@@ -196,7 +257,10 @@ function detectHiddenByCss(
       details: { visibility: style.visibility },
     };
   }
-  if (Number.parseFloat(style.opacity) === 0) {
+  if (
+    Number.parseFloat(style.opacity) === 0 &&
+    !hasOpacityAnimationInFlight(style)
+  ) {
     return { reason: "opacity-0", details: { opacity: style.opacity } };
   }
   // `font-size: 0` on a wrapper is the legacy layout trick to collapse


### PR DESCRIPTION
## Summary
- `hidden-text-strip` was the rule hiding GitHub's "Create new issue" modal. Primer's `<dialog>` backdrop (`prc-Dialog-Backdrop-*`) renders at `opacity: 0` with an opacity transition, then fades to 1 once the dialog opens — the subtree watcher caught the wrapper mid-transition and removed the entire modal subtree before the user ever saw it.
- New guard skips the `opacity-0` strip when the element has an in-flight CSS transition or animation involving `opacity` (or `all`). A plain `opacity: 0` with no animation is still stripped — the regression test for that case is added explicitly so the guard can't drift permissive.

## Why this is safe
An animating `opacity: 0` is a transient state — the text will become visible to sighted users when the animation completes, so the asymmetry the rule defends against (text invisible to humans but readable to agents) doesn't hold. The guard requires a non-zero duration to fire, so `transition: opacity 0s` / unset durations still strip normally.

## jsdom note
Real browsers expand the `transition`/`animation` shorthand into `transitionProperty` / `transitionDuration` / `animationName` / `animationDuration`. jsdom keeps only the shorthand. The detector accepts both: longhand is the production path, shorthand fallback keeps the tests honest.

## Test plan
- [x] `bun run test` — 995 passing, including 4 new cases (transition with `opacity`, transition with `all`, keyframe animation, regression guard that plain opacity:0 still strips).
- [x] `bun run check` + `bun run typecheck`.
- [ ] **Manual:** load `extension/dist/` as unpacked, visit `github.com/pixiebrix/agent-browser-shield/issues`, click **New issue** — the template chooser modal should appear.

## Out of scope
The `prc-components-Label-*` clip-to-zero strip you also saw in the console (the `Select all issues` SR-only label) is a separate false positive — Primer's label is a real SR-only element that should be admitted by `hasStructuralSrOnlyPattern`, but Primer must size it slightly differently than what we recognize. Worth a follow-up issue if it's hurting GitHub a11y output.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)