### PR TITLE
Show roach-motel and webdriver-probe detections in the popup

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,16 +1,44 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
+import type {
+  DetectionKind,
+  DetectionPayload,
+  GetTabDetectionsRequest,
+  GetTabDetectionsResponse,
+  RuleDetectionMessage,
+} from "./lib/detection-messages";
 import { subscribeEnforcementEnabled } from "./lib/enforcement";
 import { startClassifyPortListener } from "./lib/llm-background";
+import { ruleStatesStorage } from "./lib/storage";
 import { startWebdriverProbeRegistration } from "./lib/webdriver-probe-registration";
 
 // Per-tab, per-frame placeholder counts. Each content script reports its own
 // frame's tally; the badge shows the sum across frames for that tab.
 const tabCounts = new Map<number, Map<number, number>>();
 
+// Per-tab record of rule detections surfaced to the popup. One entry per
+// kind per tab — both contributing rules are topFrameOnly and self-dedupe
+// per document, so a single payload per kind is the natural shape. Held in
+// memory, cleared on top-level navigation and tab close, same posture as
+// `tabCounts`. A service-worker restart drops it; the popup briefly shows
+// "Nothing flagged" on a page that did have detections until the next
+// re-apply. Promote to chrome.storage.session if that becomes a problem.
+const tabDetections = new Map<number, Map<DetectionKind, DetectionPayload>>();
+
+// Maps each detection kind to the rule id that produces it. Used to clear
+// stale entries when a user toggles the rule off mid-session.
+const DETECTION_KIND_TO_RULE_ID = {
+  "roach-motel": "roach-motel-annotate",
+  "webdriver-probe": "webdriver-probe-annotate",
+} as const satisfies Record<DetectionKind, string>;
+
 // Pleasant blue — clearly an extension affordance, not a warning/error.
-const BADGE_COLOR = "#2563eb";
+const BADGE_COLOR_DEFAULT = "#2563eb";
+// Amber — tab has a roach-motel / webdriver-probe detection worth seeing
+// in the popup. Matches the .enforcement--off palette in popup.html so the
+// "something to look at" signal is visually consistent across surfaces.
+const BADGE_COLOR_DETECTION = "#f59e0b";
 
 function totalForTab(tabId: number): number {
   const frames = tabCounts.get(tabId);
@@ -34,17 +62,25 @@ function formatBadge(total: number): string {
   return String(total);
 }
 
-function setBadge(tabId: number, total: number): void {
-  const text = formatBadge(total);
+function hasDetections(tabId: number): boolean {
+  return (tabDetections.get(tabId)?.size ?? 0) > 0;
+}
+
+function refreshBadge(tabId: number): void {
+  const placeholderText = formatBadge(totalForTab(tabId));
+  const detection = hasDetections(tabId);
+  // Detection without a placeholder count gets a single "!" so the badge
+  // still shows up. Otherwise keep the existing count text — the color
+  // change alone signals "open the popup."
+  const text = placeholderText || (detection ? "!" : "");
   chrome.action.setBadgeText({ tabId, text }).catch(() => {
     // noop
   });
   if (text) {
-    chrome.action
-      .setBadgeBackgroundColor({ tabId, color: BADGE_COLOR })
-      .catch(() => {
-        // noop
-      });
+    const color = detection ? BADGE_COLOR_DETECTION : BADGE_COLOR_DEFAULT;
+    chrome.action.setBadgeBackgroundColor({ tabId, color }).catch(() => {
+      // noop
+    });
   }
 }
 
@@ -62,16 +98,39 @@ function recordFrameCount(tabId: number, frameId: number, count: number): void {
   } else {
     frames.set(frameId, count);
   }
-  setBadge(tabId, totalForTab(tabId));
+  refreshBadge(tabId);
+}
+
+function recordDetection(tabId: number, payload: DetectionPayload): void {
+  let entry = tabDetections.get(tabId);
+  if (!entry) {
+    entry = new Map();
+    tabDetections.set(tabId, entry);
+  }
+  entry.set(payload.kind, payload);
+  refreshBadge(tabId);
 }
 
 function clearTab(tabId: number): void {
   tabCounts.delete(tabId);
-  setBadge(tabId, 0);
+  tabDetections.delete(tabId);
+  refreshBadge(tabId);
+}
+
+function clearDetectionsOfKind(kind: DetectionKind): void {
+  for (const [tabId, entry] of tabDetections) {
+    if (entry.delete(kind)) {
+      if (entry.size === 0) {
+        tabDetections.delete(tabId);
+      }
+      refreshBadge(tabId);
+    }
+  }
 }
 
 chrome.tabs.onRemoved.addListener((tabId) => {
   tabCounts.delete(tabId);
+  tabDetections.delete(tabId);
 });
 
 // On a top-level navigation, drop stale per-frame counts so the new document
@@ -90,9 +149,47 @@ subscribeEnforcementEnabled((enabled) => {
   if (enabled) {
     return;
   }
-  for (const tabId of tabCounts.keys()) {
-    clearTab(tabId);
+  // Snapshot the union of tabs we're tracking before clearing — the badge
+  // for each needs to refresh, and we don't want to iterate a map we're
+  // mutating.
+  const affected = new Set<number>([
+    ...tabCounts.keys(),
+    ...tabDetections.keys(),
+  ]);
+  tabCounts.clear();
+  tabDetections.clear();
+  for (const tabId of affected) {
+    refreshBadge(tabId);
   }
+});
+
+// When a user disables one of the detection-producing rules mid-session,
+// drop the now-stale entries from every tab so the popup matches the
+// current rule selection. Detections for the other (still-enabled) rule
+// stay put. Seed `previousRuleStates` from storage before subscribing —
+// `subscribe` only fires on changes, never with the current value, so
+// without a seed the first off-transition would compare against `null`
+// and skip the clear. We can't use top-level await here (the bundler
+// emits IIFE for the service worker), so chain `.get().then(...)`.
+let previousRuleStates: Record<string, boolean> | null = null;
+ruleStatesStorage.subscribe((next) => {
+  const previous = previousRuleStates;
+  previousRuleStates = { ...next };
+  if (previous === null) {
+    return;
+  }
+  for (const [kind, ruleId] of Object.entries(DETECTION_KIND_TO_RULE_ID) as [
+    DetectionKind,
+    string,
+  ][]) {
+    if (previous[ruleId] === true && next[ruleId] === false) {
+      clearDetectionsOfKind(kind);
+    }
+  }
+});
+// eslint-disable-next-line unicorn/prefer-top-level-await -- IIFE bundle, no TLA
+void ruleStatesStorage.get().then((initial) => {
+  previousRuleStates ??= { ...initial };
 });
 
 chrome.runtime.onMessage.addListener(
@@ -121,6 +218,27 @@ chrome.runtime.onMessage.addListener(
       ) {
         recordFrameCount(tabId, frameId, Math.max(0, Math.floor(raw)));
       }
+      return undefined;
+    }
+
+    if (message.type === "rule-detection") {
+      const tabId = sender.tab?.id;
+      if (typeof tabId === "number") {
+        recordDetection(tabId, (message as RuleDetectionMessage).payload);
+      }
+      return undefined;
+    }
+
+    if (message.type === "get-tab-detections") {
+      const request = message as unknown as GetTabDetectionsRequest;
+      const entry =
+        typeof request.tabId === "number"
+          ? tabDetections.get(request.tabId)
+          : undefined;
+      const response: GetTabDetectionsResponse = {
+        detections: entry ? [...entry.values()] : [],
+      };
+      sendResponse(response);
       return undefined;
     }
 

--- a/extension/src/lib/detection-messages.ts
+++ b/extension/src/lib/detection-messages.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Shared payload + message types for surfacing rule detections to the
+// popup. Rules that hide their findings in the a11y tree (sr-only
+// landmarks) emit a `rule-detection` message at the same moment they
+// stamp the landmark; the background keeps a per-tab record so the popup
+// can render a human-visible "Detected on this page" list. Imported by
+// the rule modules (content world), the background service worker, and
+// the popup — keep this file dependency-free so it stays trivially
+// bundleable into each of those three entry points.
+
+import type { RoachMotelDifficulty } from "../rules/site-data.generated";
+
+export type DetectionKind = "roach-motel" | "webdriver-probe";
+
+export interface RoachMotelDetectionPayload {
+  kind: "roach-motel";
+  host: string;
+  url: string;
+  difficulty: RoachMotelDifficulty;
+  cancellationUrl: string | null;
+  source: "curated" | "justdeleteme";
+}
+
+export interface WebdriverProbeDetectionPayload {
+  kind: "webdriver-probe";
+  host: string;
+  url: string;
+}
+
+export type DetectionPayload =
+  | RoachMotelDetectionPayload
+  | WebdriverProbeDetectionPayload;
+
+export interface RuleDetectionMessage {
+  type: "rule-detection";
+  payload: DetectionPayload;
+}
+
+export interface GetTabDetectionsRequest {
+  type: "get-tab-detections";
+  tabId: number;
+}
+
+export interface GetTabDetectionsResponse {
+  detections: DetectionPayload[];
+}

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -123,11 +123,6 @@
         color: #555;
         border-bottom: 1px solid #e4e4e7;
       }
-      .detections__empty {
-        margin: 0;
-        font-size: 11px;
-        color: #888;
-      }
       .detections__list {
         list-style: none;
         margin: 0;

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -110,6 +110,71 @@
         outline: 2px solid #2563eb;
         outline-offset: 2px;
       }
+      .detections {
+        margin: 0 0 12px;
+      }
+      .detections__heading {
+        margin: 0 0 6px;
+        padding-bottom: 4px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #555;
+        border-bottom: 1px solid #e4e4e7;
+      }
+      .detections__empty {
+        margin: 0;
+        font-size: 11px;
+        color: #888;
+      }
+      .detections__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .detection {
+        padding: 8px 10px;
+        border: 1px solid #fde68a;
+        background: #fffbeb;
+        border-radius: 6px;
+        font-size: 12px;
+      }
+      .detection strong {
+        display: block;
+        font-weight: 600;
+        color: #92400e;
+      }
+      .detection__host {
+        margin: 2px 0 0;
+        font-size: 11px;
+        color: #555;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+      .detection__detail {
+        margin: 4px 0 0;
+        font-size: 11px;
+        color: #666;
+        line-height: 1.3;
+      }
+      .detection__cancel {
+        display: inline-block;
+        margin: 4px 0 0;
+        font-size: 11px;
+        color: #2563eb;
+        text-decoration: none;
+      }
+      .detection__cancel:hover {
+        text-decoration: underline;
+      }
+      .detection__source {
+        margin: 4px 0 0;
+        font-size: 10px;
+        color: #888;
+      }
       .rule-groups {
         display: flex;
         flex-direction: column;

--- a/extension/src/popup/DetectionsSection.tsx
+++ b/extension/src/popup/DetectionsSection.tsx
@@ -17,24 +17,17 @@ const SOURCE_LABEL: Record<"curated" | "justdeleteme", string> = {
 
 export function DetectionsSection() {
   const detections = useTabDetections();
-  // Hold off on rendering until the runtime fetch resolves — otherwise
-  // the empty state flashes for one frame on tabs that do have
-  // detections.
-  if (detections === null) {
+  if (detections === null || detections.length === 0) {
     return null;
   }
   return (
     <section className="detections">
-      <h2 className="detections__heading">Detected on this page</h2>
-      {detections.length === 0 ? (
-        <p className="detections__empty">Nothing flagged on this page.</p>
-      ) : (
-        <ul className="detections__list">
-          {detections.map((detection) => (
-            <DetectionItem key={detection.kind} detection={detection} />
-          ))}
-        </ul>
-      )}
+      <h2 className="detections__heading">Heads up</h2>
+      <ul className="detections__list">
+        {detections.map((detection) => (
+          <DetectionItem key={detection.kind} detection={detection} />
+        ))}
+      </ul>
     </section>
   );
 }

--- a/extension/src/popup/DetectionsSection.tsx
+++ b/extension/src/popup/DetectionsSection.tsx
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import type { DetectionPayload } from "../lib/detection-messages";
+import { useTabDetections } from "./use-tab-detections";
+
+const DIFFICULTY_LABEL: Record<"hard" | "very-hard" | "impossible", string> = {
+  hard: "hard",
+  "very-hard": "very hard",
+  impossible: "effectively impossible",
+};
+
+const SOURCE_LABEL: Record<"curated" | "justdeleteme", string> = {
+  curated: "FTC enforcement / consumer-press list",
+  justdeleteme: "JustDeleteMe directory",
+};
+
+export function DetectionsSection() {
+  const detections = useTabDetections();
+  // Hold off on rendering until the runtime fetch resolves — otherwise
+  // the empty state flashes for one frame on tabs that do have
+  // detections.
+  if (detections === null) {
+    return null;
+  }
+  return (
+    <section className="detections">
+      <h2 className="detections__heading">Detected on this page</h2>
+      {detections.length === 0 ? (
+        <p className="detections__empty">Nothing flagged on this page.</p>
+      ) : (
+        <ul className="detections__list">
+          {detections.map((detection) => (
+            <DetectionItem key={detection.kind} detection={detection} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function DetectionItem({ detection }: { detection: DetectionPayload }) {
+  if (detection.kind === "roach-motel") {
+    return (
+      <li className="detection">
+        <strong>Hard to cancel</strong>
+        <p className="detection__host">{detection.host}</p>
+        <p className="detection__detail">
+          Cancellation is {DIFFICULTY_LABEL[detection.difficulty]} on this site.
+        </p>
+        {detection.cancellationUrl !== null && (
+          <a
+            className="detection__cancel"
+            href={detection.cancellationUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            How to cancel
+          </a>
+        )}
+        <p className="detection__source">
+          Source: {SOURCE_LABEL[detection.source]}
+        </p>
+      </li>
+    );
+  }
+  return (
+    <li className="detection">
+      <strong>navigator.webdriver read</strong>
+      <p className="detection__host">{detection.host}</p>
+      <p className="detection__detail">
+        This site can distinguish AI-agent traffic from human traffic and may
+        serve different content to agents.
+      </p>
+    </li>
+  );
+}

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -8,6 +8,7 @@ import { optionsButtonStorage } from "../lib/options-button-toggle";
 import { RuleList } from "../lib/RuleList";
 import { ruleStatesStorage } from "../lib/storage";
 import { useChromeStorageValue } from "../lib/use-chrome-storage-value";
+import { DetectionsSection } from "./DetectionsSection";
 
 export function Popup() {
   const states = useChromeStorageValue(ruleStatesStorage);
@@ -60,6 +61,7 @@ export function Popup() {
           </p>
         )}
       </div>
+      <DetectionsSection />
       <RuleList
         states={states}
         availability={availability}

--- a/extension/src/popup/use-tab-detections.ts
+++ b/extension/src/popup/use-tab-detections.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import { useEffect, useState } from "react";
+import type {
+  DetectionPayload,
+  GetTabDetectionsRequest,
+  GetTabDetectionsResponse,
+} from "../lib/detection-messages";
+
+// One-shot fetch on popup mount. Returns `null` while the active-tab
+// lookup + runtime message is in flight so the section can hold off on
+// rendering its empty state until we actually know there are no
+// detections. Popups are short-lived — no subscription path needed; the
+// next open re-runs this.
+export function useTabDetections(): DetectionPayload[] | null {
+  const [detections, setDetections] = useState<DetectionPayload[] | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void fetchDetections()
+      .then((next) => {
+        if (!cancelled) {
+          setDetections(next);
+        }
+      })
+      .catch(() => {
+        // Service worker may be asleep / restarting — surface the empty
+        // state rather than hanging on `null`.
+        if (!cancelled) {
+          setDetections([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return detections;
+}
+
+async function fetchDetections(): Promise<DetectionPayload[]> {
+  const [tab] = await chrome.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  if (typeof tab?.id !== "number") {
+    return [];
+  }
+  const request: GetTabDetectionsRequest = {
+    type: "get-tab-detections",
+    tabId: tab.id,
+  };
+  // @types/chrome infers the response type from `sendMessage`'s second
+  // generic. Defend with optional chaining for the SW-restart edge where
+  // the response could come back undefined.
+  const response = await chrome.runtime.sendMessage<
+    GetTabDetectionsRequest,
+    GetTabDetectionsResponse | undefined
+  >(request);
+  return response?.detections ?? [];
+}

--- a/extension/src/rules/__tests__/roach-motel-annotate.test.ts
+++ b/extension/src/rules/__tests__/roach-motel-annotate.test.ts
@@ -7,13 +7,23 @@ import { findWarning, roachMotelAnnotateRule } from "../roach-motel-annotate";
 
 const LANDMARK_SELECTOR = 'section[data-abs-rule="roach-motel-annotate"]';
 
+// Rule's `apply` sends a `rule-detection` runtime message after landing
+// the landmark. `chrome.runtime.sendMessage` isn't present in jsdom, so
+// stub it here. Tests that assert call shape read from this mock.
+const sendMessageMock = jest.fn().mockResolvedValue(undefined);
+
 beforeEach(() => {
   document.body.innerHTML = "";
+  sendMessageMock.mockClear();
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    runtime: { sendMessage: sendMessageMock },
+  };
 });
 
 afterEach(() => {
   roachMotelAnnotateRule.teardown();
   hiddenTextStripRule.teardown();
+  delete (globalThis as unknown as { chrome?: unknown }).chrome;
 });
 
 describe("findWarning", () => {
@@ -110,6 +120,32 @@ describe("roachMotelAnnotateRule.apply (on nytimes.com/subscription/all-access)"
     expect(document.querySelectorAll(LANDMARK_SELECTOR)).toHaveLength(1);
   });
 
+  it("emits a rule-detection runtime message with the matched payload", () => {
+    roachMotelAnnotateRule.apply(document.body);
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith({
+      type: "rule-detection",
+      payload: {
+        kind: "roach-motel",
+        host: "www.nytimes.com",
+        url: "https://www.nytimes.com/subscription/all-access",
+        difficulty: "hard",
+        cancellationUrl:
+          "https://help.nytimes.com/hc/en-us/articles/115014679508",
+        source: "curated",
+      },
+    });
+  });
+
+  it("does not re-emit the runtime message on repeated apply", () => {
+    roachMotelAnnotateRule.apply(document.body);
+    roachMotelAnnotateRule.apply(document.body);
+    roachMotelAnnotateRule.apply(document.body);
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+  });
+
   it("teardown removes the landmark", () => {
     roachMotelAnnotateRule.apply(document.body);
     expect(document.querySelector(LANDMARK_SELECTOR)).not.toBeNull();
@@ -160,6 +196,7 @@ describe("JustDeleteMe fallback", () => {
     expect(warning?.notes ?? "").toContain(
       "Source: JustDeleteMe (justdelete.me)",
     );
+    expect(warning?.source).toBe("justdeleteme");
   });
 
   it("does not fire on a JDM host when path is not signup-y", () => {
@@ -185,6 +222,7 @@ describe("JustDeleteMe fallback", () => {
     expect(warning).not.toBeNull();
     expect(warning?.notes ?? "").toContain("FTC enforcement");
     expect(warning?.notes ?? "").not.toContain("JustDeleteMe");
+    expect(warning?.source).toBe("curated");
   });
 
   it("returns null when neither curated nor JDM matches", () => {

--- a/extension/src/rules/__tests__/webdriver-probe-annotate.test.ts
+++ b/extension/src/rules/__tests__/webdriver-probe-annotate.test.ts
@@ -17,8 +17,17 @@ function dispatchProbe(): void {
 
 const PROBE_FLAG = "__abs_webdriver_probe_installed";
 
+// The rule sends a runtime message on first landmark stamp; stub
+// `chrome.runtime.sendMessage` so apply() doesn't throw and so the
+// "emits to background" tests below can assert on it.
+const sendMessageMock = jest.fn().mockResolvedValue(undefined);
+
 beforeEach(() => {
   document.body.innerHTML = "";
+  sendMessageMock.mockClear();
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    runtime: { sendMessage: sendMessageMock },
+  };
   // jest-environment-jsdom DOES execute inline <script> textContent, so
   // every apply() call really wraps Navigator.prototype.webdriver and
   // the rule's teardown intentionally leaves it wrapped. Reset to a
@@ -30,6 +39,7 @@ beforeEach(() => {
 
 afterEach(() => {
   webdriverProbeAnnotateRule.teardown();
+  delete (globalThis as unknown as { chrome?: unknown }).chrome;
 });
 
 describe("webdriverProbeAnnotateRule.apply", () => {
@@ -108,6 +118,49 @@ describe("webdriverProbeAnnotateRule.apply", () => {
     expect(landmark).not.toBeNull();
     expect(landmark?.textContent).toContain("navigator.webdriver");
     hiddenTextStripRule.teardown();
+  });
+});
+
+describe("webdriverProbeAnnotateRule rule-detection emission", () => {
+  it("does not emit on apply alone — only on observed reads", () => {
+    webdriverProbeAnnotateRule.apply(document.body);
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("sends a rule-detection on the first probe event", () => {
+    webdriverProbeAnnotateRule.apply(document.body);
+    dispatchProbe();
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith({
+      type: "rule-detection",
+      payload: {
+        kind: "webdriver-probe",
+        host: globalThis.location.hostname,
+        url: globalThis.location.href,
+      },
+    });
+  });
+
+  it("does not re-emit on subsequent probe events for the same document", () => {
+    webdriverProbeAnnotateRule.apply(document.body);
+    dispatchProbe();
+    dispatchProbe();
+    dispatchProbe();
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-emits after teardown + re-apply on the same document", () => {
+    webdriverProbeAnnotateRule.apply(document.body);
+    dispatchProbe();
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+
+    webdriverProbeAnnotateRule.teardown();
+    webdriverProbeAnnotateRule.apply(document.body);
+    dispatchProbe();
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/extension/src/rules/roach-motel-annotate.ts
+++ b/extension/src/rules/roach-motel-annotate.ts
@@ -27,12 +27,13 @@
 // sr-only class allowlist plus the 1×1 + overflow:hidden inline envelope.
 
 import { URLPattern } from "urlpattern-polyfill";
+import type { RuleDetectionMessage } from "../lib/detection-messages";
 import { RULE_ATTR } from "../lib/dom-markers";
 import { log } from "../lib/log";
 import { SR_ONLY_INLINE_STYLE } from "../lib/sr-only";
 import type { JustDeleteMeEntry } from "./justdeleteme.generated";
 import { JUSTDELETEME_ENTRIES } from "./justdeleteme.generated";
-import type { RoachMotelDifficulty, SiteWarning } from "./site-data.generated";
+import type { RoachMotelDifficulty } from "./site-data.generated";
 import { ROACH_MOTEL_WARNINGS } from "./site-data.generated";
 import type { Rule } from "./types";
 
@@ -90,12 +91,21 @@ export interface WarningPayload {
   difficulty: RoachMotelDifficulty;
   cancellationUrl: string | null;
   notes: string | null;
+  // Which data source the entry came from. Surfaced to the user in the
+  // popup so curated FTC-defendant entries read distinctly from the
+  // crowdsourced JustDeleteMe fallback.
+  source: "curated" | "justdeleteme";
 }
 
-function findCuratedWarning(url: string): SiteWarning | null {
+function findCuratedWarning(url: string): WarningPayload | null {
   for (const warning of ROACH_MOTEL_WARNINGS) {
     if (warning.patterns.some((pattern) => pattern.test(url))) {
-      return warning;
+      return {
+        difficulty: warning.difficulty,
+        cancellationUrl: warning.cancellationUrl,
+        notes: warning.notes,
+        source: "curated",
+      };
     }
   }
   return null;
@@ -133,6 +143,7 @@ function findJustDeleteMeWarning(url: string): WarningPayload | null {
     difficulty: entry.difficulty,
     cancellationUrl: entry.cancellationUrl,
     notes: noteLines.join("\n"),
+    source: "justdeleteme",
   };
 }
 
@@ -188,6 +199,24 @@ function apply(_root: ParentNode): void {
   log("roach-motel-annotate applied", {
     host: globalThis.location.hostname,
     difficulty: warning.difficulty,
+  });
+  // Tell the background so the popup can render a human-visible entry
+  // for this tab. The line-181 landmark short-circuit already guarantees
+  // we only get here once per document. Service worker may be asleep —
+  // swallow the rejection per the placeholder-count.ts pattern.
+  const message: RuleDetectionMessage = {
+    type: "rule-detection",
+    payload: {
+      kind: "roach-motel",
+      host: globalThis.location.hostname,
+      url: globalThis.location.href,
+      difficulty: warning.difficulty,
+      cancellationUrl: warning.cancellationUrl,
+      source: warning.source,
+    },
+  };
+  chrome.runtime.sendMessage(message).catch(() => {
+    // noop
   });
 }
 

--- a/extension/src/rules/webdriver-probe-annotate.ts
+++ b/extension/src/rules/webdriver-probe-annotate.ts
@@ -41,6 +41,7 @@
 // rule's `teardown` only removes the landmark and the isolated-world
 // listener so re-enabling on the same page still picks up later reads.
 
+import type { RuleDetectionMessage } from "../lib/detection-messages";
 import { RULE_ATTR } from "../lib/dom-markers";
 import { log } from "../lib/log";
 import { SR_ONLY_INLINE_STYLE } from "../lib/sr-only";
@@ -98,6 +99,21 @@ function ensureLandmark(): void {
   document.body.prepend(buildLandmark());
   log("webdriver-probe-annotate landmark added", {
     host: globalThis.location.hostname,
+  });
+  // Notify the background so the popup can show a human-visible entry.
+  // The line-88 landmark short-circuit above doubles as a per-document
+  // dedupe latch — we only get here once per document, no matter how
+  // many times navigator.webdriver gets read.
+  const message: RuleDetectionMessage = {
+    type: "rule-detection",
+    payload: {
+      kind: "webdriver-probe",
+      host: globalThis.location.hostname,
+      url: globalThis.location.href,
+    },
+  };
+  chrome.runtime.sendMessage(message).catch(() => {
+    // noop
   });
 }
 


### PR DESCRIPTION
## Summary

- New "Detected on this page" section in the browser-action popup that lists what `roach-motel-annotate` and `webdriver-probe-annotate` flagged on the active tab.
- Toolbar badge tints amber on tabs with detections; shows `!` when there's no placeholder count to anchor on, otherwise keeps the existing count text.
- Detections clear on navigation, tab close, and when the user toggles the producing rule off mid-session.

## Why

Today both rules surface their findings only as `sr-only` landmarks in the accessibility tree — readable to agents but invisible to sighted users. The popup had no per-tab activity view and the badge only counted placeholders, so a roach-motel hit or a `navigator.webdriver` read on the current page produced zero human-visible signal.

## Approach

- Each rule emits a typed `rule-detection` message right after stamping its landmark. The existing landmark-presence short-circuits double as per-document dedupe latches, so no separate flag is needed.
- `background.ts` keeps a `Map<tabId, Map<DetectionKind, DetectionPayload>>` alongside the existing `tabCounts` map. A unified `refreshBadge(tabId)` reads both signals and picks color + text. Detections are cleared on `tabs.onUpdated` `status: "loading"`, `tabs.onRemoved`, enforcement-off, and rule-disable transitions via `ruleStatesStorage.subscribe`.
- The popup queries the background once on mount via a `get-tab-detections` message; the hook stays `null` until the runtime fetch resolves so the empty state doesn't flash on tabs that actually have detections.
- No new permissions required. Page DOM is untouched, which keeps `hidden-text-strip` and CSP-strict sites out of the picture.

## Out of scope

- Promoting `tabDetections` to `chrome.storage.session` so SW restarts don't lose state (in-memory matches `tabCounts` posture today).
- Surfacing detections via the on-page floating shield button.

## Test plan

- [x] `bun run typecheck`, `bun run check`, `bun run knip`, `bun run build`, `bun run test` (1005 tests pass).
- [ ] Load unpacked from `extension/dist`, visit `https://www.nytimes.com/subscription/all-access`, open popup → roach-motel entry appears with host, difficulty, cancellation link, source; badge is amber.
- [ ] Toggle `roach-motel-annotate` off → entry disappears; badge reverts to blue (or empty) when there's no placeholder count.
- [ ] Toggle `webdriver-probe-annotate` on, reload a probing page → webdriver-probe entry appears.
- [ ] Navigate the same tab elsewhere → detections clear.
- [ ] Close the tab → background drops the entry (verify via SW console).

🤖 Generated with [Claude Code](https://claude.com/claude-code)