### PR TITLE
Route webdriver-probe fallback through chrome.scripting.executeScript

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -10,8 +10,10 @@ import type {
 } from "./lib/detection-messages";
 import { subscribeEnforcementEnabled } from "./lib/enforcement";
 import { startClassifyPortListener } from "./lib/llm-background";
+import { log } from "./lib/log";
 import { ruleStatesStorage } from "./lib/storage";
 import { startWebdriverProbeRegistration } from "./lib/webdriver-probe-registration";
+import { installProbe } from "./lib/webdriver-probe-source";
 
 // Per-tab, per-frame placeholder counts. Each content script reports its own
 // frame's tally; the badge shows the sum across frames for that tab.
@@ -204,6 +206,38 @@ chrome.runtime.onMessage.addListener(
         sendResponse({ ok: true });
       });
       return true;
+    }
+
+    if (message.type === "inject-webdriver-probe") {
+      const tabId = sender.tab?.id;
+      if (typeof tabId !== "number") {
+        return undefined;
+      }
+      const frameId = sender.frameId;
+      // executeScript with world: "MAIN" is exempt from page CSP the same
+      // way the registered content script is, so this lands on strict
+      // `script-src` origins where the rule's previous inline-<script>
+      // fallback was blocked. Targeting the sender's specific frameId
+      // keeps subframes that already received the registered probe from
+      // being re-invoked. installProbe's `__abs_webdriver_probe_installed`
+      // guard makes a redundant call a no-op in the page world.
+      chrome.scripting
+        .executeScript({
+          target: {
+            tabId,
+            frameIds: typeof frameId === "number" ? [frameId] : undefined,
+          },
+          world: "MAIN",
+          func: installProbe,
+        })
+        .catch((error: unknown) => {
+          // Restricted URLs (chrome://, Web Store, view-source:, file: when
+          // disallowed) reject here. The primary registration silently
+          // skips these origins via match-pattern filtering; the fallback
+          // has to swallow the rejection explicitly.
+          log("inject-webdriver-probe executeScript failed", { error });
+        });
+      return undefined;
     }
 
     if (message.type === "placeholder-count") {

--- a/extension/src/lib/webdriver-probe-registration.ts
+++ b/extension/src/lib/webdriver-probe-registration.ts
@@ -13,10 +13,12 @@
 // already-loaded tabs retain whatever wrap they had until the user
 // reloads — same constraint as static content_scripts.
 //
-// The rule's own `apply` still inline-injects the probe as a fallback for
-// the currently-open tab (since dynamic registrations only take effect on
-// subsequent navigations). This module is purely the registration
-// life-cycle for the standalone bundle.
+// The rule's own `apply` covers the currently-open tab by asking the
+// background worker (via an `inject-webdriver-probe` message) to run the
+// probe through `chrome.scripting.executeScript` — dynamic registrations
+// only take effect on subsequent navigations, so without that round-trip
+// the user would have to reload the active tab. This module is purely
+// the registration life-cycle for the standalone bundle.
 
 import {
   getEnforcementEnabled,

--- a/extension/src/lib/webdriver-probe-source.ts
+++ b/extension/src/lib/webdriver-probe-source.ts
@@ -10,20 +10,24 @@
 //      probe runs before the page's own scripts and catches reads issued
 //      during initial parse.
 //
-//   2. Inline `<script>` injection from the rule's `apply` at
-//      `document_idle`. This is the fallback for the tab the user was
-//      already viewing when they toggled the rule on — dynamic
-//      registrations only take effect on subsequent navigations, so
-//      without this fallback the current tab would have to be reloaded
-//      to pick up the rule. The fallback misses early-parse reads, but
-//      reads from `DOMContentLoaded`/`load` handlers and polled
-//      fingerprinters are still caught.
+//   2. On-demand `chrome.scripting.executeScript` with `world: "MAIN"`,
+//      driven by the rule's `apply` sending an `inject-webdriver-probe`
+//      message to the background worker at `document_idle`. This is the
+//      fallback for the tab the user was already viewing when they
+//      toggled the rule on — dynamic registrations only take effect on
+//      subsequent navigations, so without this fallback the current tab
+//      would have to be reloaded to pick up the rule. `executeScript`
+//      with `world: "MAIN"` bypasses page CSP the same way the
+//      registered content script does, so strict `script-src` origins
+//      no longer block the fallback. The fallback misses early-parse
+//      reads, but reads from `DOMContentLoaded`/`load` handlers and
+//      polled fingerprinters are still caught.
 //
 // The function must not reference any module-scope identifiers — only
-// the function body's source crosses into the page world (either as a
-// serialized string for the inline fallback or via the bundled
-// `webdriver-probe.js` entry point). The event name is hard-coded as a
-// literal here and re-declared as a module constant in
+// the function body's source crosses into the page world (either via
+// `executeScript({ func })` from the background worker or via the
+// bundled `webdriver-probe.js` entry point). The event name is
+// hard-coded as a literal here and re-declared as a module constant in
 // `rules/webdriver-probe-annotate.ts` for the isolated-world listener;
 // the rule's tests assert the two agree.
 

--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -5,7 +5,7 @@
   "description": "Improve AI agent effectiveness.",
   "minimum_chrome_version": "148",
   "permissions": ["storage", "scripting"],
-  "host_permissions": ["https://api.openai.com/*"],
+  "host_permissions": ["<all_urls>"],
   "icons": {
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png",

--- a/extension/src/rules/__tests__/webdriver-probe-annotate.test.ts
+++ b/extension/src/rules/__tests__/webdriver-probe-annotate.test.ts
@@ -5,7 +5,7 @@ import { installProbe } from "../../lib/webdriver-probe-source";
 import { hiddenTextStripRule } from "../hidden-text-strip";
 import {
   EVENT_NAME,
-  PROBE_SOURCE,
+  INJECT_PROBE_MESSAGE,
   webdriverProbeAnnotateRule,
 } from "../webdriver-probe-annotate";
 
@@ -15,26 +15,33 @@ function dispatchProbe(): void {
   document.dispatchEvent(new CustomEvent(EVENT_NAME));
 }
 
-const PROBE_FLAG = "__abs_webdriver_probe_installed";
+let sendMessageMock: jest.Mock;
 
-// The rule sends a runtime message on first landmark stamp; stub
-// `chrome.runtime.sendMessage` so apply() doesn't throw and so the
-// "emits to background" tests below can assert on it.
-const sendMessageMock = jest.fn().mockResolvedValue(undefined);
+// The rule fires two distinct sendMessage flows: `inject-webdriver-probe`
+// on every apply (background-side executeScript fallback) and
+// `rule-detection` after a landmark is stamped (popup detections panel).
+// Helpers below filter the mock's call log by type so the suites can
+// assert on each flow independently.
+function callsOfType(type: string): unknown[] {
+  return sendMessageMock.mock.calls
+    .map(([message]: [unknown]) => message)
+    .filter((message) => (message as { type?: string }).type === type);
+}
+
+function injectCalls(): unknown[] {
+  return callsOfType("inject-webdriver-probe");
+}
+
+function detectionCalls(): unknown[] {
+  return callsOfType("rule-detection");
+}
 
 beforeEach(() => {
   document.body.innerHTML = "";
-  sendMessageMock.mockClear();
+  sendMessageMock = jest.fn().mockResolvedValue(undefined);
   (globalThis as unknown as { chrome: unknown }).chrome = {
     runtime: { sendMessage: sendMessageMock },
   };
-  // jest-environment-jsdom DOES execute inline <script> textContent, so
-  // every apply() call really wraps Navigator.prototype.webdriver and
-  // the rule's teardown intentionally leaves it wrapped. Reset to a
-  // clean baseline between tests so neither suite picks up residue from
-  // the previous test's installed probe.
-  Reflect.deleteProperty(Navigator.prototype, "webdriver");
-  Reflect.deleteProperty(globalThis, PROBE_FLAG);
 });
 
 afterEach(() => {
@@ -121,18 +128,54 @@ describe("webdriverProbeAnnotateRule.apply", () => {
   });
 });
 
+describe("webdriverProbeAnnotateRule inject-probe message", () => {
+  // The rule's apply asks the background worker to run installProbe on
+  // the active frame via chrome.scripting.executeScript. The message is
+  // the only thing the rule controls; the actual injection is asserted
+  // by inspection at the background-side handler.
+  it("asks the background worker to inject the probe on apply", () => {
+    webdriverProbeAnnotateRule.apply(document.body);
+    expect(injectCalls()).toHaveLength(1);
+    expect(injectCalls()[0]).toEqual(INJECT_PROBE_MESSAGE);
+  });
+
+  // Re-apply after teardown should ask again — the page-world probe is
+  // self-deduplicating via `__abs_webdriver_probe_installed`, so a
+  // redundant request is a no-op in the page world but still cheaper
+  // than tracking injection state across enable/disable cycles here.
+  it("re-requests injection on each apply", () => {
+    webdriverProbeAnnotateRule.apply(document.body);
+    webdriverProbeAnnotateRule.teardown();
+    webdriverProbeAnnotateRule.apply(document.body);
+
+    expect(injectCalls()).toHaveLength(2);
+  });
+
+  // The service worker may be asleep when apply runs and reject with
+  // "Receiving end does not exist". The rule must swallow that so it
+  // doesn't surface as an unhandled-promise warning.
+  it("swallows sendMessage rejections", async () => {
+    sendMessageMock.mockRejectedValueOnce(new Error("no receiver"));
+    expect(() => {
+      webdriverProbeAnnotateRule.apply(document.body);
+    }).not.toThrow();
+    // Let the microtask flush so an unhandled rejection would surface.
+    await Promise.resolve();
+  });
+});
+
 describe("webdriverProbeAnnotateRule rule-detection emission", () => {
   it("does not emit on apply alone — only on observed reads", () => {
     webdriverProbeAnnotateRule.apply(document.body);
-    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(detectionCalls()).toHaveLength(0);
   });
 
   it("sends a rule-detection on the first probe event", () => {
     webdriverProbeAnnotateRule.apply(document.body);
     dispatchProbe();
 
-    expect(sendMessageMock).toHaveBeenCalledTimes(1);
-    expect(sendMessageMock).toHaveBeenCalledWith({
+    expect(detectionCalls()).toHaveLength(1);
+    expect(detectionCalls()[0]).toEqual({
       type: "rule-detection",
       payload: {
         kind: "webdriver-probe",
@@ -148,23 +191,30 @@ describe("webdriverProbeAnnotateRule rule-detection emission", () => {
     dispatchProbe();
     dispatchProbe();
 
-    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(detectionCalls()).toHaveLength(1);
   });
 
   it("re-emits after teardown + re-apply on the same document", () => {
     webdriverProbeAnnotateRule.apply(document.body);
     dispatchProbe();
-    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(detectionCalls()).toHaveLength(1);
 
     webdriverProbeAnnotateRule.teardown();
     webdriverProbeAnnotateRule.apply(document.body);
     dispatchProbe();
 
-    expect(sendMessageMock).toHaveBeenCalledTimes(2);
+    expect(detectionCalls()).toHaveLength(2);
   });
 });
 
 describe("page-world probe", () => {
+  const PROBE_FLAG = "__abs_webdriver_probe_installed";
+
+  beforeEach(() => {
+    Reflect.deleteProperty(Navigator.prototype, "webdriver");
+    Reflect.deleteProperty(globalThis, PROBE_FLAG);
+  });
+
   it("wraps Navigator.prototype.webdriver and fires on read", () => {
     installProbe.call(globalThis as unknown as Window);
 
@@ -203,6 +253,6 @@ describe("page-world probe", () => {
   // probe hard-codes it as a literal in installProbe. If the two ever
   // drift, the rule silently stops working.
   it("hard-codes the same event name the rule listens for", () => {
-    expect(PROBE_SOURCE).toContain(`"${EVENT_NAME}"`);
+    expect(installProbe.toString()).toContain(`"${EVENT_NAME}"`);
   });
 });

--- a/extension/src/rules/webdriver-probe-annotate.ts
+++ b/extension/src/rules/webdriver-probe-annotate.ts
@@ -25,15 +25,17 @@
 //      (`background-webdriver-probe.ts`). Subsequent navigations get the
 //      probe before the page's first script — early-parse reads ARE
 //      caught.
-//   2. Fallback: this rule's `apply` (at document_idle) injects the same
-//      probe via inline `<script>` `textContent`. Covers the tab the user
-//      was already viewing when they toggled on, since dynamic
-//      registrations only apply to future navigations. Misses early-parse
-//      reads on that tab but catches `DOMContentLoaded`/`load` handlers,
-//      polled fingerprinters, and interaction-driven checks. Pages with a
-//      strict `script-src` CSP block the inline `<script>`; those origins
-//      silently fall back to the next navigation, which the dynamic
-//      registration handles.
+//   2. Fallback: this rule's `apply` (at document_idle) asks the background
+//      worker to inject the probe via `chrome.scripting.executeScript`
+//      with `world: "MAIN"`. Covers the tab the user was already viewing
+//      when they toggled on, since dynamic registrations only apply to
+//      future navigations. Also covers the SW-restart race where the
+//      primary registration may not yet be live. The fallback misses
+//      early-parse reads on that tab but catches `DOMContentLoaded`/
+//      `load` handlers, polled fingerprinters, and interaction-driven
+//      checks. `executeScript` with `world: "MAIN"` is exempt from page
+//      CSP the same way the registered content script is, so strict
+//      `script-src` origins no longer block the fallback.
 //
 // Either path triggers the same `CustomEvent` the isolated content
 // script listens for; the listener stamps the landmark on first read.
@@ -45,7 +47,6 @@ import type { RuleDetectionMessage } from "../lib/detection-messages";
 import { RULE_ATTR } from "../lib/dom-markers";
 import { log } from "../lib/log";
 import { SR_ONLY_INLINE_STYLE } from "../lib/sr-only";
-import { installProbe } from "../lib/webdriver-probe-source";
 import type { Rule } from "./types";
 
 const RULE_ID = "webdriver-probe-annotate" as const;
@@ -57,22 +58,9 @@ const LANDMARK_SELECTOR = `section[${RULE_ATTR}="${RULE_ID}"]`;
 const LANDMARK_TEXT =
   "This page read navigator.webdriver. The site can distinguish AI-agent traffic from human traffic and may serve different content to agents than to people.";
 
-// Body that runs in the page's main world via the rule's inline-injection
-// fallback. The IIFE wrap is structural; the actual de-duplication guard
-// lives inside installProbe itself. Built from the shared source in
-// `lib/webdriver-probe-source.ts`, which is also the entry point for the
-// background-registered standalone bundle, so both delivery paths run the
-// same code.
-const PROBE_SOURCE = `(${installProbe.toString()}).call(window);`;
+const INJECT_PROBE_MESSAGE = { type: "inject-webdriver-probe" } as const;
 
 let listenerAttached = false;
-// Tracks whether the page-world probe has already been injected into this
-// document. The probe itself short-circuits on `__abs_webdriver_probe_installed`,
-// so this is a same-frame churn guard — without it, every re-enable would
-// create → append → execute (as a no-op) → remove a new <script> element.
-// We never reset this on teardown: the prototype wrap persists across
-// enable/disable cycles, so re-enable doesn't need to re-inject.
-let probeInjected = false;
 
 function buildLandmark(): HTMLElement {
   const note = document.createElement("section");
@@ -121,21 +109,14 @@ function onProbed(): void {
   ensureLandmark();
 }
 
-function injectProbe(): void {
-  if (probeInjected) {
-    return;
-  }
-  probeInjected = true;
-  const script = document.createElement("script");
-  script.textContent = PROBE_SOURCE;
-  // documentElement so the script runs whether or not <head> is present
-  // (some pages skip <head> in early-mounted templates).
-  document.documentElement.append(script);
-  // The probe registers a getter on Navigator.prototype; the <script>
-  // element itself is no longer needed once executed. Removing it keeps
-  // the DOM clean and prevents downstream rules (or page code) from
-  // tripping over an unexpected child.
-  script.remove();
+function requestProbeInjection(): void {
+  // Service worker may be asleep / receiver not yet ready; swallow rejection
+  // so unhandled-promise warnings don't surface on every page load. The
+  // probe itself short-circuits on `__abs_webdriver_probe_installed`, so
+  // re-requests on the same document are no-ops in the page world.
+  chrome.runtime.sendMessage(INJECT_PROBE_MESSAGE).catch(() => {
+    // noop
+  });
 }
 
 function apply(_root: ParentNode): void {
@@ -143,7 +124,7 @@ function apply(_root: ParentNode): void {
     document.addEventListener(EVENT_NAME, onProbed);
     listenerAttached = true;
   }
-  injectProbe();
+  requestProbeInjection();
 }
 
 function teardown(): void {
@@ -177,4 +158,4 @@ export const webdriverProbeAnnotateRule = {
   teardown,
 } satisfies Rule;
 
-export { EVENT_NAME, PROBE_SOURCE };
+export { EVENT_NAME, INJECT_PROBE_MESSAGE };


### PR DESCRIPTION
## Summary
- The inline-`<script>` fallback in `webdriver-probe-annotate`'s `apply()` was blocked on strict `script-src` origins, so the active tab got no probe until the next navigation. The fallback now sends an `inject-webdriver-probe` message to the background worker, which runs `installProbe` via `chrome.scripting.executeScript` with `world: "MAIN"` — same primitive as the primary `registerContentScripts` path, just on-demand and CSP-exempt.
- Per the issue's follow-up comment, the request fires unconditionally on every `apply()` (not just when CSP would block); the probe's own `__abs_webdriver_probe_installed` flag handles dedupe. The background-side handler targets `sender.frameId` so subframes the registered probe already reached aren't re-invoked, and swallows `executeScript` rejections on restricted URLs (`chrome://`, Web Store, etc.) to match the registration's silent skip.

Closes #131

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` (1002 passing)
- [x] `bun run check` (biome + eslint clean)
- [x] `bun run build` — `background.js` purity check still passes after pulling `installProbe` from `lib/webdriver-probe-source` into the worker bundle (no rule-file leak)
- [ ] Manual: toggle `webdriver-probe-annotate` on at `https://shield-dark-pattern-demo.vercel.app/` (strict-CSP repro from the issue), confirm no CSP console violation and that a `navigator.webdriver` read still stamps the landmark on the current tab
- [ ] Manual: confirm restricted URLs (e.g. `chrome://extensions`) don't surface unhandled rejections in the background console

🤖 Generated with [Claude Code](https://claude.com/claude-code)