### PR TITLE
Document that the extension collects no telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,17 @@ Please report vulnerabilities privately via GitHub's
 ["Report a vulnerability"](https://github.com/pixiebrix/agent-browser-shield/security/advisories/new)
 form. Do **not** open a public issue for security problems.
 
+## Privacy
+
+The extension does not collect, store, or send any telemetry, analytics, or
+usage data. Rule processing runs locally in your browser; nothing is reported
+back to PixieBrix or any other server.
+
+The one outbound network call the extension can make is the optional
+`irrelevant-sections-redact` rule (off by default), which sends a compressed
+page tree to OpenAI's API for classification when you enable the rule and
+configure an API key.
+
 ## Disclaimer
 
 `agent-browser-shield` reduces the threats a browser-use agent faces on a page,

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -56,6 +56,17 @@ For the full project overview, see the
   discover it.
 </Aside>
 
+## Privacy
+
+The extension does not collect, store, or send any telemetry, analytics, or
+usage data. Rule processing runs locally in your browser; nothing is reported
+back to PixieBrix or any other server.
+
+The one outbound network call the extension can make is the optional
+[`irrelevant-sections-redact`](/agent-browser-shield/rules/#hide-irrelevant-sections-ai)
+rule (off by default), which sends a compressed page tree to OpenAI's API for
+classification when you enable the rule and configure an API key.
+
 <Aside type="caution" title="Disclaimer">
   `agent-browser-shield` reduces the threats a browser-use agent faces on a
   page, but it can't catch everything. Take precautions when using AI agents


### PR DESCRIPTION
## Summary
- Add a **Privacy** section to `README.md` and the docs landing page (`docs/src/content/docs/index.mdx`) stating that no telemetry, analytics, or usage data is collected, stored, or sent.
- Call out the single nuance: the opt-in `irrelevant-sections-redact` rule (off by default) sends a compressed page tree to OpenAI's API when enabled with an API key.

## Test plan
- [ ] Render the docs site locally and confirm the Privacy section appears between the GitHub-star tip and the Disclaimer, and that the link to `irrelevant-sections-redact` resolves.
- [ ] Skim the README on GitHub after merge to confirm the new section formats cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)