### PR TITLE
Skip SVG text nodes in prompt-injection-redact

### DIFF
--- a/extension/src/rules/__tests__/prompt-injection-redact.test.ts
+++ b/extension/src/rules/__tests__/prompt-injection-redact.test.ts
@@ -113,6 +113,33 @@ describe("prompt-injection-redact", () => {
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
   });
 
+  it("does not redact the surrounding article when injection text lives inside an SVG", () => {
+    // svg-text-strip is the rule that scrubs SVG title/desc/text content.
+    // prompt-injection-redact must not fire on those text nodes — the SVG
+    // has no paragraph-like ancestor, so it would otherwise escalate the
+    // placeholder all the way up to the wrapping <article> and wipe out
+    // the whole section (#133).
+    document.body.innerHTML = `
+      <article>
+        <h1>Product title that stays visible.</h1>
+        <div>
+          <svg>
+            <title>${FIXTURES.IGNORE_HACKED}</title>
+            <desc>${FIXTURES.OVERRIDE_GUARDRAILS}</desc>
+            <text>${FIXTURES.DISREGARD}</text>
+          </svg>
+        </div>
+      </article>
+    `;
+    promptInjectionRedactRule.apply(document.body);
+
+    expect(document.querySelector("article")).not.toBeNull();
+    expect(document.querySelector("h1")?.textContent).toBe(
+      "Product title that stays visible.",
+    );
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+
   it("does not process text inside SCRIPT or STYLE", () => {
     document.body.innerHTML = `
       <script>${FIXTURES.SCRIPT_STRING}</script>

--- a/extension/src/rules/prompt-injection-redact.ts
+++ b/extension/src/rules/prompt-injection-redact.ts
@@ -54,7 +54,16 @@ function findContainer(textNode: Text): HTMLElement | null {
 
 function apply(root: ParentNode): void {
   const containers = new Set<HTMLElement>();
-  for (const node of walkTextNodes(root, { minLength: MIN_TEXT_LENGTH })) {
+  for (const node of walkTextNodes(root, {
+    minLength: MIN_TEXT_LENGTH,
+    // SVG <title>/<desc>/<text> are the injection carriers inside SVG, and
+    // `svg-text-strip` handles them by blanking the text in place. Letting
+    // prompt-injection-redact also fire on those text nodes is destructive:
+    // the SVG has no p/li/td ancestor, so `findContainer` escalates all the
+    // way up to the surrounding <article>/<section> and the entire product
+    // header gets replaced with a single placeholder (#133).
+    shouldSkipParent: (parent) => parent.closest("svg") !== null,
+  })) {
     if (!containsInjection(node.nodeValue ?? "")) {
       continue;
     }


### PR DESCRIPTION
## Summary
- Fixes #133: the default ruleset was redacting the entire `<article>` product header on the demo site
- Root cause: `prompt-injection-redact` matched injection-shaped text inside the inline "Verified" SVG's `<title>` / `<desc>` / `<text>` and walked up looking for a paragraph-like ancestor. With no `p`/`li`/`td`/etc. between the SVG and the article, it escalated to `<article>` and replaced the whole header.
- `svg-text-strip` is the rule that handles SVG accessible/rendered text; skip those nodes in `prompt-injection-redact` so a buried-in-SVG match no longer collapses a surrounding section.

## Test plan
- [x] `jest src/rules/__tests__/prompt-injection-redact.test.ts` — 15/15 pass, including new regression case mirroring the demo SVG shape
- [x] `jest src/rules` — 934/934 pass
- [x] `bun run typecheck`
- [ ] Manual: load the extension with default rules, visit `https://shield-dark-pattern-demo.vercel.app/product/p-headphones-1`, confirm the product header (image, title, price, Add to Cart) renders normally and SVG title/desc/text are still scrubbed

🤖 Generated with [Claude Code](https://claude.com/claude-code)