### PR TITLE
Fix cross-origin-frame-redact watcher missing top-level iframes

### DIFF
--- a/extension/src/rules/__tests__/cross-origin-frame-redact.test.ts
+++ b/extension/src/rules/__tests__/cross-origin-frame-redact.test.ts
@@ -189,6 +189,24 @@ describe("crossOriginFrameRedactRule", () => {
       expect(getPlaceholder()).not.toBeNull();
     });
 
+    // Regression: when an iframe is appended directly (no wrapper), the
+    // MutationObserver root *is* the iframe, and querySelectorAll on it
+    // returns nothing. The watcher must rescan from document.body to catch
+    // this case.
+    it("replaces a bare cross-origin iframe appended directly to body", async () => {
+      crossOriginFrameRedactRule.apply(document.body);
+
+      const iframe = document.createElement("iframe");
+      iframe.src = "https://example.com/widget";
+      document.body.append(iframe);
+
+      await flushMutations();
+      jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+      expect(document.querySelector("iframe")).toBeNull();
+      expect(getPlaceholder()).not.toBeNull();
+    });
+
     it("teardown stops the observer so later additions are ignored", async () => {
       crossOriginFrameRedactRule.apply(document.body);
       crossOriginFrameRedactRule.teardown();

--- a/extension/src/rules/cross-origin-frame-redact.ts
+++ b/extension/src/rules/cross-origin-frame-redact.ts
@@ -77,10 +77,13 @@ function scan(root: ParentNode): void {
 }
 
 const watcher = createSubtreeWatcher({
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scan(root);
-    }
+  // MutationObserver hands us the newly-inserted element itself, but
+  // querySelectorAll on that element does not match the element itself —
+  // so a bare cross-origin <iframe> appended directly to document.body
+  // would be missed. Rescan from document.body on every batch; the
+  // is-connected / is-revealed checks in scan() keep it idempotent.
+  onSubtrees: () => {
+    scan(document.body);
   },
   skipPlaceholderSubtrees: true,
 });


### PR DESCRIPTION
> Stacked on #139 — merge that first. Review only [the fix commit](../commit/ec081a3).

## Summary
- The watcher's `onSubtrees` handed each added subtree root to `scan()`, which calls `root.querySelectorAll("iframe")`. `querySelectorAll` matches descendants only, so a bare cross-origin `<iframe>` appended directly to `document.body` slipped past the watcher (the iframe itself is the root, and it has no iframe descendants).
- Mirrors the workaround already documented in `selector-hide-rule.ts:148-163`: drop the per-root loop and rescan from `document.body` on every batch. The is-connected / is-revealed checks in `scan()` keep it idempotent and the watcher's throttle coalesces bursts.
- Adds a regression test that appends a bare iframe directly to `body`.

## Test plan
- [ ] New regression test passes (`replaces a bare cross-origin iframe appended directly to body`)
- [ ] All 19 tests in `cross-origin-frame-redact.test.ts` pass
- [ ] `bun run preflight` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)