### PR TITLE
Cover prompt-injection-redact findContainer escalation paths

### DIFF
--- a/extension/jest.config.cjs
+++ b/extension/jest.config.cjs
@@ -105,10 +105,10 @@ module.exports = {
       lines: 68,
     },
     "./src/rules/": {
-      statements: 90,
-      branches: 77,
-      functions: 95,
-      lines: 90,
+      statements: 91,
+      branches: 78,
+      functions: 96,
+      lines: 91,
     },
   },
 };

--- a/extension/src/rules/__tests__/prompt-injection-redact.test.ts
+++ b/extension/src/rules/__tests__/prompt-injection-redact.test.ts
@@ -176,4 +176,40 @@ describe("prompt-injection-redact", () => {
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
     expect(document.body.textContent).toContain(FIXTURES.IGNORE_ALL);
   });
+
+  describe("findContainer escalation", () => {
+    // When injection text lives directly in <body> with no block-level
+    // ancestor, the rule must not redact — wrapping <body> in a placeholder
+    // would black out the whole page. findContainer returns null on the
+    // BODY/HTML guard.
+    it("does not redact text that is a direct child of <body>", () => {
+      document.body.innerHTML = "";
+      document.body.append(document.createTextNode(FIXTURES.IGNORE_ALL));
+
+      promptInjectionRedactRule.apply(document.body);
+
+      expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+      expect(document.body.textContent).toContain(FIXTURES.IGNORE_ALL);
+    });
+
+    // When the only ancestor is a non-block element (a bare <div>/<span>/etc.
+    // not in BLOCK_CONTAINER_SELECTOR), the rule falls back to that direct
+    // parent rather than escalating. Confirms the "return parent" branch.
+    it("wraps the direct parent when no block-level ancestor matches", () => {
+      document.body.innerHTML = `<div id="wrap"><span id="leaf">${FIXTURES.IGNORE_ALL}</span></div>`;
+
+      promptInjectionRedactRule.apply(document.body);
+
+      // The <span> is the direct parent of the text node and not in the
+      // block selector — it gets replaced rather than escalating to <body>.
+      expect(document.querySelector("#leaf")).toBeNull();
+      expect(document.querySelector("#wrap")).not.toBeNull();
+      const placeholder = document.querySelector(`.${PLACEHOLDER_CLASS}`);
+      expect(placeholder).not.toBeNull();
+      // Placeholder sits inside the wrapper, not in place of the wrapper.
+      expect(
+        document.querySelector("#wrap")?.contains(placeholder ?? null),
+      ).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Brings \`src/rules/prompt-injection-redact.ts\` from **81.25% → 90.62% statements** and **44.44% → 77.77% branches**. The gap was in \`findContainer\`'s escalation guard.

## What the new tests cover
- **BODY/HTML guard** — when injection text lives as a direct text-node child of \`<body>\`, the rule must *not* redact (wrapping \`<body>\` in a placeholder would black out the whole page). Confirms \`findContainer\` returns null on that branch.
- **Non-block fallback** — when the only ancestor is a non-block element (a bare \`<div>\` / \`<span>\`, not in \`BLOCK_CONTAINER_SELECTOR\`), the rule wraps the direct parent rather than escalating further up.

## Remaining gap
The three still-uncovered checks (\`!parent\`, \`!element.isConnected\`, inner \`isInsidePlaceholder\` at lines 41/78/81) are defense-in-depth fallbacks. \`walkTextNodes\` and \`filterToOutermost\` invariants upstream prevent the conditions from being reachable in normal flow. Leaving them as-is documents intent without forcing synthetic coverage.

## Ratchet
\`./src/rules/\` thresholds 90/77/95/90 → 91/78/96/91.

## Test plan
- [ ] \`bun run preflight\` passes
- [ ] \`prompt-injection-redact.ts\` branches 44% → 77% in the coverage report
- [ ] \`./src/rules/\` threshold passes at 91/78/96/91

🤖 Generated with [Claude Code](https://claude.com/claude-code)