### PR TITLE
Cover storage setRuleEnabled / setAllRuleStates / normalize paths

### DIFF
--- a/extension/jest.config.cjs
+++ b/extension/jest.config.cjs
@@ -100,9 +100,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 69,
-      branches: 64,
-      functions: 67,
-      lines: 68,
+      branches: 65,
+      functions: 70,
+      lines: 69,
     },
     "./src/rules/": {
       statements: 91,

--- a/extension/src/lib/__tests__/storage.test.ts
+++ b/extension/src/lib/__tests__/storage.test.ts
@@ -11,12 +11,15 @@
 // the freshly-derived defaults instead of any stale stored value from a
 // previous case.
 
-import { RULE_DEFAULTS } from "../../rules/rule-defaults.generated";
-import type { getRuleStates as GetRuleStates } from "../storage";
+import { RULE_DEFAULTS as RAW_RULE_DEFAULTS } from "../../rules/rule-defaults.generated";
+import type * as Storage from "../storage";
 
-interface StorageModule {
-  getRuleStates: typeof GetRuleStates;
-}
+type StorageModule = typeof Storage;
+
+// `RULE_DEFAULTS` is exported as a deeply-typed `as const` object so callers
+// see per-key literal types. For these tests we want plain string indexing —
+// pick a rule id off Object.keys, look up its default. Widen via this alias.
+const RULE_DEFAULTS = RAW_RULE_DEFAULTS as Readonly<Record<string, boolean>>;
 
 async function loadStorage(): Promise<StorageModule> {
   let module!: StorageModule;
@@ -113,5 +116,160 @@ describe("storage default states", () => {
     const { getRuleStates } = await loadStorage();
     const states = await getRuleStates();
     expect(states).toEqual(RULE_DEFAULTS);
+  });
+
+  // parseOverrides rejects anything that isn't a plain object: null,
+  // arrays, and primitives all decode but should be ignored. Without this
+  // case the `Array.isArray(parsed)` / typeof guard at the top of
+  // parseOverrides goes uncovered.
+  it.each([
+    ["null", "null"],
+    ["an array", JSON.stringify([true, false])],
+    ["a primitive number", "42"],
+  ])("ignores EXTENSION_DEFAULT_OVERRIDES that decodes to %s", async (_label, raw) => {
+    process.env.EXTENSION_DEFAULT_OVERRIDES = raw;
+    const { getRuleStates } = await loadStorage();
+    await expect(getRuleStates()).resolves.toEqual(RULE_DEFAULTS);
+  });
+});
+
+describe("normalize via getRuleStates", () => {
+  // Pick stable rule ids off the live catalog so the test doesn't tie itself
+  // to the iteration order of RULE_DEFAULTS.
+  function pickRuleIds(): { first: string; second: string } {
+    const ids = Object.keys(RULE_DEFAULTS);
+    const first = ids[0];
+    const second = ids[1];
+    if (!first || !second) {
+      throw new Error("RULE_DEFAULTS must have at least two entries");
+    }
+    return { first, second };
+  }
+
+  it("substitutes the codegen default for any non-boolean stored value", async () => {
+    const { getRuleStates, ruleStatesStorage } = await loadStorage();
+    const { first, second } = pickRuleIds();
+    // Cast to bypass the typed shape — the whole point is that the storage
+    // layer's normalize() drops the corrupt string value.
+    await ruleStatesStorage.set({
+      [first]: !RULE_DEFAULTS[first],
+      [second]: "yes",
+    } as unknown as Storage.RuleStates);
+
+    const states = await getRuleStates();
+    expect(states[first]).toBe(!RULE_DEFAULTS[first]);
+    expect(states[second]).toBe(RULE_DEFAULTS[second]);
+  });
+
+  it("fills in missing rule ids from defaults when stored state is partial", async () => {
+    const { getRuleStates, ruleStatesStorage } = await loadStorage();
+    const { first } = pickRuleIds();
+    await ruleStatesStorage.set({ [first]: !RULE_DEFAULTS[first] });
+
+    const states = await getRuleStates();
+    expect(states[first]).toBe(!RULE_DEFAULTS[first]);
+    // Every other rule still resolves to its codegen default.
+    for (const [id, value] of Object.entries(RULE_DEFAULTS)) {
+      if (id === first) {
+        continue;
+      }
+      expect(states[id]).toBe(value);
+    }
+  });
+});
+
+describe("setRuleEnabled", () => {
+  it("flips one rule while preserving the others", async () => {
+    const { getRuleStates, setRuleEnabled } = await loadStorage();
+    const target = Object.keys(RULE_DEFAULTS)[0];
+    if (!target) {
+      throw new Error("RULE_DEFAULTS must have at least one entry");
+    }
+    const next = !RULE_DEFAULTS[target];
+
+    await setRuleEnabled(target, next);
+
+    const states = await getRuleStates();
+    expect(states[target]).toBe(next);
+    for (const [id, value] of Object.entries(RULE_DEFAULTS)) {
+      if (id === target) {
+        continue;
+      }
+      expect(states[id]).toBe(value);
+    }
+  });
+
+  it("notifies subscribers when state changes", async () => {
+    const { setRuleEnabled, subscribe } = await loadStorage();
+    const target = Object.keys(RULE_DEFAULTS)[0];
+    if (!target) {
+      throw new Error("RULE_DEFAULTS must have at least one entry");
+    }
+    const listener = jest.fn();
+    subscribe(listener);
+
+    await setRuleEnabled(target, !RULE_DEFAULTS[target]);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ [target]: !RULE_DEFAULTS[target] }),
+    );
+  });
+});
+
+describe("setAllRuleStates", () => {
+  it("normalizes partial input before writing — missing ids fill from defaults", async () => {
+    const { getRuleStates, setAllRuleStates } = await loadStorage();
+    const target = Object.keys(RULE_DEFAULTS)[0];
+    if (!target) {
+      throw new Error("RULE_DEFAULTS must have at least one entry");
+    }
+
+    await setAllRuleStates({ [target]: !RULE_DEFAULTS[target] });
+
+    const states = await getRuleStates();
+    expect(states[target]).toBe(!RULE_DEFAULTS[target]);
+    for (const [id, value] of Object.entries(RULE_DEFAULTS)) {
+      if (id === target) {
+        continue;
+      }
+      expect(states[id]).toBe(value);
+    }
+  });
+
+  it("drops non-boolean values via normalize before writing", async () => {
+    const { getRuleStates, setAllRuleStates } = await loadStorage();
+    const target = Object.keys(RULE_DEFAULTS)[0];
+    if (!target) {
+      throw new Error("RULE_DEFAULTS must have at least one entry");
+    }
+
+    // Cast to bypass the typed shape — normalize() inside setAllRuleStates
+    // is responsible for dropping the corrupt string value.
+    await setAllRuleStates({
+      [target]: "junk",
+    } as unknown as Partial<Storage.RuleStates>);
+
+    // junk replaced with default → stored map equals defaults.
+    await expect(getRuleStates()).resolves.toEqual(RULE_DEFAULTS);
+  });
+});
+
+describe("subscribe", () => {
+  it("stops invoking the listener after the returned cleanup runs", async () => {
+    const { setRuleEnabled, subscribe } = await loadStorage();
+    const target = Object.keys(RULE_DEFAULTS)[0];
+    if (!target) {
+      throw new Error("RULE_DEFAULTS must have at least one entry");
+    }
+    const listener = jest.fn();
+    const cleanup = subscribe(listener);
+
+    await setRuleEnabled(target, !RULE_DEFAULTS[target]);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    await setRuleEnabled(target, Boolean(RULE_DEFAULTS[target]));
+    expect(listener).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
Brings \`src/lib/storage.ts\` from **86.48% → 100% statements** (66.66% → 100% functions, 82.35% → 94.11% branches). The existing tests covered \`DEFAULT_STATES\` composition and \`parseOverrides\` env-var paths; this PR extends with the missing mutators and the stored-value normalize paths.

## What the new tests cover
- **\`parseOverrides\` null / array / primitive guard** — covers the \`!parsed || typeof parsed !== "object" || Array.isArray(parsed)\` short-circuit that none of the existing cases exercised.
- **\`normalize\` via \`getRuleStates\`** — corrupt stored values (non-boolean for a rule id) fall back to defaults; missing rule ids fill from defaults.
- **\`setRuleEnabled\`** — flips one rule while preserving the others; notifies subscribers on change.
- **\`setAllRuleStates\`** — normalizes partial input and drops non-boolean values before writing.
- **\`subscribe\`** — returned cleanup stops further notifications.

## Ratchet
Global thresholds 69/64/67/68 → 69/65/70/69. \`src/lib\` overall: 96.11% → 97.41% statements, 94.97% → 95.89% branches.

## Test plan
- [ ] \`bun run preflight\` passes
- [ ] \`storage.ts\` shows 100/94/100/100 in the coverage report
- [ ] Global threshold check passes at the new 69/65/70/69 floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)