### PR TITLE
Perf: SPA route-change re-sweep + detached-subtree fast-path (#150 Tier 1S)

### DIFF
--- a/extension/src/lib/__tests__/route-change.test.ts
+++ b/extension/src/lib/__tests__/route-change.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Tests for the shared route-change emitter. jsdom doesn't ship the
+// Navigation API, so the Navigation-API path is exercised indirectly via
+// the popstate / hashchange listeners — those are what older browsers and
+// the test environment actually surface.
+
+import {
+  __resetRouteChangeForTesting,
+  subscribeRouteChange,
+} from "../route-change";
+
+beforeEach(() => {
+  __resetRouteChangeForTesting();
+  // Reset the URL between tests — jsdom's location persists across cases.
+  history.replaceState(null, "", "/initial");
+});
+
+afterEach(() => {
+  __resetRouteChangeForTesting();
+});
+
+describe("subscribeRouteChange", () => {
+  it("fires the listener when popstate changes the URL", () => {
+    const listener = jest.fn();
+    subscribeRouteChange(listener);
+
+    history.replaceState(null, "", "/next");
+    globalThis.dispatchEvent(new Event("popstate"));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires the listener on hashchange when the URL changes", () => {
+    const listener = jest.fn();
+    subscribeRouteChange(listener);
+
+    history.replaceState(null, "", "/initial#section");
+    globalThis.dispatchEvent(new Event("hashchange"));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes — same URL across events fires the listener once", () => {
+    const listener = jest.fn();
+    subscribeRouteChange(listener);
+
+    history.replaceState(null, "", "/next");
+    globalThis.dispatchEvent(new Event("popstate"));
+    // Same URL — same event again should be a no-op.
+    globalThis.dispatchEvent(new Event("popstate"));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("fans out to multiple subscribers", () => {
+    const a = jest.fn();
+    const b = jest.fn();
+    subscribeRouteChange(a);
+    subscribeRouteChange(b);
+
+    history.replaceState(null, "", "/next");
+    globalThis.dispatchEvent(new Event("popstate"));
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribe stops the listener from firing", () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeRouteChange(listener);
+    unsubscribe();
+
+    history.replaceState(null, "", "/next");
+    globalThis.dispatchEvent(new Event("popstate"));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when the URL is unchanged across multiple events", () => {
+    const listener = jest.fn();
+    subscribeRouteChange(listener);
+
+    // Same URL — should not emit at all.
+    globalThis.dispatchEvent(new Event("popstate"));
+    globalThis.dispatchEvent(new Event("hashchange"));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/lib/__tests__/subtree-watcher.test.ts
+++ b/extension/src/lib/__tests__/subtree-watcher.test.ts
@@ -9,6 +9,7 @@
 // skipPlaceholderSubtrees gating, and the start/stop lifecycle.
 
 import { PLACEHOLDER_CLASS } from "../placeholder";
+import { __resetRouteChangeForTesting } from "../route-change";
 import { createSubtreeWatcher } from "../subtree-watcher";
 
 const THROTTLE_MS = 250;
@@ -20,6 +21,8 @@ async function flushMutations(): Promise<void> {
 beforeEach(() => {
   document.body.innerHTML = "";
   jest.useFakeTimers();
+  __resetRouteChangeForTesting();
+  history.replaceState(null, "", "/initial");
 });
 
 afterEach(() => {
@@ -29,6 +32,7 @@ afterEach(() => {
     configurable: true,
     value: false,
   });
+  __resetRouteChangeForTesting();
 });
 
 describe("createSubtreeWatcher", () => {
@@ -448,6 +452,147 @@ describe("createSubtreeWatcher", () => {
       document.body.append(document.createElement("div"));
       await flushMutations();
       jest.advanceTimersByTime(THROTTLE_MS);
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      watcher.stop();
+    });
+  });
+
+  describe("detached-subtree fast-path", () => {
+    it("drops elements detached before the MO callback fires", async () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      // React-style reconciliation: add then remove inside one synchronous
+      // block. The MutationObserver callback fires later in a microtask and
+      // sees the addition record, but the element is already detached.
+      const transient = document.createElement("div");
+      document.body.append(transient);
+      transient.remove();
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).not.toHaveBeenCalled();
+      watcher.stop();
+    });
+
+    it("still surfaces connected siblings of detached additions", async () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      const transient = document.createElement("div");
+      document.body.append(transient);
+      transient.remove();
+
+      const stay = document.createElement("section");
+      document.body.append(stay);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      const [roots] = onSubtrees.mock.calls[0] as [Element[]];
+      expect(roots).toEqual([stay]);
+      watcher.stop();
+    });
+  });
+
+  describe("route-change re-sweep", () => {
+    function fireRouteChange(toUrl: string): void {
+      history.replaceState(null, "", toUrl);
+      globalThis.dispatchEvent(new Event("popstate"));
+    }
+
+    it("sweeps document.body on the next animation frame after a route change", async () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      // Seed some content so document.body has something to scan.
+      document.body.append(document.createElement("article"));
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      // One drain from the seeded addition.
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      onSubtrees.mockClear();
+
+      fireRouteChange("/route-b");
+
+      // Sweep is deferred to rAF — nothing fires synchronously.
+      expect(onSubtrees).not.toHaveBeenCalled();
+      jest.advanceTimersToNextFrame();
+
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      const [roots] = onSubtrees.mock.calls[0] as [Element[]];
+      expect(roots).toEqual([document.body]);
+      watcher.stop();
+    });
+
+    it("cancels pending throttled drains so the rAF sweep is the only call", async () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      // Add a node but don't advance past the throttle window — pending is
+      // non-empty when the route change comes in.
+      document.body.append(document.createElement("div"));
+      await flushMutations();
+      expect(onSubtrees).not.toHaveBeenCalled();
+
+      fireRouteChange("/route-b");
+      jest.advanceTimersToNextFrame();
+      // Single call: the rAF sweep with document.body. The throttle window's
+      // drain of the in-flight addition must have been cancelled.
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      const [roots] = onSubtrees.mock.calls[0] as [Element[]];
+      expect(roots).toEqual([document.body]);
+
+      // Even after the throttle window would have fired, no second call.
+      jest.advanceTimersByTime(THROTTLE_MS);
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      watcher.stop();
+    });
+
+    it("does not sweep when the watcher is stopped before the rAF fires", () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      fireRouteChange("/route-b");
+      watcher.stop();
+      jest.advanceTimersToNextFrame();
+
+      expect(onSubtrees).not.toHaveBeenCalled();
+    });
+
+    it("does not sweep while the tab is hidden", () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: true,
+      });
+      fireRouteChange("/route-b");
+      jest.advanceTimersToNextFrame();
+
+      expect(onSubtrees).not.toHaveBeenCalled();
+      watcher.stop();
+    });
+
+    it("coalesces consecutive route changes into a single rAF sweep", () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      fireRouteChange("/route-b");
+      fireRouteChange("/route-c");
+      fireRouteChange("/route-d");
+
+      jest.advanceTimersToNextFrame();
       expect(onSubtrees).toHaveBeenCalledTimes(1);
       watcher.stop();
     });

--- a/extension/src/lib/route-change.ts
+++ b/extension/src/lib/route-change.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Process-wide SPA route-change emitter.
+//
+// Rules' subtree watchers subscribe so they can proactively re-sweep when
+// the URL changes — without it, a React/Vue route swap that dumps 5k nodes
+// in one render either waits out a throttle window before the new content
+// is hidden, or misses URL-gated selectors that newly apply (selector-hide
+// rules whose siteRules now match this route).
+//
+// Coverage:
+//   - Navigation API (`navigatesuccess`) — modern Chrome; fires for every
+//     navigation regardless of how it was triggered, including page-side
+//     pushState/replaceState that a content script cannot otherwise hook.
+//   - `popstate` — back/forward.
+//   - `hashchange` — hash routing.
+//
+// Older browsers without Navigation API miss pushState-only routes, but the
+// MutationObserver still catches the new content on the next throttle window
+// — the route-change signal is a latency optimization, not a correctness
+// requirement.
+
+import { log } from "./log";
+
+type RouteChangeListener = () => void;
+
+const listeners = new Set<RouteChangeListener>();
+let installed = false;
+let lastUrl = "";
+
+interface NavigationGlobal {
+  navigation?: EventTarget;
+}
+
+function emit(): void {
+  const url = globalThis.location.href;
+  if (url === lastUrl) {
+    return;
+  }
+  log("route change", { from: lastUrl, to: url });
+  lastUrl = url;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function install(): void {
+  if (installed) {
+    return;
+  }
+  installed = true;
+  lastUrl = globalThis.location.href;
+
+  const navigation = (globalThis as NavigationGlobal).navigation;
+  if (navigation) {
+    navigation.addEventListener("navigatesuccess", emit);
+  }
+  globalThis.addEventListener("popstate", emit);
+  globalThis.addEventListener("hashchange", emit);
+}
+
+// Listener is called once per detected URL change. The same listener
+// subscribed twice fires twice — the watcher relies on this being a
+// simple Set add.
+export function subscribeRouteChange(
+  listener: RouteChangeListener,
+): () => void {
+  install();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// Test-only: reset module state between tests. The install() guard would
+// otherwise carry listener registrations across test cases.
+export function __resetRouteChangeForTesting(): void {
+  if (installed) {
+    const navigation = (globalThis as NavigationGlobal).navigation;
+    if (navigation) {
+      navigation.removeEventListener("navigatesuccess", emit);
+    }
+    globalThis.removeEventListener("popstate", emit);
+    globalThis.removeEventListener("hashchange", emit);
+  }
+  listeners.clear();
+  installed = false;
+  lastUrl = "";
+}

--- a/extension/src/lib/subtree-watcher.ts
+++ b/extension/src/lib/subtree-watcher.ts
@@ -10,6 +10,7 @@
 
 import throttle from "lodash/throttle";
 import { PLACEHOLDER_CLASS } from "./placeholder";
+import { subscribeRouteChange } from "./route-change";
 
 // Tags whose insertion is never interesting to any rule. Filtering at enqueue
 // keeps `pending` small during noisy bursts where a framework injects
@@ -58,6 +59,8 @@ export function createSubtreeWatcher(
   let throttledScan: ReturnType<typeof throttle> | null = null;
   let observedTarget: Node | null = null;
   let visibilityListener: (() => void) | null = null;
+  let unsubscribeRouteChange: (() => void) | null = null;
+  let routeSweepHandle: number | null = null;
   const pending = new Set<Element>();
 
   function drain(): void {
@@ -79,6 +82,15 @@ export function createSubtreeWatcher(
         }
         const element = added as Element;
         if (IGNORE_TAGS.has(element.tagName)) {
+          continue;
+        }
+        // React-style reconciliation routinely adds-then-removes a node in
+        // the same tick. By the time MutationObserver fires (microtask
+        // afterward), the addition record is still there but the node is
+        // already detached. drain() filters by isConnected too — checking
+        // at enqueue avoids buffering churn in pending during a 5k-node
+        // route swap with high in-tick removal rate.
+        if (!element.isConnected) {
           continue;
         }
         if (skipPlaceholderSubtrees) {
@@ -104,6 +116,40 @@ export function createSubtreeWatcher(
       return;
     }
     throttledScan?.();
+  }
+
+  function handleRouteChange(): void {
+    if (!observer) {
+      return;
+    }
+    // Cancel anything pending — the new route's content will arrive in the
+    // next render and we want the user-visible hide to happen against the
+    // new tree, not as a tail of the old throttle window. Discard buffered
+    // MutationRecords for the same reason: they describe the old route's
+    // teardown, which we're about to re-scan past anyway.
+    observer.takeRecords();
+    throttledScan?.cancel();
+    pending.clear();
+
+    // Wait one frame so React/Vue/Svelte can finish committing the new
+    // route's DOM, then sweep document.body once. Passing document.body
+    // makes rules that scan from their root argument do a full re-scan;
+    // selector-hide-rule's onSubtrees already scans from document.body
+    // regardless — both shapes end up doing the right thing.
+    if (routeSweepHandle !== null) {
+      cancelAnimationFrame(routeSweepHandle);
+    }
+    routeSweepHandle = requestAnimationFrame(() => {
+      routeSweepHandle = null;
+      if (!observer || document.hidden) {
+        return;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!document.body) {
+        return;
+      }
+      onSubtrees([document.body]);
+    });
   }
 
   function handleVisibilityChange(): void {
@@ -151,6 +197,7 @@ export function createSubtreeWatcher(
       }
       visibilityListener = handleVisibilityChange;
       document.addEventListener("visibilitychange", visibilityListener);
+      unsubscribeRouteChange = subscribeRouteChange(handleRouteChange);
     },
     stop(): void {
       observer?.disconnect();
@@ -162,6 +209,12 @@ export function createSubtreeWatcher(
       if (visibilityListener) {
         document.removeEventListener("visibilitychange", visibilityListener);
         visibilityListener = null;
+      }
+      unsubscribeRouteChange?.();
+      unsubscribeRouteChange = null;
+      if (routeSweepHandle !== null) {
+        cancelAnimationFrame(routeSweepHandle);
+        routeSweepHandle = null;
       }
     },
   };


### PR DESCRIPTION
Tier 1S of #150 — targets SPA route transitions specifically. Without these, a React/Vue route swap that mounts thousands of nodes either waits out a 250ms throttle window before the new content is hidden, or misses URL-gated selectors that newly apply to the route.

## Summary

**`lib/route-change.ts` (new)** — process-wide route-change emitter:
- Hooks the Navigation API `navigatesuccess` (modern Chrome) plus `popstate` and `hashchange` as belt-and-suspenders.
- Dedupes by URL so multiple events for the same navigation fire the listener once.
- Older browsers without Navigation API miss pushState-only routes — but the watcher's normal MutationObserver still catches up. This signal is a latency optimization, not a correctness requirement.

**`lib/subtree-watcher.ts`** — wire route changes + detached fast-path:
- Subscribe to `subscribeRouteChange` in `start()`. On a detected change:
  1. Cancel the pending throttle, discard buffered `MutationRecord`s, clear `pending`.
  2. Schedule a one-frame-later sweep that calls `onSubtrees([document.body])`.
  3. The rAF wait lets the framework commit the new route's DOM before we scan.
  4. Consecutive route changes coalesce — only the latest scheduled sweep fires.
  5. Skipped while the tab is hidden or the watcher has been stopped.
- **Detached-subtree fast-path in `enqueue()`**: React reconciliation routinely adds-then-removes nodes within one synchronous block. By the time the MO callback fires, the addition record is still there but the node is already detached. `drain()` filters by `isConnected` too — checking at enqueue keeps `pending` small during noisy route-swap bursts.

## What Tier 1S items are landed

From issue #150:
- ✅ #7 Route-change signal as proactive coalesce
- ✅ #8 Pause-and-batch around route transitions (via the rAF deferral)
- ✅ #9 Detached-subtree fast-path

## Test plan

- [x] `bun run test` → 1177 passed (1164 baseline + 6 route-change.test.ts + 7 new subtree-watcher cases)
- [x] `bun run typecheck`
- [x] `bun run check` (biome + eslint)
- [x] `bun run knip`
- [x] `bun run test:coverage` — statements 85.55% / branches 76.81% / functions 88.71% / lines 85.46% (above ratchet)
- [ ] Manual smoke on a real SPA (e.g. a React Router app, GitHub web UI) — confirm placeholders apply on initial route AND after a route swap, no double-application, no perf regression on rapid back/forward

Refs #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)