### PR TITLE
Test: property test for outermost-match, memoization + cross-state coverage

### DIFF
--- a/extension/src/lib/__tests__/selector-hide-rule.property.test.ts
+++ b/extension/src/lib/__tests__/selector-hide-rule.property.test.ts
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Property tests for selector-hide-rule's outermost-match dedupe. The
+// existing example test pins down one nested-footer case; this file fuzzes
+// across random tree shapes and random candidate subsets so off-by-one
+// errors in the inline parent-walk (Set lookup vs. ancestor traversal)
+// can't slip through.
+//
+// Tree generator mirrors dom-utils.property.test.ts — flat encoding
+// (size + parent index per node) so generation always terminates within
+// fast-check's depth bias and any tree shape is reachable. Each generated
+// scenario lives under document.body; tests reset between runs.
+
+import fc from "fast-check";
+
+import { filterToOutermost } from "../dom-utils";
+import { PLACEHOLDER_CLASS } from "../placeholder";
+import { createSelectorHideRule } from "../selector-hide-rule";
+import type { RuleId } from "../storage";
+
+const RULE_ID = "footer-redact" as RuleId;
+const HIDE_LABEL = "[hidden]";
+const TARGET_ATTR = "data-target";
+const TARGET_SELECTOR = "[data-target]";
+
+interface FlatTree {
+  size: number;
+  parents: readonly number[];
+}
+
+const flatTreeArb: fc.Arbitrary<FlatTree> = fc
+  .integer({ min: 1, max: 20 })
+  .chain((size) => {
+    if (size === 1) {
+      return fc.constant<FlatTree>({ size, parents: [] });
+    }
+    const parentArbs = Array.from({ length: size - 1 }, (_, index) =>
+      fc.integer({ min: 0, max: index }),
+    );
+    return fc.tuple(...parentArbs).map<FlatTree>((parents) => ({
+      size,
+      parents,
+    }));
+  });
+
+function buildFlatTree(
+  { size, parents }: FlatTree,
+  into: HTMLElement[],
+): HTMLElement {
+  const nodes: HTMLElement[] = Array.from({ length: size }, (_, index) => {
+    const element = document.createElement("div");
+    element.dataset.id = String(index);
+    return element;
+  });
+  for (let i = 1; i < size; i++) {
+    const parentIndex = parents[i - 1];
+    if (parentIndex === undefined) {
+      throw new Error("parents array shorter than expected");
+    }
+    nodes[parentIndex]?.append(nodes[i] as HTMLElement);
+  }
+  function pushPreOrder(node: HTMLElement): void {
+    into.push(node);
+    for (const child of node.children) {
+      pushPreOrder(child as HTMLElement);
+    }
+  }
+  const root = nodes[0];
+  if (!root) {
+    throw new Error("empty tree (size should be >= 1)");
+  }
+  pushPreOrder(root);
+  return root;
+}
+
+const treeWithMask = flatTreeArb.chain((tree) =>
+  fc
+    .array(fc.boolean(), { minLength: tree.size, maxLength: tree.size })
+    .map((mask) => ({ tree, mask })),
+);
+
+interface Scenario {
+  root: HTMLElement;
+  candidates: HTMLElement[];
+}
+
+function realize({
+  tree,
+  mask,
+}: {
+  tree: FlatTree;
+  mask: boolean[];
+}): Scenario {
+  const all: HTMLElement[] = [];
+  const root = buildFlatTree(tree, all);
+  const candidates = all.filter((_, i) => mask[i]);
+  for (const candidate of candidates) {
+    candidate.setAttribute(TARGET_ATTR, "");
+  }
+  return { root, candidates };
+}
+
+function freshRule() {
+  return createSelectorHideRule({
+    id: RULE_ID,
+    label: "test",
+    description: "test",
+    alwaysOnSelectors: [TARGET_SELECTOR],
+    hideLabel: HIDE_LABEL,
+  });
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("scan() outermost-match (property)", () => {
+  it("places exactly one placeholder per outermost match", () => {
+    fc.assert(
+      fc.property(treeWithMask, (input) => {
+        document.body.innerHTML = "";
+        const { root, candidates } = realize(input);
+        document.body.append(root);
+
+        const expectedOutermost = filterToOutermost(candidates);
+
+        const { rule } = freshRule();
+        rule.apply(document.body);
+
+        const placeholders = document.querySelectorAll(`.${PLACEHOLDER_CLASS}`);
+        expect(placeholders).toHaveLength(expectedOutermost.length);
+      }),
+    );
+  });
+
+  it("removes every original target from the DOM after scan", () => {
+    fc.assert(
+      fc.property(treeWithMask, (input) => {
+        document.body.innerHTML = "";
+        const { root } = realize(input);
+        document.body.append(root);
+
+        const { rule } = freshRule();
+        rule.apply(document.body);
+
+        // Outermost matches are replaced directly; descendant candidates
+        // disappear with their replaced ancestor. Either way: no targets
+        // survive the scan.
+        expect(document.querySelectorAll(TARGET_SELECTOR)).toHaveLength(0);
+      }),
+    );
+  });
+
+  it("does not place a placeholder that is itself a descendant of another placeholder", () => {
+    fc.assert(
+      fc.property(treeWithMask, (input) => {
+        document.body.innerHTML = "";
+        const { root } = realize(input);
+        document.body.append(root);
+
+        const { rule } = freshRule();
+        rule.apply(document.body);
+
+        const placeholders = [
+          ...document.querySelectorAll<HTMLElement>(`.${PLACEHOLDER_CLASS}`),
+        ];
+        for (const a of placeholders) {
+          for (const b of placeholders) {
+            if (a === b) {
+              continue;
+            }
+            expect(a.contains(b)).toBe(false);
+          }
+        }
+      }),
+    );
+  });
+
+  it("is idempotent: applying twice yields the same placeholder count", () => {
+    fc.assert(
+      fc.property(treeWithMask, (input) => {
+        document.body.innerHTML = "";
+        const { root } = realize(input);
+        document.body.append(root);
+
+        const { rule } = freshRule();
+        rule.apply(document.body);
+        const after_first = document.querySelectorAll(
+          `.${PLACEHOLDER_CLASS}`,
+        ).length;
+
+        rule.apply(document.body);
+        const after_second = document.querySelectorAll(
+          `.${PLACEHOLDER_CLASS}`,
+        ).length;
+
+        expect(after_second).toBe(after_first);
+      }),
+    );
+  });
+});

--- a/extension/src/lib/__tests__/selector-hide-rule.test.ts
+++ b/extension/src/lib/__tests__/selector-hide-rule.test.ts
@@ -141,6 +141,95 @@ describe("selectorsFor URL composition", () => {
   });
 });
 
+describe("selectorsFor memoization", () => {
+  it("returns equal selector lists for repeated calls with the same URL", () => {
+    const { selectorsFor } = createSelectorHideRule({
+      id: RULE_ID,
+      label: "test",
+      description: "test",
+      alwaysOnSelectors: ["footer"],
+      siteRules: [
+        {
+          patterns: [new URLPattern({ hostname: "{*.}?amazon.{*}" })],
+          selectors: ["#navFooter"],
+        },
+      ],
+      hideLabel: HIDE_LABEL,
+    });
+
+    const first = selectorsFor("https://www.amazon.com/dp/X");
+    const second = selectorsFor("https://www.amazon.com/dp/X");
+    expect(second).toEqual(first);
+  });
+
+  it("recomputes the selector list when the URL changes (memo invalidation)", () => {
+    const { selectorsFor } = createSelectorHideRule({
+      id: RULE_ID,
+      label: "test",
+      description: "test",
+      alwaysOnSelectors: ["footer"],
+      siteRules: [
+        {
+          patterns: [new URLPattern({ hostname: "{*.}?amazon.{*}" })],
+          selectors: ["#navFooter"],
+        },
+      ],
+      hideLabel: HIDE_LABEL,
+    });
+
+    expect(selectorsFor("https://example.com/")).toEqual(["footer"]);
+    // Different URL — site rule must now apply.
+    expect(selectorsFor("https://www.amazon.com/dp/X")).toEqual([
+      "footer",
+      "#navFooter",
+    ]);
+    // And switching back returns the original shape.
+    expect(selectorsFor("https://example.com/")).toEqual(["footer"]);
+  });
+
+  it("returns a fresh array on each call — caller mutation does not poison the memo", () => {
+    const { selectorsFor } = createSelectorHideRule({
+      id: RULE_ID,
+      label: "test",
+      description: "test",
+      alwaysOnSelectors: ["footer", "main"],
+      hideLabel: HIDE_LABEL,
+    });
+
+    const first = selectorsFor("https://example.com/");
+    first.push("INJECTED");
+    first.pop();
+    first.length = 0;
+
+    // Subsequent call must not see any of the prior caller's mutations.
+    expect(selectorsFor("https://example.com/")).toEqual(["footer", "main"]);
+  });
+
+  it("rules built from separate factory calls have independent memos", () => {
+    const ruleA = createSelectorHideRule({
+      id: RULE_ID,
+      label: "test",
+      description: "test",
+      alwaysOnSelectors: ["footer"],
+      hideLabel: HIDE_LABEL,
+    });
+    const ruleB = createSelectorHideRule({
+      id: RULE_ID,
+      label: "test",
+      description: "test",
+      alwaysOnSelectors: ["aside"],
+      hideLabel: HIDE_LABEL,
+    });
+
+    // Same URL — but each rule's memo holds its own selector list.
+    expect(ruleA.selectorsFor("https://example.com/")).toEqual(["footer"]);
+    expect(ruleB.selectorsFor("https://example.com/")).toEqual(["aside"]);
+    // And the second access to each is still its own value.
+    expect(ruleA.selectorsFor("https://example.com/")).toEqual(["footer"]);
+    expect(ruleB.selectorsFor("https://example.com/")).toEqual(["aside"]);
+  });
+});
+
 describe("scan behavior", () => {
   it("short-circuits when the effective selector list is empty", () => {
     // No alwaysOnSelectors and no matching siteRules → empty list → no scan.

--- a/extension/src/lib/__tests__/subtree-watcher.test.ts
+++ b/extension/src/lib/__tests__/subtree-watcher.test.ts
@@ -597,4 +597,122 @@ describe("createSubtreeWatcher", () => {
       watcher.stop();
     });
   });
+
+  describe("cross-state interactions", () => {
+    function setHidden(hidden: boolean): void {
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: hidden,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    }
+
+    function fireRouteChange(toUrl: string): void {
+      history.replaceState(null, "", toUrl);
+      globalThis.dispatchEvent(new Event("popstate"));
+    }
+
+    it("cancels the scheduled rAF sweep when the tab hides between route change and frame", () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      fireRouteChange("/route-b");
+      // Tab goes hidden BEFORE the rAF fires — the scheduled sweep checks
+      // document.hidden inside the rAF and bails.
+      setHidden(true);
+
+      jest.advanceTimersToNextFrame();
+
+      expect(onSubtrees).not.toHaveBeenCalled();
+      watcher.stop();
+    });
+
+    it("burst flush followed by route change: each fires once", async () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      // Burst above threshold drains immediately.
+      const fragment = document.createDocumentFragment();
+      for (let i = 0; i < 600; i++) {
+        fragment.append(document.createElement("div"));
+      }
+      document.body.append(fragment);
+      await flushMutations();
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+
+      // Then a route change schedules its own rAF sweep.
+      fireRouteChange("/route-b");
+      jest.advanceTimersToNextFrame();
+      expect(onSubtrees).toHaveBeenCalledTimes(2);
+
+      const [secondCallRoots] = onSubtrees.mock.calls[1] as [Element[]];
+      expect(secondCallRoots).toEqual([document.body]);
+      watcher.stop();
+    });
+
+    it("mutations during the rAF wait drain on the next throttle window", async () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      fireRouteChange("/route-b");
+      // A mutation arrives between the route-change signal and the rAF.
+      document.body.append(document.createElement("article"));
+      await flushMutations();
+
+      jest.advanceTimersToNextFrame();
+      // Route sweep ran with document.body.
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      const [firstCallRoots] = onSubtrees.mock.calls[0] as [Element[]];
+      expect(firstCallRoots).toEqual([document.body]);
+
+      // The mid-wait mutation still drains on its own throttle window
+      // — not swallowed by the route-change cancellation, since it
+      // arrived AFTER the cancel.
+      jest.advanceTimersByTime(THROTTLE_MS);
+      expect(onSubtrees).toHaveBeenCalledTimes(2);
+      watcher.stop();
+    });
+
+    it("visibility flushes pending and a route change while hidden does not sweep", async () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      document.body.append(document.createElement("div"));
+      await flushMutations();
+      // Hide → pending drains via flush.
+      setHidden(true);
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+
+      // Route change while hidden — listener still fires (we subscribe in
+      // start, not start-when-visible), but the rAF guards on hidden.
+      fireRouteChange("/route-b");
+      jest.advanceTimersToNextFrame();
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      watcher.stop();
+    });
+
+    it("route change after a normal drain still triggers the rAF sweep", async () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      document.body.append(document.createElement("div"));
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+
+      // Pending is empty when the route change comes in — the rAF still
+      // schedules and sweeps from document.body.
+      fireRouteChange("/route-b");
+      jest.advanceTimersToNextFrame();
+      expect(onSubtrees).toHaveBeenCalledTimes(2);
+      const [secondCallRoots] = onSubtrees.mock.calls[1] as [Element[]];
+      expect(secondCallRoots).toEqual([document.body]);
+      watcher.stop();
+    });
+  });
 });


### PR DESCRIPTION
Three test additions targeting the gaps that opened up with the Tier 1 (#151) and Tier 1S (#152) perf work. Pure test additions — no production code touched.

## Summary

**`selector-hide-rule.property.test.ts` (new)** — fast-check fuzz over the rule's public `apply()` → `scan()` path:
- Random tree shapes (flat encoding, ≤20 nodes — any tree shape reachable, generation always terminates)
- Random candidate subsets via boolean mask
- Four properties:
  - placeholder count equals naive `filterToOutermost` size
  - no targets survive scan (descendants of replaced outermosts disappear with their ancestor)
  - no placeholder is nested inside another
  - idempotent under double-apply

The Tier 1 PR rewrote outermost-match from O(C²) `candidates.some(contains)` to an O(C·D) `Set` + `parentElement` walk. The existing single example test (nested footer) doesn't cover deep chains, sibling forests, or roots-as-candidates — these properties do.

**`selector-hide-rule.test.ts` (additions)** — `selectorsFor(url)` memoization:
- same URL returns equal list
- URL change recomputes (and switching back works — covers the cache key flip-flop case)
- defensive copy: caller mutating the returned array doesn't poison the memo
- factory instances have independent memos

**`subtree-watcher.test.ts` (additions)** — cross-state interactions:
- visibility hides between a route change and its rAF sweep → sweep bails
- burst flush followed by route change → two separate `onSubtrees` calls
- mutations arriving during the rAF wait → rAF sweeps, then the late mutation drains on its own throttle window
- route change while hidden → listener still fires but rAF guards on hidden
- route change after a normal drain → still sweeps from `document.body`

## What I considered and skipped

- **Property tests for the route-change emitter** — state machine too small (set add, dedupe by URL, fan-out). Existing example tests cover it.
- **Full-pipe integration test (watcher → real selector-hide-rule)** — tempting but expensive to set up; the seam isn't where bugs hide. Both sides have direct unit tests at the boundary.

## Follow-up worth filing separately

`filterToOutermost` in `lib/dom-utils.ts` still uses the original O(C²) `candidates.some(other.contains(element))` shape, but is used by `hidden-text-strip`, `prompt-injection-redact`, and `disguised-ad-flag`. Same fix as Tier 1 PR #151 (Set + parentElement walk) would propagate the perf win across those rules. Property tests for the helper already exist in `dom-utils.property.test.ts`, so they'd cover the change for free.

## Test plan

- [x] `bun run test` → 1190 passed (was 1177; +13 new)
- [x] `bun run typecheck`
- [x] `bun run check` (biome + eslint)
- [x] `bun run knip`
- [x] `bun run test:coverage` — held at statements 85.55% / branches 76.81% / functions 88.71% / lines 85.46% (new tests cover already-covered lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)