### PR TITLE
Perf: dispatch id/class attribute mutations through the token index (#150 Tier 2)

### DIFF
--- a/extension/src/lib/__tests__/selector-hide-rule.test.ts
+++ b/extension/src/lib/__tests__/selector-hide-rule.test.ts
@@ -704,6 +704,66 @@ describe("subtree dispatcher integration", () => {
     expect(widget.style.display).toBe("");
   });
 
+  it("catches a post-insert id assignment (attribute-mutation dispatch)", async () => {
+    // jQuery-style pattern: page injects a generic <div>, then later
+    // sets the id that the rule targets. The token-index dispatcher
+    // opts into attribute observation so this no longer slips through.
+    const { rule } = createSelectorHideRule({
+      id: RULE_ID,
+      label: "test",
+      description: "test",
+      alwaysOnSelectors: ["#late-id"],
+      removeEntirely: true,
+      watchSubtrees: true,
+    });
+
+    rule.apply(document.body);
+
+    const widget = document.createElement("div");
+    document.body.append(widget);
+    await flushMutations();
+    jest.advanceTimersByTime(THROTTLE_MS);
+    // No id at insertion time — the rule shouldn't have hidden it.
+    expect(widget.style.display).toBe("");
+
+    // The page sets the id afterward. With observeAttributes the
+    // dispatcher re-runs and hides the now-matching element.
+    widget.id = "late-id";
+    await flushMutations();
+    jest.advanceTimersByTime(THROTTLE_MS);
+
+    expect(widget.style.display).toBe("none");
+
+    rule.teardown?.();
+  });
+
+  it("catches a post-insert class assignment (attribute-mutation dispatch)", async () => {
+    const { rule } = createSelectorHideRule({
+      id: RULE_ID,
+      label: "test",
+      description: "test",
+      alwaysOnSelectors: [".late-class"],
+      removeEntirely: true,
+      watchSubtrees: true,
+    });
+
+    rule.apply(document.body);
+
+    const widget = document.createElement("div");
+    document.body.append(widget);
+    await flushMutations();
+    jest.advanceTimersByTime(THROTTLE_MS);
+    expect(widget.style.display).toBe("");
+
+    widget.classList.add("late-class");
+    await flushMutations();
+    jest.advanceTimersByTime(THROTTLE_MS);
+
+    expect(widget.style.display).toBe("none");
+
+    rule.teardown?.();
+  });
+
   it("registers siteRule selectors in the token index too", async () => {
     // Without this, a URL-gated selector would never be triggered by
     // the dispatcher even when the URL matches — the rule's scan would

--- a/extension/src/lib/__tests__/subtree-watcher.test.ts
+++ b/extension/src/lib/__tests__/subtree-watcher.test.ts
@@ -980,4 +980,246 @@ describe("createSubtreeWatcher", () => {
       watcherB.stop();
     });
   });
+
+  describe("observeAttributes", () => {
+    // Opt-in: only subscribers with observeAttributes:true hear about
+    // id/class mutations on already-inserted nodes. Other subscribers
+    // on the same router are unaffected.
+
+    it("delivers an attribute mutation as a subtree root", async () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({
+        onSubtrees,
+        observeAttributes: true,
+      });
+      watcher.start(document.body);
+
+      const div = document.createElement("div");
+      document.body.append(div);
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      // Initial drain from the addition itself.
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      onSubtrees.mockClear();
+
+      // Mutate an observed attribute — should fire onSubtrees a second
+      // time with the same div as the root.
+      div.id = "now-i-have-an-id";
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      const [roots] = onSubtrees.mock.calls[0] as [Element[]];
+      expect(roots).toEqual([div]);
+      watcher.stop();
+    });
+
+    it("delivers a class mutation as a subtree root", async () => {
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({
+        onSubtrees,
+        observeAttributes: true,
+      });
+      watcher.start(document.body);
+
+      const div = document.createElement("div");
+      document.body.append(div);
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      onSubtrees.mockClear();
+
+      div.classList.add("late-class");
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      const [roots] = onSubtrees.mock.calls[0] as [Element[]];
+      expect(roots).toEqual([div]);
+      watcher.stop();
+    });
+
+    it("ignores attribute mutations for subscribers that did not opt in", async () => {
+      // Two subscribers on document.body: one opted in, one not. A
+      // post-insert attribute mutation fires only the opted-in one.
+      const optedIn = jest.fn();
+      const optedOut = jest.fn();
+      const watcherIn = createSubtreeWatcher({
+        onSubtrees: optedIn,
+        observeAttributes: true,
+      });
+      const watcherOut = createSubtreeWatcher({ onSubtrees: optedOut });
+      watcherIn.start(document.body);
+      watcherOut.start(document.body);
+
+      const div = document.createElement("div");
+      document.body.append(div);
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      optedIn.mockClear();
+      optedOut.mockClear();
+
+      div.id = "post-insert-id";
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(optedIn).toHaveBeenCalledTimes(1);
+      expect(optedOut).not.toHaveBeenCalled();
+
+      watcherIn.stop();
+      watcherOut.stop();
+    });
+
+    it("upgrades the shared MO when an attribute subscriber joins after a non-attribute one", async () => {
+      // Order matters: the first subscriber doesn't want attributes, so
+      // the router starts with childList+subtree only. When a second
+      // subscriber with observeAttributes joins, the MO must be
+      // re-configured so attribute mutations actually fire.
+      const optedOut = jest.fn();
+      const optedIn = jest.fn();
+      const watcherOut = createSubtreeWatcher({ onSubtrees: optedOut });
+      const watcherIn = createSubtreeWatcher({
+        onSubtrees: optedIn,
+        observeAttributes: true,
+      });
+
+      watcherOut.start(document.body);
+      watcherIn.start(document.body);
+
+      const div = document.createElement("div");
+      document.body.append(div);
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      optedIn.mockClear();
+      optedOut.mockClear();
+
+      div.classList.add("late-class");
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(optedIn).toHaveBeenCalledTimes(1);
+      expect(optedOut).not.toHaveBeenCalled();
+
+      watcherIn.stop();
+      watcherOut.stop();
+    });
+
+    it("downgrades the shared MO when the last attribute subscriber stops", async () => {
+      // The opted-in watcher leaves; the remaining (non-opted) watcher
+      // should no longer be re-routed attribute mutations.
+      const optedIn = jest.fn();
+      const optedOut = jest.fn();
+      const watcherIn = createSubtreeWatcher({
+        onSubtrees: optedIn,
+        observeAttributes: true,
+      });
+      const watcherOut = createSubtreeWatcher({ onSubtrees: optedOut });
+
+      watcherIn.start(document.body);
+      watcherOut.start(document.body);
+
+      const div = document.createElement("div");
+      document.body.append(div);
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      // Verify the in watcher is actually getting attribute mutations
+      // while it's still subscribed.
+      optedIn.mockClear();
+      div.id = "first";
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      expect(optedIn).toHaveBeenCalledTimes(1);
+
+      // Drop the opted-in watcher. The remaining opted-out watcher
+      // should not see subsequent attribute mutations even though it's
+      // still active on the same router.
+      watcherIn.stop();
+      optedOut.mockClear();
+
+      div.id = "second";
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      expect(optedOut).not.toHaveBeenCalled();
+
+      watcherOut.stop();
+    });
+
+    it("drops attribute mutations on placeholder elements when skipPlaceholderSubtrees is on", async () => {
+      // Same gate as childList: a class change on a placeholder element
+      // doesn't surface to subscribers that asked to skip placeholders.
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({
+        onSubtrees,
+        observeAttributes: true,
+        skipPlaceholderSubtrees: true,
+      });
+
+      const placeholder = document.createElement("div");
+      placeholder.classList.add(PLACEHOLDER_CLASS);
+      document.body.append(placeholder);
+      watcher.start(document.body);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      onSubtrees.mockClear();
+
+      // Add an unrelated id to the placeholder. The attribute mutation
+      // fires, but the placeholder gate filters it out.
+      placeholder.id = "x";
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).not.toHaveBeenCalled();
+      watcher.stop();
+    });
+
+    it("filters detached targets out of attribute-mutation drains", async () => {
+      // If the element is detached by the time the MO callback fires,
+      // the enqueue should drop it — same isConnected gate as childList.
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({
+        onSubtrees,
+        observeAttributes: true,
+      });
+      watcher.start(document.body);
+
+      const div = document.createElement("div");
+      document.body.append(div);
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      onSubtrees.mockClear();
+
+      // Mutate attribute, then detach before the MO microtask runs.
+      div.id = "transient";
+      div.remove();
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).not.toHaveBeenCalled();
+      watcher.stop();
+    });
+
+    it("does not fire on attribute mutations when no subscriber opted in", async () => {
+      // Sanity check: pre-existing rules that don't opt in keep seeing
+      // exactly the childList shape they did before — even when an
+      // attribute mutates on the observed root.
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      const div = document.createElement("div");
+      document.body.append(div);
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      onSubtrees.mockClear();
+
+      div.id = "should-not-fire";
+      div.classList.add("also-should-not-fire");
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).not.toHaveBeenCalled();
+      watcher.stop();
+    });
+  });
 });

--- a/extension/src/lib/selector-token-index.ts
+++ b/extension/src/lib/selector-token-index.ts
@@ -153,6 +153,11 @@ function ensureWatcherStarted(): void {
   }
   sharedWatcher = createSubtreeWatcher({
     skipPlaceholderSubtrees: true,
+    // Catch jQuery-style `element.id = 'foo'` / `classList.add('foo')`
+    // on already-inserted nodes — without this, the token dispatcher
+    // would silently miss any rule whose match was attached to a
+    // post-insert attribute change.
+    observeAttributes: true,
     onSubtrees: dispatchToRules,
   });
   sharedWatcher.start(document.body);

--- a/extension/src/lib/subtree-watcher.ts
+++ b/extension/src/lib/subtree-watcher.ts
@@ -35,6 +35,12 @@ const IGNORE_TAGS: ReadonlySet<string> = new Set(["STYLE", "BR"]);
 // (Pattern from Ghostery's adblocker DOMMonitor.)
 const BURST_FLUSH_THRESHOLD = 512;
 
+// `id` and `class` are the only attributes the selector-token-index
+// dispatcher keys on. Limiting the filter at the MO level keeps the
+// burst from page JS toggling unrelated attributes (style, data-*,
+// aria-*) off the hot path.
+const OBSERVED_ATTRIBUTES = ["id", "class"];
+
 interface SubtreeWatcherOptions {
   // Called once per throttle window with all the (still-connected) subtree
   // roots that were added since the previous drain. Batched together so
@@ -46,6 +52,14 @@ interface SubtreeWatcherOptions {
   // inside one are dropped during enqueue. Rules whose own placeholder
   // insertions would otherwise re-trigger them want this on.
   skipPlaceholderSubtrees?: boolean;
+  // When true, this subscriber also receives elements whose `id` or
+  // `class` attribute changed in place — surfaced through the same
+  // onSubtrees callback as freshly-added subtrees. The shared router
+  // upgrades the MO config when any subscriber asks; other subscribers
+  // are unaffected. Use this for token-index-style dispatch where a
+  // jQuery-style `addClass` on an existing node would otherwise be
+  // silently missed.
+  observeAttributes?: boolean;
 }
 
 export interface SubtreeWatcher {
@@ -56,6 +70,7 @@ export interface SubtreeWatcher {
 interface Subscriber {
   onSubtrees: (roots: Element[]) => void;
   skipPlaceholderSubtrees: boolean;
+  observeAttributes: boolean;
   throttledScan: ReturnType<typeof throttle>;
   pending: Set<Element>;
 }
@@ -63,6 +78,7 @@ interface Subscriber {
 interface Router {
   target: Node;
   observer: MutationObserver | null;
+  observingAttributes: boolean;
   subscribers: Set<Subscriber>;
   visibilityListener: (() => void) | null;
   unsubscribeRouteChange: (() => void) | null;
@@ -98,6 +114,37 @@ function drainSubscriber(subscriber: Subscriber): void {
   }
 }
 
+function enqueueAttributeMutation(
+  router: Router,
+  mutation: MutationRecord,
+): void {
+  const target = mutation.target;
+  if (target.nodeType !== Node.ELEMENT_NODE) {
+    return;
+  }
+  const element = target as Element;
+  if (IGNORE_TAGS.has(element.tagName)) {
+    return;
+  }
+  if (!element.isConnected) {
+    return;
+  }
+  for (const subscriber of router.subscribers) {
+    if (!subscriber.observeAttributes) {
+      continue;
+    }
+    if (subscriber.skipPlaceholderSubtrees) {
+      if (element.classList.contains(PLACEHOLDER_CLASS)) {
+        continue;
+      }
+      if (element.closest(`.${PLACEHOLDER_CLASS}`)) {
+        continue;
+      }
+    }
+    subscriber.pending.add(element);
+  }
+}
+
 function fanOut(router: Router, mutations: MutationRecord[]): void {
   // Walk every added node once and dispatch into each subscriber's pending
   // set. The shared filters (nodeType, IGNORE_TAGS, isConnected) run once
@@ -105,6 +152,14 @@ function fanOut(router: Router, mutations: MutationRecord[]): void {
   // router. Per-subscriber filters (skipPlaceholderSubtrees) still run
   // per (node, subscriber) pair, but they're cheap classlist reads.
   for (const mutation of mutations) {
+    if (mutation.type === "attributes") {
+      // id/class changed on an existing element. Only subscribers that
+      // opted into observeAttributes hear about it — other rules don't
+      // benefit from re-scanning the same node just because a class
+      // toggled.
+      enqueueAttributeMutation(router, mutation);
+      continue;
+    }
     for (const added of mutation.addedNodes) {
       if (added.nodeType !== Node.ELEMENT_NODE) {
         continue;
@@ -152,6 +207,29 @@ function fanOut(router: Router, mutations: MutationRecord[]): void {
   }
 }
 
+function observerInit(router: Router): MutationObserverInit {
+  // Attribute observation rides on the same MO. We attach it whenever
+  // any current subscriber wants attribute mutations; the per-subscriber
+  // gate in fanOut keeps non-opted-in subscribers from seeing them.
+  const wantsAttributes = router.observingAttributes;
+  return {
+    childList: true,
+    subtree: true,
+    ...(wantsAttributes
+      ? { attributes: true, attributeFilter: OBSERVED_ATTRIBUTES }
+      : {}),
+  };
+}
+
+function refreshObservation(router: Router): void {
+  if (!router.observer || document.hidden) {
+    return;
+  }
+  // observe() on an already-observed MO replaces the existing options
+  // without re-emitting historical records.
+  router.observer.observe(router.target, observerInit(router));
+}
+
 function handleVisibilityChange(router: Router): void {
   if (document.hidden) {
     // Flush whatever's pending so we don't sit on a stale snapshot until
@@ -163,7 +241,7 @@ function handleVisibilityChange(router: Router): void {
     }
     router.observer?.disconnect();
   } else if (router.observer) {
-    router.observer.observe(router.target, { childList: true, subtree: true });
+    refreshObservation(router);
   }
 }
 
@@ -214,7 +292,7 @@ function startRouter(router: Router): void {
   });
   router.observer = observer;
   if (!document.hidden) {
-    observer.observe(router.target, { childList: true, subtree: true });
+    observer.observe(router.target, observerInit(router));
   }
   router.visibilityListener = () => {
     handleVisibilityChange(router);
@@ -247,6 +325,7 @@ function getOrCreateRouter(target: Node): Router {
     router = {
       target,
       observer: null,
+      observingAttributes: false,
       subscribers: new Set(),
       visibilityListener: null,
       unsubscribeRouteChange: null,
@@ -264,6 +343,7 @@ export function createSubtreeWatcher(
     onSubtrees,
     throttleMs = 250,
     skipPlaceholderSubtrees = false,
+    observeAttributes = false,
   } = options;
 
   let subscriber: Subscriber | null = null;
@@ -282,6 +362,7 @@ export function createSubtreeWatcher(
       const ownSubscriber: Subscriber = {
         onSubtrees,
         skipPlaceholderSubtrees,
+        observeAttributes,
         pending: new Set(),
         // Trailing-only: a burst of additions inside one window collapses
         // to a single drain at the end of it, instead of one drain at the
@@ -297,7 +378,19 @@ export function createSubtreeWatcher(
       };
       subscriber = ownSubscriber;
       router.subscribers.add(ownSubscriber);
-      startRouter(router);
+      const needsAttributeUpgrade =
+        observeAttributes && !router.observingAttributes;
+      if (needsAttributeUpgrade) {
+        router.observingAttributes = true;
+      }
+      if (router.observer === null) {
+        startRouter(router);
+      } else if (needsAttributeUpgrade) {
+        // Re-observe with the upgraded options. Calling observe() on an
+        // already-active MO with the same target merges configurations
+        // without re-emitting historical mutations.
+        refreshObservation(router);
+      }
     },
     stop(): void {
       if (!subscriber || !router) {
@@ -308,6 +401,16 @@ export function createSubtreeWatcher(
       subscriber.pending.clear();
       if (router.subscribers.size === 0) {
         stopRouter(router);
+      } else if (subscriber.observeAttributes) {
+        // Downgrade if this was the last attribute-observing subscriber.
+        // We leave the MO connected — only the option set narrows.
+        const stillWantsAttributes = [...router.subscribers].some(
+          (s) => s.observeAttributes,
+        );
+        if (!stillWantsAttributes && router.observingAttributes) {
+          router.observingAttributes = false;
+          refreshObservation(router);
+        }
       }
       subscriber = null;
       router = null;


### PR DESCRIPTION
Stacks on #157.

## Summary

Closes the one behavioral regression flagged in #157's risk section: **attribute mutations on already-inserted elements**. Before this PR, the token-index dispatcher only walked added subtree roots, so jQuery-style `element.id = 'cookie-banner'` or `classList.add('cookie-banner')` after insertion was silently missed. The old code (pre-#157) caught these incidentally because every batch ran a full-doc QSA.

## Changes

- `lib/subtree-watcher.ts`: opt-in `observeAttributes?: boolean` on `createSubtreeWatcher`. When any subscriber asks, the shared `MutationObserver` upgrades to `{ childList, subtree, attributes, attributeFilter: ['id', 'class'] }`. The router fans attribute mutations only to subscribers that opted in — other rules don't see them.
- Router dynamically upgrades when an attribute subscriber joins after a non-attribute one and downgrades when the last attribute subscriber leaves, via `MO.observe()` re-call on the same target.
- `lib/selector-token-index.ts`: dispatcher opts in. Attribute targets flow through `findTriggeredRules` the same way as added subtree roots.

## Why opt-in (not blanket)

22 other rules use `createSubtreeWatcher` directly (pii-redact, secrets-redact, json-ld-sanitize, etc.). Most don't benefit from re-scanning a node just because a class toggled, and pages doing animation-driven class toggling could produce MO storms. The opt-in keeps the existing fast path for those rules intact; only the selector-hide-rule dispatcher pays the attribute-observation cost.

## What about MO config replacement semantics

Per the DOM spec, calling `observe()` on the same MO with the same target updates the registered observer's options in place — no historical record re-emission. We rely on that for both the upgrade and downgrade paths. The router holds `observingAttributes` to make the desired config recomputable from current subscribers.

## Test plan

- [x] `bun run test` — 1254 / 1254 pass
- [x] `bun run typecheck`
- [x] `bun run check` (biome + eslint)
- [x] `bun run knip`
- [x] New subtree-watcher tests cover: attribute mutation delivered as a subtree root, opt-out subscribers ignored, dynamic upgrade after a non-attribute subscriber joined first, downgrade after the last attribute subscriber leaves, placeholder gate still applies, detached-target gate still applies, and the no-op case where no subscriber opted in.
- [x] selector-hide-rule integration tests cover the canonical regression scenarios: a generic `<div>` is inserted with no id/class, page later sets `div.id = 'late-id'` or `div.classList.add('late-class')`, the rule's removeEntirely path fires on the second drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)