### PR TITLE
Fix: prompt-injection-redact would re-hide a revealed container

### DIFF
--- a/extension/src/rules/__tests__/prompt-injection-redact.test.ts
+++ b/extension/src/rules/__tests__/prompt-injection-redact.test.ts
@@ -177,6 +177,60 @@ describe("prompt-injection-redact", () => {
     expect(document.body.textContent).toContain(FIXTURES.IGNORE_ALL);
   });
 
+  describe("reveal flow", () => {
+    // The container the rule hides is an ancestor of the matched text
+    // node, so the reveal stamp lands on the container — not on anything
+    // walkTextNodes returns. A second apply() stands in for the disable→
+    // enable cycle (and for the watcher-driven re-scan that would happen
+    // if a MutationObserver is ever wired in). Same shape as the
+    // disguised-ad-flag bug fixed in #160.
+    it("does not re-hide a container the user revealed", () => {
+      document.body.innerHTML = `<p>${FIXTURES.IGNORE_ALL}</p>`;
+      promptInjectionRedactRule.apply(document.body);
+
+      const placeholder = document.querySelector<HTMLElement>(
+        `.${PLACEHOLDER_CLASS}`,
+      );
+      placeholder?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      expect(document.querySelector("p")).not.toBeNull();
+
+      promptInjectionRedactRule.apply(document.body);
+
+      expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+      expect(document.querySelector("p")).not.toBeNull();
+      expect(document.body.textContent).toContain(FIXTURES.IGNORE_ALL);
+    });
+
+    // Reveal exempts the revealed container (and its descendants) only —
+    // a sibling paragraph with its own injection must still be hidden.
+    it("still hides a sibling container after an unrelated reveal", () => {
+      document.body.innerHTML = `
+        <p id="first">${FIXTURES.IGNORE_ALL}</p>
+        <p id="second">${FIXTURES.DISREGARD}</p>
+      `;
+      promptInjectionRedactRule.apply(document.body);
+      expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(
+        2,
+      );
+
+      const [firstPlaceholder] = document.querySelectorAll<HTMLElement>(
+        `.${PLACEHOLDER_CLASS}`,
+      );
+      firstPlaceholder?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+
+      promptInjectionRedactRule.apply(document.body);
+
+      // First container revealed and stays revealed; second stays hidden.
+      expect(document.querySelector("p#first")).not.toBeNull();
+      expect(document.querySelector("p#second")).toBeNull();
+      expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(
+        1,
+      );
+    });
+  });
+
   describe("findContainer escalation", () => {
     // When injection text lives directly in <body> with no block-level
     // ancestor, the rule must not redact — wrapping <body> in a placeholder

--- a/extension/src/rules/prompt-injection-redact.ts
+++ b/extension/src/rules/prompt-injection-redact.ts
@@ -13,6 +13,7 @@
 // shipped extension bundle therefore contains plaintext regexes, not
 // `atob` decoding (matters for Chrome Web Store review).
 
+import { REVEALED_ATTR } from "../lib/dom-markers";
 import {
   filterToOutermost,
   isInsidePlaceholder,
@@ -23,6 +24,7 @@ import { INJECTION_PATTERNS } from "./injection-patterns.generated";
 import type { Rule } from "./types";
 
 const RULE_ID = "prompt-injection-redact" as const;
+const REVEALED_SELECTOR = `[${REVEALED_ATTR}="${RULE_ID}"]`;
 const MIN_TEXT_LENGTH = 8;
 
 // Containers we consider a reasonable unit to hide. Walking up from the text
@@ -78,6 +80,15 @@ function apply(root: ParentNode): void {
       continue;
     }
     if (isInsidePlaceholder(element)) {
+      continue;
+    }
+    // The container is an ancestor of the matched text node, so the reveal
+    // stamp lands here — not on the text node we walked from. If a previous
+    // run hid this container and the user revealed it, a re-apply (rule
+    // disable→enable, or a future MutationObserver-driven re-scan) would
+    // otherwise re-hide the same block. Same shape as the disguised-ad-flag
+    // bug fixed in #160.
+    if (element.closest(REVEALED_SELECTOR)) {
       continue;
     }
     replaceWithBlockPlaceholder(


### PR DESCRIPTION
## Summary

Same structural bug as #160 (disguised-ad-flag): the hidden element is an **ancestor** of the matched text node (the nearest `p/li/blockquote/…/section`), so the reveal stamp lands on the container — not on anything `walkTextNodes` returns. The candidate-skip set only checked `isInsidePlaceholder` and `isConnected`, so a subsequent `apply` walked back up from the still-present injection text and re-wrapped the same container into a fresh placeholder.

Not yet user-visible because `prompt-injection-redact` has no `MutationObserver`, so reveal never triggers an immediate re-scan. Two paths still hit it today:

- **Disable → enable cycle.** The user reveals a container manually, toggles the rule off (preserving the manual reveal — `revealAll` is a no-op for already-revealed placeholders), then toggles it back on. `apply` re-fires and re-hides their previously-revealed content.
- **Future watcher.** A few recent PRs (#150 tier work) have been wiring rules into the shared subtree watcher. If `prompt-injection-redact` ever gets one, this becomes the same unrevealable-loop bug #160 fixed.

Fix is the one-liner from #160 — `closest([data-abs-revealed="prompt-injection-redact"])` against the container before hiding.

Audited every other reveal-capable rule while I was in here; this was the only twin. Other rules either pass the candidate directly to `replaceWithBlockPlaceholder` (so `REVEALED_ATTR` lands on what they check), dedup via a per-rule `WeakSet` of processed elements (`countdown-timer-redact`, `irrelevant-sections-redact`), or use inline text-node placeholders whose reveal mutation the watcher already filters out.

## Test plan

- [x] `bun run test` (1265 passed, 65 suites)
- [x] `bunx tsc --noEmit` clean
- [x] `bunx eslint` clean on touched files
- [x] New regression tests in `prompt-injection-redact.test.ts`:
  - "does not re-hide a container the user revealed" — the actual bug.
  - "still hides a sibling container after an unrelated reveal" — guards against the skip check being too broad (sibling paragraphs with their own injection text must still get hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)