### PR TITLE
Fix: scroll to top on SPA navigation in demo site

### DIFF
--- a/demo-site/src/App.tsx
+++ b/demo-site/src/App.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-import { Outlet } from "react-router-dom";
+import { useLayoutEffect } from "react";
+import { Outlet, useLocation } from "react-router-dom";
 import ChatWidget from "./components/ChatWidget";
 import CookieBanner from "./components/CookieBanner";
 import Footer from "./components/Footer";
@@ -9,6 +10,12 @@ import Header from "./components/Header";
 import NewsletterModal from "./components/NewsletterModal";
 
 export default function App() {
+  const { pathname } = useLocation();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the trigger — the effect runs for its side effect, not its read.
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
   return (
     <div className="flex min-h-screen flex-col">
       <Header />


### PR DESCRIPTION
## Summary
- Clicking the brand logo from a scrolled product detail page updated the URL and re-rendered the Home route, but `BrowserRouter` preserved the scroll position — the user landed mid-page on Home and the hero never came into view, so it looked like nothing changed.
- Added a `useLayoutEffect` keyed on `pathname` in `App` that scrolls to top on every SPA navigation.

## Test plan
- [x] `bun run check` passes
- [x] Manually verified: scroll a product detail page down ~1500px, click the RiverMart logo — Home now renders at scroll 0 with the "Spring Refresh Sale" hero in view.
- [x] Verified routing still works from `/` to product detail and back via Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)