### PR TITLE
Feat: shadow-aware subtree watcher (#164 Tier 1)

### DIFF
--- a/demo-site/src/components/ShadowDomEmbed.tsx
+++ b/demo-site/src/components/ShadowDomEmbed.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import { useEffect, useRef } from "react";
+
+// Mounts third-party-style widget markup INSIDE an open shadow root so
+// reviewers can confirm the extension's rules see past the shadow
+// boundary. Without the shadow-aware subtree watcher every rule would
+// be light-DOM only — chat widget, ad slot, and any other marker
+// rendered here would survive untouched.
+//
+// The shadow contents intentionally use the same vendor ids/classes the
+// matching rules already target in the light tree (`#intercom-frame`,
+// `ins.adsbygoogle`) so the demo doesn't depend on any per-shadow
+// special-casing in the rules themselves — only on the dispatcher
+// actually reaching the content.
+
+export default function ShadowDomEmbed() {
+  const hostRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host || host.shadowRoot) {
+      return;
+    }
+    const shadow = host.attachShadow({ mode: "open" });
+
+    // Match chat-widget-hide's `#intercom-frame` selector. The rule
+    // hides the wrapper outright when found in the light tree; with the
+    // shadow-aware watcher it should reach this one too.
+    const chat = document.createElement("div");
+    chat.id = "intercom-frame";
+    chat.style.cssText =
+      "display:inline-block;margin-right:8px;padding:6px 10px;border:1px solid #2563eb;background:#eff6ff;color:#1e3a8a;border-radius:4px;font:13px system-ui;";
+    chat.textContent = "Live chat — open to talk to support";
+    shadow.append(chat);
+
+    // Match ads-hide's `ins.adsbygoogle` selector. EasyList's CSS-only
+    // path can't reach shadow trees, but the curated-selector path goes
+    // through the watcher dispatch and should hide this one.
+    const ad = document.createElement("ins");
+    ad.className = "adsbygoogle";
+    ad.setAttribute("data-ad-client", "ca-pub-0000000000000000");
+    ad.setAttribute("data-ad-slot", "shadow-demo");
+    ad.style.cssText =
+      "display:inline-block;padding:6px 10px;border:1px dashed #d97706;background:#fffbeb;color:#92400e;font:13px system-ui;";
+    ad.textContent = "Sponsored — limited-time offer from a partner brand";
+    shadow.append(ad);
+
+    return () => {
+      // React StrictMode runs effects twice in dev. Leaving the shadow
+      // root behind on unmount would let it accumulate across reloads;
+      // clearing children lets the next mount rebuild cleanly. The
+      // shadow root itself can't be detached once attached, so we
+      // settle for emptying it.
+      shadow.replaceChildren();
+    };
+  }, []);
+
+  return (
+    <section
+      aria-label="Shadow-DOM third-party widgets"
+      className="rounded border border-slate-300 bg-white p-4"
+    >
+      <h2 className="text-base font-semibold text-slate-900">
+        Third-party widgets mounted inside an open shadow root
+      </h2>
+      <p className="mt-2 text-sm text-stone-700">
+        The two items below are appended into <code>this.attachShadow()</code> —
+        the same way modern chat, consent, and ad SDKs ship their UI to keep
+        their styles isolated from the host page. Without the shadow-aware
+        subtree watcher the extension's rules would walk right past them; with
+        it, the chat launcher should be removed and the sponsored block
+        replaced.
+      </p>
+      <div
+        ref={hostRef}
+        className="shadow-host mt-3 rounded border border-dashed border-slate-300 p-3"
+      />
+    </section>
+  );
+}

--- a/demo-site/src/pages/Home.tsx
+++ b/demo-site/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import AdvertorialCard from "../components/AdvertorialCard";
 import BotDetectorProbe from "../components/BotDetectorProbe";
 import CountdownBadge from "../components/CountdownBadge";
 import ProductCard from "../components/ProductCard";
+import ShadowDomEmbed from "../components/ShadowDomEmbed";
 import { products } from "../data/products";
 
 export default function Home() {
@@ -104,6 +105,8 @@ export default function Home() {
           />
         </div>
       </section>
+
+      <ShadowDomEmbed />
 
       <BotDetectorProbe />
 

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -5,6 +5,15 @@ import { isTopFrame } from "./lib/frame";
 import { startOptionsBadge } from "./lib/options-badge";
 import { startPlaceholderCountReporter } from "./lib/placeholder-count";
 import { start } from "./lib/rule-engine";
+import { installShadowRootHook } from "./lib/shadow-roots";
+
+// Install the attachShadow patch as early as possible. The content script
+// runs at document_idle so page scripts that built shadow trees during
+// parsing already ran — those are caught by the subtree watcher's
+// initial walk at startup. The hook here covers every subsequent attach,
+// including custom elements that defer attachShadow into a connected
+// callback, lit-element upgrades, etc.
+installShadowRootHook();
 
 // Content script runs in every frame (`all_frames: true`). The rule engine
 // applies frame-appropriate rules in each; the badge is a single UI affordance

--- a/extension/src/lib/__tests__/shadow-roots.property.test.ts
+++ b/extension/src/lib/__tests__/shadow-roots.property.test.ts
@@ -1,0 +1,460 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Property tests for the shadow-root tracker + the subtree watcher's
+// shadow integration. Three structural invariants that fuzz better than
+// they assert:
+//
+//   - Closed roots never enter the open-tracker. A future refactor that
+//     accidentally registers a closed root would leak it to every
+//     subscriber.
+//   - discoverShadowRootsIn is set-idempotent — its result depends only
+//     on the document's open-shadow shape, not on the order or number
+//     of attach / discover operations leading up to it. Catches
+//     order-of-operations bugs in the bootstrap path.
+//   - The subtree watcher's dispatch covers every element living inside
+//     any open shadow root reachable from the target, transitively.
+//     Closed shadows cut off the branch but siblings stay covered. This
+//     is the integration property the hand-written tests don't enumerate
+//     across nesting depths.
+
+import fc from "fast-check";
+
+import { __resetRouteChangeForTesting } from "../route-change";
+import {
+  __resetShadowRootsForTesting,
+  discoverShadowRootsIn,
+  getOpenShadowRoots,
+  installShadowRootHook,
+} from "../shadow-roots";
+import {
+  __resetSubtreeWatcherForTesting,
+  createSubtreeWatcher,
+} from "../subtree-watcher";
+
+const THROTTLE_MS = 250;
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  __resetShadowRootsForTesting();
+  __resetRouteChangeForTesting();
+  __resetSubtreeWatcherForTesting();
+  installShadowRootHook();
+});
+
+afterEach(() => {
+  __resetShadowRootsForTesting();
+  __resetRouteChangeForTesting();
+  __resetSubtreeWatcherForTesting();
+});
+
+// -----------------------------------------------------------------------
+// Generators
+// -----------------------------------------------------------------------
+
+// Each node spec carries an optional shadow attachment. `null` means no
+// shadow; `"open"` / `"closed"` attach a root in that mode. Closed roots
+// silently swallow any child specs assigned to them (they're opaque to
+// our tracker, which is exactly the property we want to fuzz).
+type ShadowMode = "open" | "closed" | null;
+
+interface NodeSpec {
+  shadow: ShadowMode;
+}
+
+const shadowModeArb: fc.Arbitrary<ShadowMode> = fc.oneof(
+  { arbitrary: fc.constant(null as ShadowMode), weight: 4 },
+  { arbitrary: fc.constant<ShadowMode>("open"), weight: 3 },
+  { arbitrary: fc.constant<ShadowMode>("closed"), weight: 1 },
+);
+
+const nodeSpecArb: fc.Arbitrary<NodeSpec> = fc.record({
+  shadow: shadowModeArb,
+});
+
+interface FlatTree {
+  size: number;
+  parents: readonly number[];
+  // Whether node i should be parented into its parent's *shadow root*
+  // (if its parent has one) vs. the parent's light children. Honored
+  // only when the parent has an open or closed shadow root. Lets the
+  // generator produce content inside shadow trees, not just hosts of
+  // empty shadows.
+  intoShadow: readonly boolean[];
+  specs: readonly NodeSpec[];
+}
+
+const flatTreeArb: fc.Arbitrary<FlatTree> = fc
+  .integer({ min: 1, max: 10 })
+  .chain((size) => {
+    const specsArb = fc.array(nodeSpecArb, {
+      minLength: size,
+      maxLength: size,
+    });
+    if (size === 1) {
+      return specsArb.map((specs) => ({
+        size,
+        parents: [],
+        intoShadow: [],
+        specs,
+      }));
+    }
+    const parentArbs = Array.from({ length: size - 1 }, (_, index) =>
+      fc.integer({ min: 0, max: index }),
+    );
+    const intoShadowArb = fc.array(fc.boolean(), {
+      minLength: size - 1,
+      maxLength: size - 1,
+    });
+    return fc
+      .tuple(fc.tuple(...parentArbs), intoShadowArb, specsArb)
+      .map(([parents, intoShadow, specs]) => ({
+        size,
+        parents,
+        intoShadow,
+        specs,
+      }));
+  });
+
+interface BuiltTree {
+  root: HTMLElement;
+  nodes: HTMLElement[];
+  // Which shadow root (if any) the node was parented into. null means
+  // light-tree placement. Used by the dispatch-coverage assertion to
+  // decide which subset of nodes should be reachable through the
+  // watcher's payload.
+  parentShadows: Array<ShadowRoot | null>;
+}
+
+function buildTree(tree: FlatTree): BuiltTree {
+  const { size, parents, intoShadow, specs } = tree;
+  const nodes: HTMLElement[] = [];
+  const parentShadows: Array<ShadowRoot | null> = [];
+
+  for (let i = 0; i < size; i++) {
+    const element = document.createElement("div");
+    element.dataset.index = String(i);
+    nodes.push(element);
+    parentShadows.push(null);
+  }
+
+  // Attach shadows in pre-order so children can be placed into them.
+  for (let i = 0; i < size; i++) {
+    const mode = (specs[i] as NodeSpec).shadow;
+    if (mode !== null) {
+      nodes[i]?.attachShadow({ mode });
+    }
+  }
+
+  for (let i = 1; i < size; i++) {
+    const parentIndex = parents[i - 1];
+    if (parentIndex === undefined) {
+      continue;
+    }
+    const parent = nodes[parentIndex];
+    if (!parent) {
+      continue;
+    }
+    const placeInShadow = intoShadow[i - 1] === true && parent.shadowRoot;
+    if (placeInShadow) {
+      placeInShadow.append(nodes[i] as HTMLElement);
+      parentShadows[i] = placeInShadow;
+    } else {
+      parent.append(nodes[i] as HTMLElement);
+    }
+  }
+
+  const root = nodes[0];
+  if (!root) {
+    throw new Error("empty tree (size should be >= 1)");
+  }
+  return { root, nodes, parentShadows };
+}
+
+// -----------------------------------------------------------------------
+// Invariant 1: closed roots never enter the open-tracker
+// -----------------------------------------------------------------------
+
+describe("shadow-root tracker — closed-root isolation", () => {
+  it("getOpenShadowRoots only ever contains open roots, for any random tree", () => {
+    fc.assert(
+      fc.property(flatTreeArb, (tree) => {
+        document.body.innerHTML = "";
+        __resetShadowRootsForTesting();
+        const built = buildTree(tree);
+        document.body.append(built.root);
+
+        const tracked = getOpenShadowRoots();
+
+        // Every tracked root must be the .shadowRoot of *some* element
+        // in the tree (i.e. it was attached as "open" — the only kind
+        // exposed through that property).
+        const hostShadows = new Set<ShadowRoot>();
+        for (const node of built.nodes) {
+          if (node.shadowRoot) {
+            hostShadows.add(node.shadowRoot);
+          }
+        }
+        for (const root of tracked) {
+          expect(hostShadows.has(root)).toBe(true);
+        }
+
+        // Symmetric: every host that has a non-null .shadowRoot is open
+        // and should be tracked.
+        for (const node of built.nodes) {
+          if (node.shadowRoot) {
+            expect(tracked.has(node.shadowRoot)).toBe(true);
+          }
+        }
+      }),
+    );
+  });
+
+  it("the tracker size equals the number of nodes with open shadows", () => {
+    fc.assert(
+      fc.property(flatTreeArb, (tree) => {
+        document.body.innerHTML = "";
+        __resetShadowRootsForTesting();
+        const built = buildTree(tree);
+        document.body.append(built.root);
+
+        const openCount = tree.specs.filter(
+          (spec) => spec.shadow === "open",
+        ).length;
+        expect(getOpenShadowRoots().size).toBe(openCount);
+      }),
+    );
+  });
+});
+
+// -----------------------------------------------------------------------
+// Invariant 2: discoverShadowRootsIn set-idempotence under interleavings
+// -----------------------------------------------------------------------
+
+// Op shape (inferred from the generator):
+//   { kind: "attach", mode: "open" | "closed", hostIndex: number }
+//   { kind: "discover" }
+//
+// Hand-rolled chain: build a small pool of hosts first, then generate
+// a random ordered sequence of attach / discover operations against
+// them. fc's sized arbitraries don't naturally compose this shape,
+// and the explicit version reads more clearly than nested chains.
+const opSequenceArb = fc.integer({ min: 1, max: 8 }).chain((hostCount) =>
+  fc
+    .array(
+      fc.oneof(
+        fc.record({
+          kind: fc.constant<"attach">("attach"),
+          mode: fc.constantFrom<"open" | "closed">("open", "closed"),
+          hostIndex: fc.integer({ min: 0, max: hostCount - 1 }),
+        }),
+        fc.record({ kind: fc.constant<"discover">("discover") }),
+      ),
+      { minLength: 1, maxLength: 16 },
+    )
+    .map((ops) => ({ hostCount, ops })),
+);
+
+describe("discoverShadowRootsIn — set-idempotence", () => {
+  it("final registry equals the set of open roots, regardless of attach/discover order", () => {
+    fc.assert(
+      fc.property(opSequenceArb, ({ hostCount, ops }) => {
+        // Hard reset between iterations — fast-check runs the body
+        // many times in one `it`, and any host left behind in body
+        // would still be findable by a discoverShadowRootsIn call in
+        // a later iteration.
+        document.body.innerHTML = "";
+        __resetShadowRootsForTesting();
+        const hosts = Array.from({ length: hostCount }, () => {
+          const host = document.createElement("div");
+          document.body.append(host);
+          return host;
+        });
+        const attached = new Set<number>();
+        const expectedOpen = new Set<ShadowRoot>();
+
+        for (const op of ops) {
+          if (op.kind === "attach") {
+            const host = hosts[op.hostIndex];
+            // attachShadow throws if the host already has a shadow of
+            // either mode. Track attachment ourselves because
+            // host.shadowRoot is null for closed roots and would
+            // otherwise miss the second-call-on-closed case.
+            if (!host || attached.has(op.hostIndex)) {
+              continue;
+            }
+            attached.add(op.hostIndex);
+            const root = host.attachShadow({ mode: op.mode });
+            if (op.mode === "open") {
+              expectedOpen.add(root);
+            }
+          } else {
+            discoverShadowRootsIn(document.body);
+          }
+        }
+
+        // After any sequence, the registry should equal exactly the
+        // set of "attach open" results — discover calls don't add or
+        // remove anything that attachShadow didn't already register,
+        // and never accidentally add closed roots.
+        const tracked = new Set(getOpenShadowRoots());
+        expect(tracked).toEqual(expectedOpen);
+      }),
+    );
+  });
+
+  it("discovery rebuilds every open root reachable from body without crossing closed shadows", () => {
+    fc.assert(
+      fc.property(flatTreeArb, (tree) => {
+        document.body.innerHTML = "";
+        __resetShadowRootsForTesting();
+        const built = buildTree(tree);
+        document.body.append(built.root);
+
+        // Compute the expected reachable set by walking the document
+        // ourselves through light children and through open shadows
+        // only. Open shadows nested inside a closed shadow are
+        // deliberately unreachable — closed roots are dead-ends.
+        const reachable = new Set<ShadowRoot>();
+        const stack: Node[] = [document.body];
+        while (stack.length > 0) {
+          const node = stack.pop();
+          if (!node) {
+            continue;
+          }
+          if (node instanceof Element && node.shadowRoot) {
+            reachable.add(node.shadowRoot);
+            stack.push(node.shadowRoot);
+          }
+          for (const child of node.childNodes) {
+            stack.push(child);
+          }
+        }
+
+        // Simulate "attached before our content script loaded" — the
+        // hook never saw these. Re-discovery from body must recover
+        // exactly the reachable set.
+        __resetShadowRootsForTesting();
+        discoverShadowRootsIn(document.body);
+
+        expect(new Set(getOpenShadowRoots())).toEqual(reachable);
+      }),
+    );
+  });
+});
+
+// -----------------------------------------------------------------------
+// Invariant 3: dispatch coverage on randomized nested shadow forests
+// -----------------------------------------------------------------------
+
+// Walk one shadow tree (no crossing into nested shadows) and collect
+// every element. Used to compute the "should have been seen" set for
+// the coverage assertion.
+function elementsInTree(root: ParentNode): Set<Element> {
+  const out = new Set<Element>();
+  for (const element of root.querySelectorAll("*")) {
+    out.add(element);
+  }
+  return out;
+}
+
+describe("subtree watcher — shadow dispatch coverage", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // Every element that lives directly inside an *open* shadow root
+  // tracked by the dispatcher should be reachable through the
+  // subscriber payload — either as a dispatched root itself, or as a
+  // descendant of one (within the same shadow tree boundary, since
+  // querySelectorAll doesn't cross shadows). Elements inside closed
+  // shadows must NOT appear, even transitively.
+  it("covers every open-shadow element and excludes every closed-shadow element", async () => {
+    await fc.assert(
+      fc.asyncProperty(flatTreeArb, async (tree) => {
+        __resetShadowRootsForTesting();
+        __resetSubtreeWatcherForTesting();
+        document.body.innerHTML = "";
+        installShadowRootHook();
+
+        const built = buildTree(tree);
+        document.body.append(built.root);
+
+        // Compute coverage targets BEFORE starting the watcher so the
+        // assertion is about the dispatcher's discovery + observation,
+        // not about elements added later.
+        const openShadowElements = new Set<Element>();
+        const closedShadowElements = new Set<Element>();
+        for (const node of built.nodes) {
+          if (!node.shadowRoot) {
+            // Either no shadow, or a closed one — closed shadows are
+            // walked via the build-time parentShadows map below.
+            continue;
+          }
+          for (const element of elementsInTree(node.shadowRoot)) {
+            openShadowElements.add(element);
+          }
+        }
+        // Closed-shadow descendants aren't reachable through
+        // host.shadowRoot — that property is null for closed hosts by
+        // design. The builder's parentShadows map remembers where each
+        // child was placed: a child whose parent host has null
+        // .shadowRoot but whose parentShadows entry is non-null lives
+        // in a closed tree.
+        for (let i = 1; i < built.nodes.length; i++) {
+          const placed = built.parentShadows[i];
+          if (!placed) {
+            continue;
+          }
+          const hostIndex = tree.parents[i - 1] as number;
+          const host = built.nodes[hostIndex] as HTMLElement;
+          if (host.shadowRoot === null) {
+            // Host's shadow is closed.
+            closedShadowElements.add(built.nodes[i] as Element);
+          }
+        }
+
+        const onSubtrees = jest.fn();
+        const watcher = createSubtreeWatcher({ onSubtrees });
+        watcher.start(document.body);
+
+        await Promise.resolve();
+        jest.advanceTimersByTime(THROTTLE_MS);
+        await Promise.resolve();
+
+        const dispatched = new Set<Element>();
+        const calls = onSubtrees.mock.calls as Array<[Element[]]>;
+        for (const [roots] of calls) {
+          for (const root of roots) {
+            dispatched.add(root);
+            for (const descendant of root.querySelectorAll("*")) {
+              dispatched.add(descendant);
+            }
+          }
+        }
+
+        // Coverage: every open-shadow element is reachable from some
+        // dispatched root (the root itself or one of its descendants
+        // within the same shadow tree).
+        for (const element of openShadowElements) {
+          expect(dispatched.has(element)).toBe(true);
+        }
+
+        // Isolation: no closed-shadow element appears in the payload.
+        for (const element of closedShadowElements) {
+          expect(dispatched.has(element)).toBe(false);
+        }
+
+        watcher.stop();
+      }),
+      // Async properties are slower than sync ones; cap the runs to
+      // keep the suite snappy. 30 is plenty to find the obvious
+      // shapes; deeper fuzz would belong in a slower nightly run.
+      { numRuns: 30 },
+    );
+  });
+});

--- a/extension/src/lib/__tests__/shadow-roots.test.ts
+++ b/extension/src/lib/__tests__/shadow-roots.test.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Tests for the attachShadow patch and the discovery walk. The
+// subtree-watcher tests exercise the integration; this file pins down
+// the tracker's contract in isolation.
+
+import {
+  __resetShadowRootsForTesting,
+  discoverShadowRootsIn,
+  getOpenShadowRoots,
+  installShadowRootHook,
+  subscribeShadowRootAttached,
+} from "../shadow-roots";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  __resetShadowRootsForTesting();
+  installShadowRootHook();
+});
+
+afterEach(() => {
+  __resetShadowRootsForTesting();
+});
+
+describe("installShadowRootHook", () => {
+  it("registers open shadow roots created after the hook is installed", () => {
+    const host = document.createElement("div");
+    const root = host.attachShadow({ mode: "open" });
+    expect(getOpenShadowRoots().has(root)).toBe(true);
+  });
+
+  it("does not register closed shadow roots", () => {
+    const host = document.createElement("div");
+    host.attachShadow({ mode: "closed" });
+    // Closed roots are opt-out by design — host.shadowRoot is null and
+    // the tracker should respect that boundary.
+    expect(getOpenShadowRoots().size).toBe(0);
+  });
+
+  it("is idempotent — calling install twice does not stack the patch", () => {
+    installShadowRootHook();
+    installShadowRootHook();
+
+    const host = document.createElement("div");
+    host.attachShadow({ mode: "open" });
+
+    // If the patch had stacked, each attachShadow would have fired the
+    // listener once per layer.
+    expect(getOpenShadowRoots().size).toBe(1);
+  });
+
+  it("notifies subscribers when a new open shadow root attaches", () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeShadowRootAttached(listener);
+
+    const host = document.createElement("div");
+    const root = host.attachShadow({ mode: "open" });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(root);
+    unsubscribe();
+  });
+
+  it("does not notify subscribers for closed roots", () => {
+    const listener = jest.fn();
+    subscribeShadowRootAttached(listener);
+
+    const host = document.createElement("div");
+    host.attachShadow({ mode: "closed" });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeShadowRootAttached(listener);
+    unsubscribe();
+
+    const host = document.createElement("div");
+    host.attachShadow({ mode: "open" });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("discoverShadowRootsIn", () => {
+  it("returns open shadow roots reachable from the given subtree", () => {
+    const host = document.createElement("div");
+    const root = host.attachShadow({ mode: "open" });
+    document.body.append(host);
+
+    expect(discoverShadowRootsIn(document.body)).toContain(root);
+  });
+
+  it("recurses into nested shadow roots", () => {
+    const outer = document.createElement("div");
+    const outerRoot = outer.attachShadow({ mode: "open" });
+    const middle = document.createElement("section");
+    const middleRoot = middle.attachShadow({ mode: "open" });
+    const inner = document.createElement("article");
+    const innerRoot = inner.attachShadow({ mode: "open" });
+    middleRoot.append(inner);
+    outerRoot.append(middle);
+    document.body.append(outer);
+
+    const found = discoverShadowRootsIn(document.body);
+    expect(found).toContain(outerRoot);
+    expect(found).toContain(middleRoot);
+    expect(found).toContain(innerRoot);
+  });
+
+  it("skips closed shadow roots", () => {
+    const open = document.createElement("div");
+    const openRoot = open.attachShadow({ mode: "open" });
+    const closed = document.createElement("div");
+    closed.attachShadow({ mode: "closed" });
+    document.body.append(open, closed);
+
+    const found = discoverShadowRootsIn(document.body);
+    expect(found).toContain(openRoot);
+    expect(found).toHaveLength(1);
+  });
+
+  it("registers roots discovered on the walk so subscribers fire later", () => {
+    const host = document.createElement("div");
+    const root = host.attachShadow({ mode: "open" });
+    document.body.append(host);
+
+    // Simulate the "attached before our hook was installed" case by
+    // clearing the registry after attach. discoverShadowRootsIn is the
+    // bootstrap that rescues the root.
+    __resetShadowRootsForTesting();
+    expect(getOpenShadowRoots().size).toBe(0);
+
+    discoverShadowRootsIn(document.body);
+
+    expect(getOpenShadowRoots().has(root)).toBe(true);
+  });
+});

--- a/extension/src/lib/__tests__/subtree-watcher.test.ts
+++ b/extension/src/lib/__tests__/subtree-watcher.test.ts
@@ -11,6 +11,10 @@
 import { PLACEHOLDER_CLASS } from "../placeholder";
 import { __resetRouteChangeForTesting } from "../route-change";
 import {
+  __resetShadowRootsForTesting,
+  installShadowRootHook,
+} from "../shadow-roots";
+import {
   __resetSubtreeWatcherForTesting,
   createSubtreeWatcher,
 } from "../subtree-watcher";
@@ -26,6 +30,11 @@ beforeEach(() => {
   jest.useFakeTimers();
   __resetRouteChangeForTesting();
   __resetSubtreeWatcherForTesting();
+  __resetShadowRootsForTesting();
+  // The attachShadow patch itself is idempotent and persists across tests,
+  // but installing it inside beforeEach lets tests that exercise shadow
+  // behavior run regardless of whether content.ts has been imported.
+  installShadowRootHook();
   history.replaceState(null, "", "/initial");
 });
 
@@ -38,6 +47,7 @@ afterEach(() => {
   });
   __resetRouteChangeForTesting();
   __resetSubtreeWatcherForTesting();
+  __resetShadowRootsForTesting();
 });
 
 describe("createSubtreeWatcher", () => {
@@ -1220,6 +1230,273 @@ describe("createSubtreeWatcher", () => {
 
       expect(onSubtrees).not.toHaveBeenCalled();
       watcher.stop();
+    });
+  });
+
+  describe("shadow DOM", () => {
+    it("dispatches existing open-shadow children when the watcher starts", async () => {
+      // Page script attaches a shadow root and populates it before our
+      // content script (and therefore the watcher) starts — the
+      // discovery walk at startRouter time should pick the contents up.
+      const host = document.createElement("div");
+      host.id = "host";
+      const shadow = host.attachShadow({ mode: "open" });
+      const inner = document.createElement("section");
+      inner.id = "in-shadow";
+      shadow.append(inner);
+      document.body.append(host);
+
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      const [roots] = onSubtrees.mock.calls[0] as [Element[]];
+      expect(roots).toContain(inner);
+      watcher.stop();
+    });
+
+    it("does not look into closed shadow roots", async () => {
+      // Closed shadow roots are opt-out by design — the host's
+      // .shadowRoot property is null to external code, and we
+      // deliberately don't register them in the tracker.
+      const host = document.createElement("div");
+      const shadow = host.attachShadow({ mode: "closed" });
+      const inner = document.createElement("section");
+      inner.id = "in-closed-shadow";
+      shadow.append(inner);
+      document.body.append(host);
+
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      // host itself wasn't observed as an addition (watcher started
+      // after the host was already in the body), and the closed shadow
+      // is invisible — no subtree should surface.
+      expect(onSubtrees).not.toHaveBeenCalled();
+      watcher.stop();
+    });
+
+    it("observes mutations inside open shadow roots after start", async () => {
+      const host = document.createElement("div");
+      const shadow = host.attachShadow({ mode: "open" });
+      document.body.append(host);
+
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      // Flush the empty-shadow bootstrap so the mutation below is the
+      // only thing the next drain will surface.
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      onSubtrees.mockClear();
+
+      const inner = document.createElement("article");
+      shadow.append(inner);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      const [roots] = onSubtrees.mock.calls[0] as [Element[]];
+      expect(roots).toContain(inner);
+      watcher.stop();
+    });
+
+    it("observes shadow roots attached AFTER the watcher started", async () => {
+      // Custom elements often call attachShadow inside connectedCallback,
+      // which fires after the host is in the DOM. The patched
+      // attachShadow notifies the router so the new root is observed.
+      const host = document.createElement("div");
+      document.body.append(host);
+
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      onSubtrees.mockClear();
+
+      const shadow = host.attachShadow({ mode: "open" });
+      const inner = document.createElement("section");
+      shadow.append(inner);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      const [roots] = onSubtrees.mock.calls[0] as [Element[]];
+      expect(roots).toContain(inner);
+      watcher.stop();
+    });
+
+    it("dispatches a pre-populated shadow on a freshly inserted host", async () => {
+      // Web components built in a constructor or upgrade callback ship
+      // their shadow tree at insertion time. Discovery during the host's
+      // light-tree dispatch catches the shadow contents in the same
+      // drain — without it, those would be silently missed.
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      const host = document.createElement("div");
+      const shadow = host.attachShadow({ mode: "open" });
+      const inner = document.createElement("section");
+      inner.id = "lazy-shadow";
+      shadow.append(inner);
+
+      // attachShadow + populate happened before the host was connected;
+      // dispatch should surface both the host (light) and the shadow
+      // child when the host is appended.
+      document.body.append(host);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      const [roots] = onSubtrees.mock.calls[0] as [Element[]];
+      expect(roots).toContain(host);
+      expect(roots).toContain(inner);
+      watcher.stop();
+    });
+
+    it("recurses through nested shadow roots", async () => {
+      const outerHost = document.createElement("div");
+      const outerShadow = outerHost.attachShadow({ mode: "open" });
+      const innerHost = document.createElement("section");
+      const innerShadow = innerHost.attachShadow({ mode: "open" });
+      const leaf = document.createElement("article");
+      leaf.id = "deep";
+      innerShadow.append(leaf);
+      outerShadow.append(innerHost);
+      document.body.append(outerHost);
+
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      const allRoots = (onSubtrees.mock.calls as Array<[Element[]]>).flatMap(
+        (call) => call[0],
+      );
+      expect(allRoots).toContain(innerHost);
+      expect(allRoots).toContain(leaf);
+      watcher.stop();
+    });
+
+    it("seeds a late-joining subscriber from existing shadow content", async () => {
+      const host = document.createElement("div");
+      const shadow = host.attachShadow({ mode: "open" });
+      const inner = document.createElement("section");
+      shadow.append(inner);
+      document.body.append(host);
+
+      const firstOnSubtrees = jest.fn();
+      const first = createSubtreeWatcher({ onSubtrees: firstOnSubtrees });
+      first.start(document.body);
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      // Second subscriber joins after the router has already adopted the
+      // shadow root. It should still receive the existing children.
+      const secondOnSubtrees = jest.fn();
+      const second = createSubtreeWatcher({ onSubtrees: secondOnSubtrees });
+      second.start(document.body);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(secondOnSubtrees).toHaveBeenCalledTimes(1);
+      const [roots] = secondOnSubtrees.mock.calls[0] as [Element[]];
+      expect(roots).toContain(inner);
+      first.stop();
+      second.stop();
+    });
+
+    it("respects skipPlaceholderSubtrees inside shadow roots", async () => {
+      // A rule that injected a placeholder into a shadow tree shouldn't
+      // re-trigger itself on the next sweep.
+      const host = document.createElement("div");
+      const shadow = host.attachShadow({ mode: "open" });
+      const placeholder = document.createElement("div");
+      placeholder.classList.add(PLACEHOLDER_CLASS);
+      shadow.append(placeholder);
+      document.body.append(host);
+
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({
+        onSubtrees,
+        skipPlaceholderSubtrees: true,
+      });
+      watcher.start(document.body);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).not.toHaveBeenCalled();
+      watcher.stop();
+    });
+
+    it("does not adopt shadows attached to nodes outside the router target", async () => {
+      // A router targeting document.head shouldn't end up observing a
+      // shadow whose host lives in document.body. Two routers run side
+      // by side so we can confirm only the body-rooted one fires.
+      const bodyOnSubtrees = jest.fn();
+      const headOnSubtrees = jest.fn();
+      const bodyWatcher = createSubtreeWatcher({ onSubtrees: bodyOnSubtrees });
+      const headWatcher = createSubtreeWatcher({ onSubtrees: headOnSubtrees });
+      bodyWatcher.start(document.body);
+      headWatcher.start(document.head);
+
+      const host = document.createElement("div");
+      const shadow = host.attachShadow({ mode: "open" });
+      const inner = document.createElement("section");
+      shadow.append(inner);
+      document.body.append(host);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      const bodyRoots = (
+        bodyOnSubtrees.mock.calls as Array<[Element[]]>
+      ).flatMap((call) => call[0]);
+      expect(bodyRoots).toContain(inner);
+      expect(headOnSubtrees).not.toHaveBeenCalled();
+
+      bodyWatcher.stop();
+      headWatcher.stop();
+    });
+
+    it("stops observing shadow roots after the watcher stops", async () => {
+      const host = document.createElement("div");
+      const shadow = host.attachShadow({ mode: "open" });
+      document.body.append(host);
+
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      watcher.stop();
+      onSubtrees.mockClear();
+
+      shadow.append(document.createElement("article"));
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).not.toHaveBeenCalled();
     });
   });
 });

--- a/extension/src/lib/__tests__/subtree-watcher.test.ts
+++ b/extension/src/lib/__tests__/subtree-watcher.test.ts
@@ -1498,5 +1498,84 @@ describe("createSubtreeWatcher", () => {
 
       expect(onSubtrees).not.toHaveBeenCalled();
     });
+
+    it("disconnects shadow observers when the tab goes hidden", async () => {
+      // Regression for unblocked review: handleVisibilityChange used
+      // to only disconnect the main observer, leaving per-shadow
+      // observers firing fanOut callbacks in background tabs and
+      // defeating the optimization.
+      function setHidden(hidden: boolean): void {
+        Object.defineProperty(document, "hidden", {
+          configurable: true,
+          value: hidden,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      }
+
+      const host = document.createElement("div");
+      const shadow = host.attachShadow({ mode: "open" });
+      document.body.append(host);
+
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+      onSubtrees.mockClear();
+
+      setHidden(true);
+
+      shadow.append(document.createElement("article"));
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      expect(onSubtrees).not.toHaveBeenCalled();
+      watcher.stop();
+    });
+
+    it("re-observes each shadow root on its own target after refreshObservation", async () => {
+      // Regression for unblocked review: refreshObservation iterated
+      // shadowObservers.values() and re-observed each one on
+      // router.target, which (per the DOM spec) appends a second
+      // registration on body without removing the shadow-root one.
+      // After visibility restore, body mutations would double-fire
+      // through fanOut. Assert exactly one dispatch per body
+      // addition.
+      function setHidden(hidden: boolean): void {
+        Object.defineProperty(document, "hidden", {
+          configurable: true,
+          value: hidden,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      }
+
+      const host = document.createElement("div");
+      host.attachShadow({ mode: "open" });
+      document.body.append(host);
+
+      const onSubtrees = jest.fn();
+      const watcher = createSubtreeWatcher({ onSubtrees });
+      watcher.start(document.body);
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      setHidden(true);
+      setHidden(false);
+      onSubtrees.mockClear();
+
+      const added = document.createElement("section");
+      document.body.append(added);
+
+      await flushMutations();
+      jest.advanceTimersByTime(THROTTLE_MS);
+
+      // One drain, one root — not two copies (which is what a
+      // double-registration on body would have produced via the
+      // shadow observer also firing for body mutations).
+      expect(onSubtrees).toHaveBeenCalledTimes(1);
+      const [roots] = onSubtrees.mock.calls[0] as [Element[]];
+      expect(roots.filter((r) => r === added)).toHaveLength(1);
+      watcher.stop();
+    });
   });
 });

--- a/extension/src/lib/shadow-roots.ts
+++ b/extension/src/lib/shadow-roots.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Track open shadow roots so the subtree watcher and token-index dispatcher
+// can scan into them. Without this hook the rule pipeline is light-DOM only:
+// MutationObserver does not cross shadow boundaries, querySelectorAll stops
+// at the host, and document stylesheets don't apply inside shadow trees.
+//
+// Closed shadow roots ({mode: "closed"}) are deliberately not tracked. They
+// are opt-out of external access by design; observing them would be hostile
+// to widget authors who rely on the encapsulation contract. The patched
+// attachShadow still returns the closed root to the caller untouched — we
+// just don't add it to our registry.
+//
+// Content scripts run at document_idle, so any shadow attachments made during
+// page parsing have already happened by the time we install the hook. Callers
+// pair `installShadowRootHook()` with `discoverShadowRootsIn(document.body)`
+// at startup to catch those.
+
+const HOOK_INSTALLED = Symbol.for("abs.shadowRootHookInstalled");
+
+const openShadowRoots = new Set<ShadowRoot>();
+const attachListeners = new Set<(root: ShadowRoot) => void>();
+
+export function installShadowRootHook(): void {
+  // One patch per realm. Idempotent so a subframe re-import or test re-run
+  // doesn't stack patches on top of each other.
+  const flagHolder = globalThis as unknown as Record<symbol, unknown>;
+  if (flagHolder[HOOK_INSTALLED]) {
+    return;
+  }
+  flagHolder[HOOK_INSTALLED] = true;
+
+  // The bound method we replace is invoked as `this.attachShadow(init)` by
+  // page scripts, so `this` lands on the host element naturally — the lint
+  // warning about unbound-method binding doesn't apply to our trampoline.
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const original = Element.prototype.attachShadow;
+  Element.prototype.attachShadow = function patched(
+    this: Element,
+    init: ShadowRootInit,
+  ): ShadowRoot {
+    const root = original.call(this, init);
+    if (init.mode === "open") {
+      registerShadowRoot(root);
+    }
+    return root;
+  };
+}
+
+function registerShadowRoot(root: ShadowRoot): void {
+  if (openShadowRoots.has(root)) {
+    return;
+  }
+  openShadowRoots.add(root);
+  for (const listener of attachListeners) {
+    listener(root);
+  }
+}
+
+// Walk a subtree (descending through any nested shadow roots) and register
+// every open shadow root found. Used at watcher startup to capture roots
+// attached before installShadowRootHook ran — and again whenever a host with
+// a pre-populated shadow tree is inserted into the document.
+//
+// Returns every shadow root discovered on this call, regardless of whether
+// it was already registered, so callers can attach observers without
+// re-querying the registry.
+export function discoverShadowRootsIn(root: Node): ShadowRoot[] {
+  const discovered: ShadowRoot[] = [];
+  const stack: Node[] = [root];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) {
+      continue;
+    }
+    if (node instanceof Element && node.shadowRoot) {
+      // shadowRoot is null for closed roots, so the open-only filter is
+      // implicit.
+      registerShadowRoot(node.shadowRoot);
+      discovered.push(node.shadowRoot);
+      stack.push(node.shadowRoot);
+    }
+    for (const child of node.childNodes) {
+      stack.push(child);
+    }
+  }
+  return discovered;
+}
+
+export function getOpenShadowRoots(): ReadonlySet<ShadowRoot> {
+  return openShadowRoots;
+}
+
+export function subscribeShadowRootAttached(
+  listener: (root: ShadowRoot) => void,
+): () => void {
+  attachListeners.add(listener);
+  return () => {
+    attachListeners.delete(listener);
+  };
+}
+
+// Test-only: clear the registry and any subscribers. The attachShadow patch
+// itself stays installed (re-patching across tests is unnecessary), but the
+// state it builds up is reset so cases don't leak shadow roots into each
+// other.
+export function __resetShadowRootsForTesting(): void {
+  openShadowRoots.clear();
+  attachListeners.clear();
+}

--- a/extension/src/lib/subtree-watcher.ts
+++ b/extension/src/lib/subtree-watcher.ts
@@ -18,6 +18,10 @@
 import throttle from "lodash/throttle";
 import { PLACEHOLDER_CLASS } from "./placeholder";
 import { subscribeRouteChange } from "./route-change";
+import {
+  discoverShadowRootsIn,
+  subscribeShadowRootAttached,
+} from "./shadow-roots";
 
 // Tags whose insertion is never interesting to any rule. Filtering at enqueue
 // keeps `pending` small during noisy bursts where a framework injects
@@ -83,6 +87,14 @@ interface Router {
   visibilityListener: (() => void) | null;
   unsubscribeRouteChange: (() => void) | null;
   routeSweepHandle: number | null;
+  // Per-router map of observed shadow roots. Each shadow root gets its
+  // own MutationObserver because MO does not cross shadow boundaries —
+  // an observer on document.body misses every mutation inside a shadow
+  // tree even with subtree:true. Mutations fan into the same `fanOut`
+  // callback so subscribers don't know or care which tree a record
+  // came from.
+  shadowObservers: Map<ShadowRoot, MutationObserver>;
+  unsubscribeShadowAttach: (() => void) | null;
 }
 
 // One router per observed root. document.body is the common case; the head
@@ -177,16 +189,15 @@ function fanOut(router: Router, mutations: MutationRecord[]): void {
       if (!element.isConnected) {
         continue;
       }
-      for (const subscriber of router.subscribers) {
-        if (subscriber.skipPlaceholderSubtrees) {
-          if (element.classList.contains(PLACEHOLDER_CLASS)) {
-            continue;
-          }
-          if (element.closest(`.${PLACEHOLDER_CLASS}`)) {
-            continue;
-          }
-        }
-        subscriber.pending.add(element);
+      enqueueForAllSubscribers(router, element);
+      // A freshly-inserted host element may already have a populated
+      // open shadow root (custom elements that build their shadow in
+      // the constructor, lit/stencil components, etc.). adoptShadowRoot
+      // observes the root and dispatches its initial children — without
+      // this, mutation observation would only catch FUTURE additions
+      // into the shadow, never the content present at insertion time.
+      for (const shadow of discoverShadowRootsIn(element)) {
+        adoptShadowRoot(router, shadow);
       }
     }
   }
@@ -228,6 +239,124 @@ function refreshObservation(router: Router): void {
   // observe() on an already-observed MO replaces the existing options
   // without re-emitting historical records.
   router.observer.observe(router.target, observerInit(router));
+  // Same options apply to each shadow-root observer — keep them in sync
+  // when the router's observingAttributes flag toggles.
+  for (const observer of router.shadowObservers.values()) {
+    observer.observe(router.target, observerInit(router));
+  }
+}
+
+// Add `element` to every subscriber's pending set, respecting each
+// subscriber's per-subscriber filters (skipPlaceholderSubtrees). The
+// shared filters (IGNORE_TAGS, isConnected) are applied by the caller.
+function enqueueForAllSubscribers(router: Router, element: Element): void {
+  for (const subscriber of router.subscribers) {
+    if (subscriber.skipPlaceholderSubtrees) {
+      if (element.classList.contains(PLACEHOLDER_CLASS)) {
+        continue;
+      }
+      if (element.closest(`.${PLACEHOLDER_CLASS}`)) {
+        continue;
+      }
+    }
+    subscriber.pending.add(element);
+  }
+}
+
+// Add a shadow root's existing element children (and any nested shadow
+// roots within them) to every subscriber's pending set, observe the
+// shadow root for future mutations, and trigger drains. Called both at
+// router startup (for shadow roots discovered on `target`) and at runtime
+// (for shadows on hosts inserted later, or attached via the
+// attachShadow hook).
+function adoptShadowRoot(router: Router, shadowRoot: ShadowRoot): void {
+  if (router.shadowObservers.has(shadowRoot)) {
+    return;
+  }
+  // Each shadow root gets its own MO. MO can target multiple nodes via
+  // separate `observe()` calls, but one-observer-per-root keeps
+  // disconnect bookkeeping straightforward.
+  const observer = new MutationObserver((mutations) => {
+    fanOut(router, mutations);
+  });
+  router.shadowObservers.set(shadowRoot, observer);
+  if (!document.hidden) {
+    observer.observe(shadowRoot, observerInit(router));
+  }
+
+  // Pre-existing shadow content (the common case when a host attached
+  // its shadow before our content script loaded) is dispatched as if it
+  // had just been inserted — push each element child into pending and
+  // recurse into any nested shadow roots.
+  for (const child of shadowRoot.childNodes) {
+    if (child.nodeType !== Node.ELEMENT_NODE) {
+      continue;
+    }
+    const element = child as Element;
+    if (IGNORE_TAGS.has(element.tagName)) {
+      continue;
+    }
+    if (!element.isConnected) {
+      continue;
+    }
+    enqueueForAllSubscribers(router, element);
+    // A pre-populated shadow may itself contain hosts with shadows.
+    for (const nested of discoverShadowRootsIn(element)) {
+      adoptShadowRoot(router, nested);
+    }
+  }
+
+  for (const subscriber of router.subscribers) {
+    if (subscriber.pending.size > 0) {
+      subscriber.throttledScan();
+    }
+  }
+}
+
+// Seed a single subscriber's pending set from one shadow root's element
+// children. Used when a subscriber joins a running router and needs to
+// be brought up to the same starting state as subscribers that were
+// present when the shadow root was first adopted.
+function seedSubscriberFromShadowRoot(
+  subscriber: Subscriber,
+  shadowRoot: ShadowRoot,
+): void {
+  for (const child of shadowRoot.childNodes) {
+    if (child.nodeType !== Node.ELEMENT_NODE) {
+      continue;
+    }
+    const element = child as Element;
+    if (IGNORE_TAGS.has(element.tagName)) {
+      continue;
+    }
+    if (!element.isConnected) {
+      continue;
+    }
+    if (subscriber.skipPlaceholderSubtrees) {
+      if (element.classList.contains(PLACEHOLDER_CLASS)) {
+        continue;
+      }
+      if (element.closest(`.${PLACEHOLDER_CLASS}`)) {
+        continue;
+      }
+    }
+    subscriber.pending.add(element);
+  }
+}
+
+function isUnderRouterTarget(router: Router, node: Node): boolean {
+  // The router's target is document.body for the main router and
+  // document.head for meta-injection-strip's secondary one. A shadow
+  // root's host can live in either tree (or in neither, if the host
+  // is detached). Filter so the head router doesn't pick up shadows
+  // attached to body-tree hosts.
+  if (router.target === document) {
+    return node.isConnected;
+  }
+  if (!(router.target instanceof Node)) {
+    return false;
+  }
+  return router.target.contains(node);
 }
 
 function handleVisibilityChange(router: Router): void {
@@ -301,11 +430,37 @@ function startRouter(router: Router): void {
   router.unsubscribeRouteChange = subscribeRouteChange(() => {
     handleRouteChange(router);
   });
+
+  // Discover any open shadow roots that already live under this router's
+  // target — page scripts that ran before document_idle and built their
+  // shadow trees during parsing produce these. adoptShadowRoot observes
+  // each and dispatches its existing children to subscribers.
+  for (const shadow of discoverShadowRootsIn(router.target)) {
+    adoptShadowRoot(router, shadow);
+  }
+  // Future attachShadow calls land here; we observe the new root if its
+  // host lives under our target. Routers that target document.head can
+  // skip body-tree shadows and vice versa.
+  router.unsubscribeShadowAttach = subscribeShadowRootAttached((shadow) => {
+    if (!router.observer) {
+      return;
+    }
+    if (!isUnderRouterTarget(router, shadow.host)) {
+      return;
+    }
+    adoptShadowRoot(router, shadow);
+  });
 }
 
 function stopRouter(router: Router): void {
   router.observer?.disconnect();
   router.observer = null;
+  for (const observer of router.shadowObservers.values()) {
+    observer.disconnect();
+  }
+  router.shadowObservers.clear();
+  router.unsubscribeShadowAttach?.();
+  router.unsubscribeShadowAttach = null;
   if (router.visibilityListener) {
     document.removeEventListener("visibilitychange", router.visibilityListener);
     router.visibilityListener = null;
@@ -330,6 +485,8 @@ function getOrCreateRouter(target: Node): Router {
       visibilityListener: null,
       unsubscribeRouteChange: null,
       routeSweepHandle: null,
+      shadowObservers: new Map(),
+      unsubscribeShadowAttach: null,
     };
     routersByTarget.set(target, router);
   }
@@ -385,11 +542,24 @@ export function createSubtreeWatcher(
       }
       if (router.observer === null) {
         startRouter(router);
-      } else if (needsAttributeUpgrade) {
-        // Re-observe with the upgraded options. Calling observe() on an
-        // already-active MO with the same target merges configurations
-        // without re-emitting historical mutations.
-        refreshObservation(router);
+      } else {
+        // A late subscriber joining a running router missed the initial
+        // shadow-root bootstrap that startRouter ran when the first
+        // subscriber arrived. Seed this subscriber's pending with every
+        // known shadow root's current children so it sees the same
+        // starting state as the originals.
+        for (const shadow of router.shadowObservers.keys()) {
+          seedSubscriberFromShadowRoot(ownSubscriber, shadow);
+        }
+        if (ownSubscriber.pending.size > 0) {
+          ownSubscriber.throttledScan();
+        }
+        if (needsAttributeUpgrade) {
+          // Re-observe with the upgraded options. Calling observe() on an
+          // already-active MO with the same target merges configurations
+          // without re-emitting historical mutations.
+          refreshObservation(router);
+        }
       }
     },
     stop(): void {
@@ -425,6 +595,10 @@ export function createSubtreeWatcher(
 export function __resetSubtreeWatcherForTesting(): void {
   for (const router of routersByTarget.values()) {
     router.observer?.disconnect();
+    for (const observer of router.shadowObservers.values()) {
+      observer.disconnect();
+    }
+    router.unsubscribeShadowAttach?.();
     if (router.visibilityListener) {
       document.removeEventListener(
         "visibilitychange",

--- a/extension/src/lib/subtree-watcher.ts
+++ b/extension/src/lib/subtree-watcher.ts
@@ -240,9 +240,14 @@ function refreshObservation(router: Router): void {
   // without re-emitting historical records.
   router.observer.observe(router.target, observerInit(router));
   // Same options apply to each shadow-root observer — keep them in sync
-  // when the router's observingAttributes flag toggles.
-  for (const observer of router.shadowObservers.values()) {
-    observer.observe(router.target, observerInit(router));
+  // when the router's observingAttributes flag toggles. Each observer
+  // must re-observe its OWN shadow root: per the DOM spec, observe()
+  // with a different target appends a new registration on that target
+  // rather than replacing the original, so passing router.target here
+  // would leave the shadow observer double-watching body alongside its
+  // shadow root (silently doubling every body mutation through fanOut).
+  for (const [shadowRoot, observer] of router.shadowObservers) {
+    observer.observe(shadowRoot, observerInit(router));
   }
 }
 
@@ -364,11 +369,16 @@ function handleVisibilityChange(router: Router): void {
     // Flush whatever's pending so we don't sit on a stale snapshot until
     // the user returns, then stop receiving mutations. Background tabs
     // keep firing observer callbacks; disconnecting is the cheap way to
-    // opt out for the duration.
+    // opt out for the duration. Shadow observers need the same
+    // treatment — they have their own MO instances and would otherwise
+    // keep delivering mutations in the background.
     for (const subscriber of router.subscribers) {
       subscriber.throttledScan.flush();
     }
     router.observer?.disconnect();
+    for (const observer of router.shadowObservers.values()) {
+      observer.disconnect();
+    }
   } else if (router.observer) {
     refreshObservation(router);
   }


### PR DESCRIPTION
## Summary

- Patches `Element.prototype.attachShadow` so the shared subtree watcher observes open shadow roots alongside `document.body`, fanning their mutations and existing children into the same subscriber pipeline.
- No rule-code changes — every `createSubtreeWatcher` / `createSelectorHideRule` rule now reaches content rendered inside open shadow trees.
- Adds a `ShadowDomEmbed` to the demo home page that mounts a chat-widget marker and an `ins.adsbygoogle` block inside an open shadow root so reviewers can confirm the dispatcher actually reaches them.

Closes #164 Tier 1. Closed shadow roots stay opaque by design. Text-walk rules (`pii-redact`, `prompt-injection-redact`, etc.) are the separate Tier 2 fix tracked in the same issue.

## What changed

- `extension/src/lib/shadow-roots.ts` (new) — open-only `attachShadow` patch + a `discoverShadowRootsIn` walk for roots attached before `document_idle`. Closed roots are explicitly skipped.
- `extension/src/lib/subtree-watcher.ts` — each router now owns a per-shadow-root `MutationObserver`, subscribes to attach events, and seeds subscribers' pending sets from existing shadow children. `fanOut` also discovers shadows on freshly inserted hosts so pre-populated web components aren't missed at the same drain that surfaces the host.
- `extension/src/content.ts` — installs the hook at script entry.
- Tests:
  - `shadow-roots.test.ts` (new) — unit tests for the hook + discovery contract.
  - `subtree-watcher.test.ts` — added a `describe("shadow DOM", …)` block covering pre-existing shadow content, post-start attachments, mutations inside shadows, nested shadow roots, late-joining subscribers, the placeholder skip, head-vs-body router isolation, and closed-shadow opacity.
  - `shadow-roots.property.test.ts` (new) — fast-check property tests for three invariants that fuzz better than they assert:
    - closed shadow roots never enter the open-tracker, for any random tree shape;
    - `discoverShadowRootsIn` is set-idempotent under any interleaving of attach/discover ops, and after a registry reset rebuilds exactly the set of open roots reachable without crossing closed boundaries;
    - the subtree watcher's dispatch payload covers every open-shadow element and excludes every closed-shadow element, across nested forests.
- `demo-site/src/components/ShadowDomEmbed.tsx` (new) + a one-line `Home.tsx` wiring.

## Test plan

- [x] `bun jest` — 1314 / 1314 pass (including the 5 new property tests).
- [x] `bun run check` — biome + eslint clean (extension + demo-site).
- [x] `bun run build` — both the extension and the demo bundle build clean.
- [ ] Manual: load the unpacked extension, open the demo home page, confirm the chat launcher and sponsored block inside the shadow root are hidden / replaced with placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)