### PR TITLE
Feat: shadow-piercing text walkers (#164 Tier 2)

### DIFF
--- a/demo-site/src/components/ShadowDomEmbed.tsx
+++ b/demo-site/src/components/ShadowDomEmbed.tsx
@@ -2,6 +2,7 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import { useEffect, useRef } from "react";
+import { INJECTIONS } from "../data/injection-fixtures";
 
 // Mounts third-party-style widget markup INSIDE an open shadow root so
 // reviewers can confirm the extension's rules see past the shadow
@@ -13,7 +14,11 @@ import { useEffect, useRef } from "react";
 // matching rules already target in the light tree (`#intercom-frame`,
 // `ins.adsbygoogle`) so the demo doesn't depend on any per-shadow
 // special-casing in the rules themselves — only on the dispatcher
-// actually reaching the content.
+// actually reaching the content. The injection paragraph at the bottom
+// exercises the Tier 2 shadow-piercing text walker
+// (`prompt-injection-redact` / `pii-redact` / `secrets-redact`): a
+// reachable instruction-shaped block that a light-DOM-only walker
+// would have missed entirely.
 
 export default function ShadowDomEmbed() {
   const hostRef = useRef<HTMLDivElement>(null);
@@ -47,6 +52,18 @@ export default function ShadowDomEmbed() {
     ad.textContent = "Sponsored — limited-time offer from a partner brand";
     shadow.append(ad);
 
+    // Injection-shaped paragraph for the text-walk rules. The fixture
+    // is reused from the product detail page so we don't ship a new
+    // plaintext payload in source — the existing base64 encoding in
+    // `injection-fixtures.ts` is the convention. Wrapped in a <p>
+    // because `prompt-injection-redact` looks for a block-level
+    // ancestor (`p, li, blockquote, …`) to scope the placeholder.
+    const injection = document.createElement("p");
+    injection.style.cssText =
+      "margin:8px 0 0;padding:6px 10px;border:1px solid #b91c1c;background:#fef2f2;color:#7f1d1d;font:13px system-ui;";
+    injection.textContent = INJECTIONS.PRODUCT_DETAIL_HIDDEN_SYSTEM;
+    shadow.append(injection);
+
     return () => {
       // React StrictMode runs effects twice in dev. Leaving the shadow
       // root behind on unmount would let it accumulate across reloads;
@@ -66,12 +83,12 @@ export default function ShadowDomEmbed() {
         Third-party widgets mounted inside an open shadow root
       </h2>
       <p className="mt-2 text-sm text-stone-700">
-        The two items below are appended into <code>this.attachShadow()</code> —
-        the same way modern chat, consent, and ad SDKs ship their UI to keep
-        their styles isolated from the host page. Without the shadow-aware
-        subtree watcher the extension's rules would walk right past them; with
-        it, the chat launcher should be removed and the sponsored block
-        replaced.
+        The items below are appended into <code>this.attachShadow()</code> — the
+        same way modern chat, consent, and ad SDKs ship their UI to keep their
+        styles isolated from the host page. With shadow-aware rules enabled, the
+        chat launcher should be removed, the sponsored block replaced, and the
+        prompt-injection paragraph hidden behind a reveal placeholder. Without
+        shadow piercing every item would survive untouched.
       </p>
       <div
         ref={hostRef}

--- a/extension/src/lib/__tests__/text-walk-shadow.property.test.ts
+++ b/extension/src/lib/__tests__/text-walk-shadow.property.test.ts
@@ -1,0 +1,437 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Property tests for the shadow-piercing extension of walkTextNodes /
+// collectTextNodesShadowPiercing / visibleTextContent / the chunked
+// walker. Three invariants:
+//
+//   - Coverage: for any random tree with open/closed shadow attachments
+//     and text content in both light and shadow trees, walkTextNodes
+//     returns exactly the text nodes reachable through light children
+//     and open shadow boundaries. Closed shadows are dead-ends and
+//     their text never surfaces.
+//   - visibleTextContent concatenation matches the same reachable set
+//     in the same pre-order traversal.
+//   - The chunked walker's union of processed chunks matches the
+//     eager walker — equivalence holds across the shadow extension,
+//     not just the light tree.
+
+import fc from "fast-check";
+
+import {
+  collectTextNodesShadowPiercing,
+  visibleTextContent,
+  walkTextNodes,
+} from "../dom-utils";
+import {
+  __resetShadowRootsForTesting,
+  installShadowRootHook,
+} from "../shadow-roots";
+import { walkTextNodesChunked } from "../yielding-text-walk";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  __resetShadowRootsForTesting();
+  installShadowRootHook();
+});
+
+afterEach(() => {
+  __resetShadowRootsForTesting();
+});
+
+// -----------------------------------------------------------------------
+// Generators
+// -----------------------------------------------------------------------
+
+type ShadowMode = "open" | "closed" | null;
+
+interface NodeSpec {
+  shadow: ShadowMode;
+  // Text content the element will own as a direct text-node child.
+  // Empty string means no text node is attached, which keeps the
+  // "node has shadow but no own text" branch reachable.
+  text: string;
+}
+
+const shadowModeArb: fc.Arbitrary<ShadowMode> = fc.oneof(
+  { arbitrary: fc.constant<ShadowMode>(null), weight: 4 },
+  { arbitrary: fc.constant<ShadowMode>("open"), weight: 3 },
+  { arbitrary: fc.constant<ShadowMode>("closed"), weight: 1 },
+);
+
+const nodeSpecArb: fc.Arbitrary<NodeSpec> = fc.record({
+  shadow: shadowModeArb,
+  // Mix of empty and short non-empty strings so the minLength filter
+  // exercises both branches and shadow-vs-light text both surface.
+  text: fc.oneof(fc.constant(""), fc.string({ minLength: 1, maxLength: 12 })),
+});
+
+interface FlatTree {
+  size: number;
+  parents: readonly number[];
+  intoShadow: readonly boolean[];
+  specs: readonly NodeSpec[];
+}
+
+const flatTreeArb: fc.Arbitrary<FlatTree> = fc
+  .integer({ min: 1, max: 10 })
+  .chain((size) => {
+    const specsArb = fc.array(nodeSpecArb, {
+      minLength: size,
+      maxLength: size,
+    });
+    if (size === 1) {
+      return specsArb.map((specs) => ({
+        size,
+        parents: [],
+        intoShadow: [],
+        specs,
+      }));
+    }
+    const parentArbs = Array.from({ length: size - 1 }, (_, index) =>
+      fc.integer({ min: 0, max: index }),
+    );
+    const intoShadowArb = fc.array(fc.boolean(), {
+      minLength: size - 1,
+      maxLength: size - 1,
+    });
+    return fc
+      .tuple(fc.tuple(...parentArbs), intoShadowArb, specsArb)
+      .map(([parents, intoShadow, specs]) => ({
+        size,
+        parents,
+        intoShadow,
+        specs,
+      }));
+  });
+
+interface BuiltTree {
+  root: HTMLElement;
+  nodes: HTMLElement[];
+  // Captured at attach time so we can reach closed shadow roots later
+  // — host.shadowRoot is null for closed mode, so a later
+  // `parent.shadowRoot.append(child)` won't work for them. Keeping the
+  // reference here lets the builder actually place content into closed
+  // shadows, which the exclusion property needs to be non-vacuous.
+  shadowsByIndex: Array<ShadowRoot | null>;
+}
+
+function buildTree(tree: FlatTree): BuiltTree {
+  const { size, parents, intoShadow, specs } = tree;
+  const nodes: HTMLElement[] = [];
+  const shadowsByIndex: Array<ShadowRoot | null> = [];
+
+  for (let i = 0; i < size; i++) {
+    const element = document.createElement("div");
+    element.dataset.index = String(i);
+    const text = (specs[i] as NodeSpec).text;
+    if (text.length > 0) {
+      element.append(document.createTextNode(text));
+    }
+    nodes.push(element);
+  }
+
+  // Pre-order attach so shadow targets exist before children try to land.
+  for (let i = 0; i < size; i++) {
+    const mode = (specs[i] as NodeSpec).shadow;
+    shadowsByIndex.push(
+      mode === null ? null : (nodes[i] as HTMLElement).attachShadow({ mode }),
+    );
+  }
+
+  for (let i = 1; i < size; i++) {
+    const parentIndex = parents[i - 1];
+    if (parentIndex === undefined) {
+      continue;
+    }
+    const parent = nodes[parentIndex];
+    if (!parent) {
+      continue;
+    }
+    const parentShadow = shadowsByIndex[parentIndex];
+    const placeInShadow = intoShadow[i - 1] === true && parentShadow;
+    if (placeInShadow) {
+      parentShadow.append(nodes[i] as HTMLElement);
+    } else {
+      parent.append(nodes[i] as HTMLElement);
+    }
+  }
+
+  const root = nodes[0];
+  if (!root) {
+    throw new Error("empty tree (size should be >= 1)");
+  }
+  return { root, nodes, shadowsByIndex };
+}
+
+// -----------------------------------------------------------------------
+// Reference implementation
+// -----------------------------------------------------------------------
+
+// Manual recursive walker that pre-orders light children, then descends
+// into open shadow roots. The text helpers are correct iff their output
+// matches this reference for every random tree.
+function referenceTextNodes(
+  root: Node,
+  options: { minLength?: number } = {},
+): Text[] {
+  const { minLength = 0 } = options;
+  const out: Text[] = [];
+  function visit(node: Node): void {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node as Text;
+      const value = text.nodeValue;
+      if (value && value.length >= minLength) {
+        out.push(text);
+      }
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
+    const element = node as Element;
+    // Match the helpers' NON_CONTENT_TAGS pruning. The generator
+    // doesn't emit script/style/noscript/template, so this is just
+    // a defensive mirror.
+    if (
+      element.tagName === "SCRIPT" ||
+      element.tagName === "STYLE" ||
+      element.tagName === "NOSCRIPT" ||
+      element.tagName === "TEMPLATE"
+    ) {
+      return;
+    }
+    for (const child of element.childNodes) {
+      visit(child);
+    }
+    if (element.shadowRoot) {
+      for (const child of element.shadowRoot.childNodes) {
+        visit(child);
+      }
+    }
+  }
+  if (root.nodeType === Node.ELEMENT_NODE) {
+    visit(root);
+  } else {
+    for (const child of (root as ParentNode).childNodes) {
+      visit(child);
+    }
+  }
+  return out;
+}
+
+// -----------------------------------------------------------------------
+// Invariant 1: walkTextNodes / collectTextNodesShadowPiercing coverage
+// -----------------------------------------------------------------------
+
+describe("walkTextNodes — shadow coverage", () => {
+  it("returns exactly the open-shadow-reachable text nodes for any tree", () => {
+    fc.assert(
+      fc.property(
+        flatTreeArb,
+        fc.integer({ min: 0, max: 6 }),
+        (tree, minLength) => {
+          document.body.innerHTML = "";
+          __resetShadowRootsForTesting();
+          installShadowRootHook();
+          const built = buildTree(tree);
+          document.body.append(built.root);
+
+          const expected = referenceTextNodes(document.body, { minLength });
+          const actual = walkTextNodes(document.body, { minLength });
+          expect(actual).toEqual(expected);
+        },
+      ),
+    );
+  });
+
+  it("collectTextNodesShadowPiercing matches walkTextNodes (same core)", () => {
+    fc.assert(
+      fc.property(flatTreeArb, (tree) => {
+        document.body.innerHTML = "";
+        __resetShadowRootsForTesting();
+        installShadowRootHook();
+        const built = buildTree(tree);
+        document.body.append(built.root);
+
+        // walkTextNodes delegates to collectTextNodesShadowPiercing
+        // today, but the public surface is what consumers depend on
+        // — pin the equivalence so a future refactor that diverges
+        // them surfaces here.
+        const a = walkTextNodes(document.body, { minLength: 1 });
+        const b = collectTextNodesShadowPiercing(document.body, {
+          minLength: 1,
+        });
+        expect(a).toEqual(b);
+      }),
+    );
+  });
+
+  it("never returns text living inside a closed shadow root", () => {
+    fc.assert(
+      fc.property(flatTreeArb, (tree) => {
+        document.body.innerHTML = "";
+        __resetShadowRootsForTesting();
+        installShadowRootHook();
+        const built = buildTree(tree);
+        document.body.append(built.root);
+
+        // Walk every descendant of every closed shadow root the
+        // builder created. Descent has to use the builder's captured
+        // shadow references because host.shadowRoot is null for
+        // closed-mode hosts and a recursive light-only walk from the
+        // host won't find anything in there. Once a text node is
+        // inside a closed shadow tree, NO further descent can take
+        // it back into reachable territory.
+        const closedSubtreeText = new Set<Text>();
+        function collectAllText(node: Node, into: Set<Text>): void {
+          if (node.nodeType === Node.TEXT_NODE) {
+            into.add(node as Text);
+            return;
+          }
+          if (node.nodeType !== Node.ELEMENT_NODE) {
+            return;
+          }
+          const element = node as Element;
+          for (const child of element.childNodes) {
+            collectAllText(child, into);
+          }
+          // Also follow the shadow reference (open OR closed) — once
+          // inside a closed wrapper, every nested open shadow is
+          // still unreachable to the production walker, so its text
+          // is in the exclusion set too.
+          const index = Number.parseInt(
+            (element as HTMLElement).dataset.index ?? "-1",
+            10,
+          );
+          if (index >= 0) {
+            const shadow = built.shadowsByIndex[index];
+            if (shadow) {
+              for (const child of shadow.childNodes) {
+                collectAllText(child, into);
+              }
+            }
+          }
+        }
+        for (let i = 0; i < built.nodes.length; i++) {
+          const shadow = built.shadowsByIndex[i];
+          if (!shadow || (built.nodes[i] as HTMLElement).shadowRoot) {
+            // No shadow, or it's open and reachable through normal
+            // walk — exclusion set doesn't apply.
+            continue;
+          }
+          for (const child of shadow.childNodes) {
+            collectAllText(child, closedSubtreeText);
+          }
+        }
+
+        const reachable = new Set(walkTextNodes(document.body));
+        for (const text of closedSubtreeText) {
+          expect(reachable.has(text)).toBe(false);
+        }
+      }),
+    );
+  });
+});
+
+// -----------------------------------------------------------------------
+// Invariant 2: visibleTextContent concatenation
+// -----------------------------------------------------------------------
+
+describe("visibleTextContent — shadow coverage", () => {
+  it("concatenates the same reachable text in pre-order for any tree", () => {
+    fc.assert(
+      fc.property(flatTreeArb, (tree) => {
+        document.body.innerHTML = "";
+        __resetShadowRootsForTesting();
+        installShadowRootHook();
+        const built = buildTree(tree);
+        document.body.append(built.root);
+
+        const expectedConcat = referenceTextNodes(built.root)
+          .map((t) => t.textContent)
+          .join("");
+        const actualConcat = visibleTextContent(built.root);
+        expect(actualConcat).toEqual(expectedConcat);
+      }),
+    );
+  });
+});
+
+// -----------------------------------------------------------------------
+// Invariant 3: chunked walker equivalence across shadow boundaries
+// -----------------------------------------------------------------------
+
+describe("walkTextNodesChunked — shadow equivalence with walkTextNodes", () => {
+  it("union of chunks equals walkTextNodes output across nested shadows (sync)", () => {
+    fc.assert(
+      fc.property(flatTreeArb, (tree) => {
+        document.body.innerHTML = "";
+        __resetShadowRootsForTesting();
+        installShadowRootHook();
+        const built = buildTree(tree);
+        document.body.append(built.root);
+
+        const expected = walkTextNodes(document.body, { minLength: 0 });
+
+        const actual: Text[] = [];
+        walkTextNodesChunked(document.body, {
+          // Big enough to hit the sync fast-path for any random tree
+          // up to the generator's cap.
+          chunkSize: 1000,
+          process: (chunk) => {
+            actual.push(...chunk);
+          },
+        });
+
+        expect(actual).toEqual(expected);
+      }),
+    );
+  });
+
+  it("union of chunks equals walkTextNodes output across nested shadows (async)", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        flatTreeArb,
+        fc.integer({ min: 1, max: 3 }),
+        async (tree, chunkSize) => {
+          document.body.innerHTML = "";
+          __resetShadowRootsForTesting();
+          installShadowRootHook();
+          const built = buildTree(tree);
+          document.body.append(built.root);
+
+          const expected = walkTextNodes(document.body, { minLength: 0 });
+
+          const actual: Text[] = [];
+          let done = false;
+          walkTextNodesChunked(document.body, {
+            chunkSize,
+            yieldStrategy: () => Promise.resolve(),
+            process: (chunk) => {
+              actual.push(...chunk);
+            },
+            onComplete: () => {
+              done = true;
+            },
+          });
+
+          for (let i = 0; i <= expected.length + 5; i++) {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (done) {
+              break;
+            }
+            await Promise.resolve();
+          }
+
+          expect(done).toBe(true);
+          expect(actual).toEqual(expected);
+        },
+      ),
+      // Async fc properties are slower; cap to keep the suite snappy.
+      // Belongs on fc.assert, not on asyncProperty — the latter would
+      // interpret the options object as another arbitrary.
+      { numRuns: 30 },
+    );
+  });
+});

--- a/extension/src/lib/dom-utils.ts
+++ b/extension/src/lib/dom-utils.ts
@@ -21,34 +21,44 @@ export function isNonContentTag(tagName: string): boolean {
 }
 
 // Text that a sighted user could perceive — like `Node.textContent` but with
-// `NON_CONTENT_TAGS` subtrees (SCRIPT/STYLE/NOSCRIPT/TEMPLATE) excluded.
-// `Node.textContent` happily serializes inline script source as if it were
-// prose, which is misleading for any check keyed on "does this element show
-// text" (e.g., color-match on a wrapper whose only `textContent` is a JSON
-// blob inside a <script>).
+// `NON_CONTENT_TAGS` subtrees (SCRIPT/STYLE/NOSCRIPT/TEMPLATE) excluded and
+// open shadow roots descended into. `Node.textContent` happily serializes
+// inline script source as if it were prose (misleading for any check keyed on
+// "does this element show text" — e.g., color-match on a wrapper whose only
+// `textContent` is a JSON blob inside a <script>) and ignores shadow trees
+// entirely (which is the wrong default for the rules that consume this —
+// hidden-text-strip, color-match heuristics, etc. need to see the text the
+// user / a11y tree would render, including from web components).
 export function visibleTextContent(element: Element): string {
-  const walker = globalThis.document.createTreeWalker(
-    element,
-    NodeFilter.SHOW_TEXT,
-    {
-      acceptNode: (node) => {
-        let parent: Node | null = node.parentNode;
-        while (parent && parent !== element) {
-          if (
-            parent.nodeType === Node.ELEMENT_NODE &&
-            NON_CONTENT_TAGS.has((parent as Element).tagName)
-          ) {
-            return NodeFilter.FILTER_REJECT;
-          }
-          parent = parent.parentNode;
-        }
-        return NodeFilter.FILTER_ACCEPT;
-      },
-    },
-  );
   let out = "";
-  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-    out += node.textContent ?? "";
+  const visit = (node: Node): void => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      out += node.textContent ?? "";
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
+    const childElement = node as Element;
+    if (NON_CONTENT_TAGS.has(childElement.tagName)) {
+      return;
+    }
+    for (const child of childElement.childNodes) {
+      visit(child);
+    }
+    if (childElement.shadowRoot) {
+      for (const child of childElement.shadowRoot.childNodes) {
+        visit(child);
+      }
+    }
+  };
+  for (const child of element.childNodes) {
+    visit(child);
+  }
+  if (element.shadowRoot) {
+    for (const child of element.shadowRoot.childNodes) {
+      visit(child);
+    }
   }
   return out;
 }
@@ -178,39 +188,91 @@ interface WalkTextNodesOptions {
 // Walk every text node under `root` whose parent is a content element (not
 // SCRIPT/STYLE/NOSCRIPT, not inside an existing placeholder) and is at least
 // `minLength` characters. Replaces the hand-rolled TreeWalker + collection
-// loop in pii-redact / secrets-redact / prompt-injection-redact.
+// loop in pii-redact / secrets-redact / prompt-injection-redact. Open shadow
+// roots are descended into so injection-defense rules catch payloads
+// rendered inside web-component shadow trees; closed shadow roots are
+// opaque by design and skipped.
 export function walkTextNodes(
   root: ParentNode,
   options: WalkTextNodesOptions = {},
 ): Text[] {
+  return collectTextNodesShadowPiercing(root, options);
+}
+
+// Shared core for `walkTextNodes` and the chunked walker in
+// `yielding-text-walk.ts`. Pre-collects every text node under `root`
+// matching the same filter both APIs expose, descending through open
+// shadow roots so the injection-defense rules don't have a free
+// bypass via `attachShadow`. Pre-collection (vs an interleaved
+// TreeWalker) is what makes shadow piercing tractable — TreeWalker
+// can't cross shadow boundaries, and a custom iterator with the same
+// chunked-resume semantics would have to dance around consumer
+// detachment. A static array side-steps both problems.
+export function collectTextNodesShadowPiercing(
+  root: ParentNode,
+  options: WalkTextNodesOptions = {},
+): Text[] {
   const { minLength = 0, shouldSkipParent } = options;
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
-    acceptNode(node) {
-      const parent = node.parentElement;
-      if (!parent) {
-        return NodeFilter.FILTER_REJECT;
-      }
-      if (isNonContentTag(parent.tagName)) {
-        return NodeFilter.FILTER_REJECT;
-      }
-      if (isInsidePlaceholder(parent)) {
-        return NodeFilter.FILTER_REJECT;
-      }
-      if (shouldSkipParent?.(parent)) {
-        return NodeFilter.FILTER_REJECT;
-      }
-      const value = node.nodeValue;
-      if (!value || value.length < minLength) {
-        return NodeFilter.FILTER_REJECT;
-      }
-      return NodeFilter.FILTER_ACCEPT;
-    },
-  });
   const out: Text[] = [];
-  let current = walker.nextNode();
-  while (current) {
-    out.push(current as Text);
-    current = walker.nextNode();
+
+  function accept(text: Text): boolean {
+    const parent = text.parentElement;
+    if (!parent) {
+      return false;
+    }
+    if (isNonContentTag(parent.tagName)) {
+      return false;
+    }
+    if (isInsidePlaceholder(parent)) {
+      return false;
+    }
+    if (shouldSkipParent?.(parent)) {
+      return false;
+    }
+    const value = text.nodeValue;
+    if (!value || value.length < minLength) {
+      return false;
+    }
+    return true;
+  }
+
+  function visit(node: Node): void {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node as Text;
+      if (accept(text)) {
+        out.push(text);
+      }
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
+    const element = node as Element;
+    // Prune NON_CONTENT_TAGS at the subtree boundary — saves the
+    // per-text-node parent check on the (rare) case where a content
+    // element has many text descendants under a script/style. Equivalent
+    // result either way; the filter at `accept` is the source of truth.
+    if (isNonContentTag(element.tagName)) {
+      return;
+    }
+    for (const child of element.childNodes) {
+      visit(child);
+    }
+    if (element.shadowRoot) {
+      for (const child of element.shadowRoot.childNodes) {
+        visit(child);
+      }
+    }
+  }
+
+  // ParentNode covers Element, Document, DocumentFragment, ShadowRoot.
+  // For an Element root, also descend into its own shadow.
+  if (root.nodeType === Node.ELEMENT_NODE) {
+    visit(root);
+  } else {
+    for (const child of root.childNodes) {
+      visit(child);
+    }
   }
   return out;
 }

--- a/extension/src/lib/yielding-text-walk.ts
+++ b/extension/src/lib/yielding-text-walk.ts
@@ -20,8 +20,13 @@
 // The filter (NON_CONTENT_TAGS skip, isInsidePlaceholder skip,
 // minLength, optional shouldSkipParent) mirrors `walkTextNodes` in
 // dom-utils — same predicates, different consumer shape.
+//
+// Collection phase descends into open shadow roots so the
+// injection-defense rules (the primary consumers of this walker)
+// catch payloads rendered inside web-component shadow trees. Closed
+// shadow roots are opaque by design and not visited.
 
-import { isInsidePlaceholder, isNonContentTag } from "./dom-utils";
+import { collectTextNodesShadowPiercing } from "./dom-utils";
 
 export interface WalkTextNodesChunkedOptions {
   // Aborts the walk at the next chunk boundary. Already-processed
@@ -85,37 +90,25 @@ export function walkTextNodesChunked(
     return;
   }
 
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
-    acceptNode(node) {
-      const parent = node.parentElement;
-      if (!parent) {
-        return NodeFilter.FILTER_REJECT;
-      }
-      if (isNonContentTag(parent.tagName)) {
-        return NodeFilter.FILTER_REJECT;
-      }
-      if (isInsidePlaceholder(parent)) {
-        return NodeFilter.FILTER_REJECT;
-      }
-      if (shouldSkipParent?.(parent)) {
-        return NodeFilter.FILTER_REJECT;
-      }
-      const value = node.nodeValue;
-      if (!value || value.length < minLength) {
-        return NodeFilter.FILTER_REJECT;
-      }
-      return NodeFilter.FILTER_ACCEPT;
-    },
-  });
+  // Pre-collect every matching text node in one pass. The original
+  // implementation interleaved a TreeWalker with chunked processing
+  // and had to dance around walker.currentNode resume across the
+  // boundary where the consumer detached nodes. Pre-collection makes
+  // the resume problem disappear (the array holds direct refs) and
+  // unlocks shadow-piercing — TreeWalker doesn't cross shadow
+  // boundaries, but the recursive collector does. Memory cost is one
+  // Text reference per qualifying node; CPU cost is one O(n) walk
+  // up-front instead of an O(n) walk interleaved with processing.
+  const texts = collectTextNodesShadowPiercing(
+    root,
+    shouldSkipParent ? { minLength, shouldSkipParent } : { minLength },
+  );
 
-  let chunk: Text[] = [];
-  // Holds a node we pre-fetched before yielding (to keep walker.currentNode
-  // anchored to a still-connected node across the boundary). Consumed
-  // as the first node on the next walkSync entry — we can't let
-  // walker.nextNode() consume it because we'd want to revisit it
-  // ourselves, and the chunk-size invariant breaks if we seed it
-  // straight into `chunk` and then push another node on top.
-  let pendingResume: Text | null = null;
+  if (signal?.aborted) {
+    return;
+  }
+
+  let index = 0;
 
   function runFinalize(): void {
     if (signal?.aborted) {
@@ -124,41 +117,16 @@ export function walkTextNodesChunked(
     onComplete?.();
   }
 
-  // Walks until the chunk fills or the tree is exhausted. Returns
-  // "yield" when a chunk was just flushed and walking should continue
-  // after a scheduler yield; "done" when the walker has no more nodes
-  // and the trailing partial chunk (if any) has been processed.
-  function walkSync(): "yield" | "done" {
-    let next: Node | null = pendingResume ?? walker.nextNode();
-    pendingResume = null;
-    while (next) {
-      chunk.push(next as Text);
-      if (chunk.length >= chunkSize) {
-        // Pre-fetch the resume point BEFORE process() runs. The
-        // consumer rules call replaceMatchesInTextNode in `process`,
-        // which detaches every text node in the chunk — including
-        // the one currently held in walker.currentNode. nextNode()
-        // off a detached node returns null and the walk silently
-        // ends after the first chunk. Grabbing the next node up
-        // front and re-anchoring walker.currentNode to it after
-        // process keeps the traversal valid across the boundary.
-        const resume = walker.nextNode();
-        process(chunk);
-        chunk = [];
-        if (!resume) {
-          return "done";
-        }
-        walker.currentNode = resume;
-        pendingResume = resume as Text;
-        return "yield";
-      }
-      next = walker.nextNode();
+  // Process up to `chunkSize` text nodes; returns "yield" when there's
+  // more to do (consumer must await a scheduler yield before calling
+  // again) or "done" when the array is exhausted.
+  function runChunkSync(): "yield" | "done" {
+    const end = Math.min(index + chunkSize, texts.length);
+    if (end > index) {
+      process(texts.slice(index, end));
+      index = end;
     }
-    if (chunk.length > 0) {
-      process(chunk);
-      chunk = [];
-    }
-    return "done";
+    return index < texts.length ? "yield" : "done";
   }
 
   function continueAsync(): void {
@@ -166,7 +134,7 @@ export function walkTextNodesChunked(
       if (signal?.aborted) {
         return;
       }
-      if (walkSync() === "done") {
+      if (runChunkSync() === "done") {
         runFinalize();
       } else {
         continueAsync();
@@ -174,7 +142,7 @@ export function walkTextNodesChunked(
     });
   }
 
-  if (walkSync() === "done") {
+  if (runChunkSync() === "done") {
     runFinalize();
   } else {
     continueAsync();


### PR DESCRIPTION
## Summary

- Tier 1 (#165) made the subtree watcher and selector dispatch reach into open shadow roots. **Tier 2 does the same for the text-walk path** that the injection-defense rules depend on: `prompt-injection-redact`, `pii-redact`, `secrets-redact`, `encoded-payload-redact`, `unicode-invisibles-strip`.
- Without this, an attacker could plant an injection payload inside a `<div>.attachShadow({mode:"open"})` and every one of these rules would walk right past it — the entire point the rules exist (asymmetry between what the user sees and what an agent reads) was bypassable with one line of page JS.

Part of #164 Tier 2.

## What changed

- `extension/src/lib/dom-utils.ts`
  - New `collectTextNodesShadowPiercing` shared collector — recursive walk that descends through `element.shadowRoot` for open hosts.
  - `walkTextNodes` now delegates to it (same public contract; same filter; just sees shadow content too).
  - `visibleTextContent` rewritten as a recursive concat that descends into open shadows; closed shadows stay opaque.
- `extension/src/lib/yielding-text-walk.ts` — the chunked walker now uses the shared collector for phase 1 and iterates by index in phase 2. Drops the `walker.currentNode` resume dance the original needed because the consumer detaches nodes mid-chunk; pre-collection makes that problem disappear (the array holds direct refs) and unlocks shadow piercing in one move. Chunking + scheduler-yield + abort semantics are unchanged.
- `extension/src/lib/__tests__/text-walk-shadow.property.test.ts` (new) — fast-check property tests for:
  - Coverage: `walkTextNodes` returns exactly the text nodes reachable through light + open-shadow boundaries for any random tree.
  - Eager / chunked equivalence: union of `walkTextNodesChunked` chunks equals `walkTextNodes` across nested shadows, in both sync and async paths.
  - `visibleTextContent` concatenates the same reachable set in pre-order across nested shadows.
  - Closed-shadow exclusion: text the builder places into a closed shadow root never surfaces (non-vacuous — the builder captures the shadow root at attach time so it can actually place content there).
- `demo-site/src/components/ShadowDomEmbed.tsx` — adds an injection-shaped paragraph inside the existing demo shadow root. Fixture reused from product detail (already base64 in source — no new plaintext payload shipped).

Closed shadow roots stay opaque by design. Tier 3 (`adoptedStyleSheets` for EasyList + placeholder styles inside shadows) is the remaining piece tracked in #164.

## Test plan

- [x] `bun jest` — 1322 / 1322 pass (6 new property tests; existing `yielding-text-walk.property.test.ts` equivalence tests continue to pass unchanged across the rewrite).
- [x] `bun run check` — biome + eslint clean (extension + demo-site).
- [x] `bun run build` — both bundles build clean.
- [ ] Manual: load the unpacked extension, open the demo home page, confirm the prompt-injection paragraph inside the shadow root is replaced with a reveal placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)