### PR TITLE
Docs: closed shadow roots are not protected (#164 follow-up)

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -24,6 +24,24 @@ override defaults at build time without forking the repo.
 Numbered citations like [[1]](#ref-greshake-2023) link to the
 [References](#references) section at the bottom.
 
+## Coverage scope
+
+All rules run against the page's light DOM and any **open shadow roots** the
+page builds via `element.attachShadow({ mode: "open" })`. That covers the way
+most chat widgets, consent banners, ad SDKs, and custom elements ship UI today —
+the host element lives in the light tree, the rendered content lives one
+boundary inside.
+
+**Closed shadow roots** (`{ mode: "closed" }`) are not reached. The Web
+Components spec makes closed mode opt-out of all external JavaScript access —
+`host.shadowRoot` is `null`, `document.adoptedStyleSheets` and
+`MutationObserver` do not cross the boundary, and no supported API undoes that.
+Any content a page renders inside a closed shadow root — whether ads, chat
+widgets, hidden text, or prompt-injection payloads — is invisible to every rule
+and will be passed through to the agent untouched. Closed shadow roots are
+uncommon outside browser UA shadows and a handful of hardened embeds, but they
+are a known gap.
+
 ## Indirect prompt injection
 
 Remove or neutralize content that could carry attacker-controlled instructions


### PR DESCRIPTION
## Summary

- The shadow-DOM piercing PRs (#165 / #166 / #167, covering #164 Tiers 1–3) reached every open shadow root in the page. Closed shadow roots (`attachShadow({ mode: "closed" })`) are opt-out of all external JavaScript access by spec — `host.shadowRoot` is null, `MutationObserver` and `adoptedStyleSheets` don't cross the boundary, and no supported API undoes that.
- This PR adds a short Coverage Scope section near the top of the Rules reference page documenting that gap, so users running into a sealed widget aren't surprised that content survived.

Closes #164 entirely (Tiers 1–3 + the docs limitation note).

## What changed

- `docs/src/content/docs/rules.md` — new Coverage Scope subsection that calls out open-shadow-root reachability (what works) and closed-shadow-root opacity (what doesn't). Phrasing stays abstract about what an attacker could plant there, in line with the project's "no prompt-injection examples in published docs" convention.

## Test plan

- [x] `bun run check` — Astro typecheck clean.
- [x] `bun run build` — docs site builds clean (8 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)