### PR TITLE
Feat: heuristic detector for closed shadow roots (#164 follow-up)

### DIFF
--- a/demo-site/src/components/ShadowDomEmbed.tsx
+++ b/demo-site/src/components/ShadowDomEmbed.tsx
@@ -20,9 +20,37 @@ import { INJECTIONS } from "../data/injection-fixtures";
 // second card exercises the Tier 3 adopted-stylesheet path: that
 // class only matches via the EasyList generic CSS sheet, which now
 // adopts into open shadow roots so the hide applies here too.
+//
+// A second host below mounts a custom element with a CLOSED shadow root
+// to exercise `closed-shadow-root-annotate`. By spec the rules cannot
+// see inside; the heuristic only confirms it's there.
+
+const CLOSED_TAG = "abs-closed-widget";
+
+if (
+  typeof customElements !== "undefined" &&
+  !customElements.get(CLOSED_TAG)
+) {
+  customElements.define(
+    CLOSED_TAG,
+    class extends HTMLElement {
+      constructor() {
+        super();
+        const shadow = this.attachShadow({ mode: "closed" });
+        const inner = document.createElement("div");
+        inner.style.cssText =
+          "padding:6px 10px;border:1px solid #7c3aed;background:#f5f3ff;color:#4c1d95;font:13px system-ui;border-radius:4px;";
+        inner.textContent =
+          "Closed-shadow widget — contents are invisible to ABS by spec.";
+        shadow.append(inner);
+      }
+    },
+  );
+}
 
 export default function ShadowDomEmbed() {
   const hostRef = useRef<HTMLDivElement>(null);
+  const closedHostRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const host = hostRef.current;
@@ -75,6 +103,18 @@ export default function ShadowDomEmbed() {
     };
   }, []);
 
+  useEffect(() => {
+    const host = closedHostRef.current;
+    if (!host || host.querySelector(CLOSED_TAG)) {
+      return;
+    }
+    const widget = document.createElement(CLOSED_TAG);
+    host.append(widget);
+    return () => {
+      widget.remove();
+    };
+  }, []);
+
   return (
     <section
       aria-label="Shadow-DOM third-party widgets"
@@ -97,6 +137,18 @@ export default function ShadowDomEmbed() {
       <div
         ref={hostRef}
         className="shadow-host mt-3 rounded border border-dashed border-slate-300 p-3"
+      />
+      <p className="mt-4 text-sm text-stone-700">
+        The widget below mounts inside a <em>closed</em> shadow root. ABS
+        cannot reach inside by spec — every rule passes its contents through
+        untouched. With <code>closed-shadow-root-annotate</code> enabled, a
+        screen-reader-only landmark is prepended to the document noting that
+        the page is using closed shadow roots and content here is invisible
+        to the extension.
+      </p>
+      <div
+        ref={closedHostRef}
+        className="closed-shadow-host mt-3 rounded border border-dashed border-slate-300 p-3"
       />
     </section>
   );

--- a/demo-site/src/components/ShadowDomEmbed.tsx
+++ b/demo-site/src/components/ShadowDomEmbed.tsx
@@ -27,10 +27,7 @@ import { INJECTIONS } from "../data/injection-fixtures";
 
 const CLOSED_TAG = "abs-closed-widget";
 
-if (
-  typeof customElements !== "undefined" &&
-  !customElements.get(CLOSED_TAG)
-) {
+if (typeof customElements !== "undefined" && !customElements.get(CLOSED_TAG)) {
   customElements.define(
     CLOSED_TAG,
     class extends HTMLElement {
@@ -139,12 +136,12 @@ export default function ShadowDomEmbed() {
         className="shadow-host mt-3 rounded border border-dashed border-slate-300 p-3"
       />
       <p className="mt-4 text-sm text-stone-700">
-        The widget below mounts inside a <em>closed</em> shadow root. ABS
-        cannot reach inside by spec — every rule passes its contents through
-        untouched. With <code>closed-shadow-root-annotate</code> enabled, a
-        screen-reader-only landmark is prepended to the document noting that
-        the page is using closed shadow roots and content here is invisible
-        to the extension.
+        The widget below mounts inside a <em>closed</em> shadow root. ABS cannot
+        reach inside by spec — every rule passes its contents through untouched.
+        With <code>closed-shadow-root-annotate</code> enabled, a
+        screen-reader-only landmark is prepended to the document noting that the
+        page is using closed shadow roots and content here is invisible to the
+        extension.
       </p>
       <div
         ref={closedHostRef}

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -40,7 +40,9 @@ Any content a page renders inside a closed shadow root — whether ads, chat
 widgets, hidden text, or prompt-injection payloads — is invisible to every rule
 and will be passed through to the agent untouched. Closed shadow roots are
 uncommon outside browser UA shadows and a handful of hardened embeds, but they
-are a known gap.
+are a known gap. The optional
+[Flag Closed Shadow Roots](#flag-closed-shadow-roots-experimental) rule can
+heuristically warn the agent at read-time when this gap is in use.
 
 ## Indirect prompt injection
 
@@ -425,6 +427,35 @@ that human reviewers never see, turning the page itself into an
 indirect-prompt-injection delivery surface. Search-engine cloaking has a long
 lineage [[19]](#ref-wu-cloaking); the same primitive aimed at LLM crawlers is
 the new threat.
+
+#### Flag Closed Shadow Roots (Experimental)
+
+- **ID:** `closed-shadow-root-annotate`
+- **Default:** off
+- **Top frame only**
+
+Heuristically detect pages that render content inside closed shadow roots and
+prepend a screen-reader-only landmark noting that the extension cannot see
+inside those shadow trees. Complements the open-shadow-root coverage described
+in [Coverage scope](#coverage-scope) above by giving the agent a positive
+signal at read-time that a known blind spot is in use on this page.
+
+Detection is necessarily heuristic: by spec, an element with `mode: "closed"`
+is indistinguishable from an element with no shadow root at all from outside
+JavaScript. The rule looks for the structural shape strongly correlated with
+"closed shadow host": an upgraded custom element (hyphenated tag name, defined
+in `customElements`) with no light-DOM children, no `host.shadowRoot`, and a
+non-zero rendered box. Built-in elements with UA shadow roots (`<input>`,
+`<details>`, `<video>`) are filtered out for free — their tag names contain
+no hyphen. Declarative shadow DOM (`<template shadowrootmode="closed">`) is
+indistinguishable from imperative closed shadows after parsing and is not
+separately surfaced.
+
+The landmark says "may contain content ABS cannot see," not "this is
+definitely a closed shadow root" — a custom element that renders via canvas,
+WebGL, or `::before` background-image with no actual shadow root will trip
+the heuristic too. Off by default while the false-positive rate is
+characterized.
 
 ### Visual identity spoofing
 

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -437,25 +437,24 @@ the new threat.
 Heuristically detect pages that render content inside closed shadow roots and
 prepend a screen-reader-only landmark noting that the extension cannot see
 inside those shadow trees. Complements the open-shadow-root coverage described
-in [Coverage scope](#coverage-scope) above by giving the agent a positive
-signal at read-time that a known blind spot is in use on this page.
+in [Coverage scope](#coverage-scope) above by giving the agent a positive signal
+at read-time that a known blind spot is in use on this page.
 
-Detection is necessarily heuristic: by spec, an element with `mode: "closed"`
-is indistinguishable from an element with no shadow root at all from outside
+Detection is necessarily heuristic: by spec, an element with `mode: "closed"` is
+indistinguishable from an element with no shadow root at all from outside
 JavaScript. The rule looks for the structural shape strongly correlated with
 "closed shadow host": an upgraded custom element (hyphenated tag name, defined
 in `customElements`) with no light-DOM children, no `host.shadowRoot`, and a
 non-zero rendered box. Built-in elements with UA shadow roots (`<input>`,
-`<details>`, `<video>`) are filtered out for free — their tag names contain
-no hyphen. Declarative shadow DOM (`<template shadowrootmode="closed">`) is
+`<details>`, `<video>`) are filtered out for free — their tag names contain no
+hyphen. Declarative shadow DOM (`<template shadowrootmode="closed">`) is
 indistinguishable from imperative closed shadows after parsing and is not
 separately surfaced.
 
-The landmark says "may contain content ABS cannot see," not "this is
-definitely a closed shadow root" — a custom element that renders via canvas,
-WebGL, or `::before` background-image with no actual shadow root will trip
-the heuristic too. Off by default while the false-positive rate is
-characterized.
+The landmark says "may contain content ABS cannot see," not "this is definitely
+a closed shadow root" — a custom element that renders via canvas, WebGL, or
+`::before` background-image with no actual shadow root will trip the heuristic
+too. Off by default while the false-positive rate is characterized.
 
 ### Visual identity spoofing
 

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -34,6 +34,7 @@
     "trust-badge-annotate": false,
     "disguised-ad-flag": true,
     "encoded-payload-redact": true,
-    "webdriver-probe-annotate": false
+    "webdriver-probe-annotate": false,
+    "closed-shadow-root-annotate": false
   }
 }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -33,6 +33,7 @@ const tabDetections = new Map<number, Map<DetectionKind, DetectionPayload>>();
 const DETECTION_KIND_TO_RULE_ID = {
   "roach-motel": "roach-motel-annotate",
   "webdriver-probe": "webdriver-probe-annotate",
+  "closed-shadow-root": "closed-shadow-root-annotate",
 } as const satisfies Record<DetectionKind, string>;
 
 // Pleasant blue — clearly an extension affordance, not a warning/error.

--- a/extension/src/lib/detection-messages.ts
+++ b/extension/src/lib/detection-messages.ts
@@ -12,7 +12,10 @@
 
 import type { RoachMotelDifficulty } from "../rules/site-data.generated";
 
-export type DetectionKind = "roach-motel" | "webdriver-probe";
+export type DetectionKind =
+  | "roach-motel"
+  | "webdriver-probe"
+  | "closed-shadow-root";
 
 export interface RoachMotelDetectionPayload {
   kind: "roach-motel";
@@ -29,9 +32,16 @@ export interface WebdriverProbeDetectionPayload {
   url: string;
 }
 
+export interface ClosedShadowRootDetectionPayload {
+  kind: "closed-shadow-root";
+  host: string;
+  url: string;
+}
+
 export type DetectionPayload =
   | RoachMotelDetectionPayload
-  | WebdriverProbeDetectionPayload;
+  | WebdriverProbeDetectionPayload
+  | ClosedShadowRootDetectionPayload;
 
 export interface RuleDetectionMessage {
   type: "rule-detection";

--- a/extension/src/lib/rule-groups.ts
+++ b/extension/src/lib/rule-groups.ts
@@ -44,6 +44,7 @@ export const RULE_GROUPS: readonly RuleGroup[] = [
       "link-spoof-annotate",
       "trust-badge-annotate",
       "webdriver-probe-annotate",
+      "closed-shadow-root-annotate",
     ],
   },
   {

--- a/extension/src/rules/__tests__/closed-shadow-root-annotate.test.ts
+++ b/extension/src/rules/__tests__/closed-shadow-root-annotate.test.ts
@@ -259,6 +259,24 @@ describe("closedShadowRootAnnotateRule.apply", () => {
     expect(document.querySelector(LANDMARK_SELECTOR)).toBeNull();
   });
 
+  it("skips the descendant walk once the landmark exists", () => {
+    // Once stamped, scan() should short-circuit before walking descendants
+    // — there's no second landmark to add and the rect/qsa work is wasted
+    // on every subsequent mutation tick for the page's lifetime.
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    document.body.append(document.createElement(tag));
+    closedShadowRootAnnotateRule.apply(document.body);
+    expect(document.querySelector(LANDMARK_SELECTOR)).not.toBeNull();
+
+    const qsaSpy = jest.spyOn(document.body, "querySelectorAll");
+    // Re-applying without teardown is the cheapest way to drive scan()
+    // again on the already-stamped document.
+    closedShadowRootAnnotateRule.apply(document.body);
+    expect(qsaSpy).not.toHaveBeenCalled();
+    qsaSpy.mockRestore();
+  });
+
   it("re-apply after teardown re-stamps on the same document", () => {
     const tag = nextTagName();
     defineClosedShadowElement(tag);

--- a/extension/src/rules/__tests__/closed-shadow-root-annotate.test.ts
+++ b/extension/src/rules/__tests__/closed-shadow-root-annotate.test.ts
@@ -1,0 +1,322 @@
+/**
+ * @jest-environment jsdom
+ */
+import { closedShadowRootAnnotateRule } from "../closed-shadow-root-annotate";
+
+const LANDMARK_SELECTOR =
+  'section[data-abs-rule="closed-shadow-root-annotate"]';
+
+// chrome.runtime.sendMessage is installed as jest.fn() on globalThis by
+// jest-webextension-mock.
+const sendMessageMock = chrome.runtime.sendMessage as unknown as jest.Mock;
+
+function detectionCalls(): unknown[] {
+  return sendMessageMock.mock.calls
+    .map(([message]: [unknown]) => message)
+    .filter(
+      (message) => (message as { type?: string }).type === "rule-detection",
+    );
+}
+
+// A unique tag name per test avoids the global customElements registry
+// colliding across cases (defining the same name twice throws).
+let tagCounter = 0;
+function nextTagName(): string {
+  tagCounter += 1;
+  return `abs-test-element-${tagCounter}`;
+}
+
+function defineClosedShadowElement(tagName: string): void {
+  class ClosedShadowElement extends HTMLElement {
+    constructor() {
+      super();
+      // Constructor attaches a closed shadow root with content. The host's
+      // `shadowRoot` property stays null externally — this is what the
+      // rule's heuristic is trying to surface.
+      const shadow = this.attachShadow({ mode: "closed" });
+      shadow.innerHTML = "<span>secret shadow content</span>";
+    }
+  }
+  customElements.define(tagName, ClosedShadowElement);
+}
+
+function defineRenderlessElement(tagName: string): void {
+  class RenderlessElement extends HTMLElement {
+    // No shadow, no children — the "looks unused" case the visibility
+    // gate is meant to filter out. jsdom always reports 0×0 so we mock
+    // getBoundingClientRect per-test where needed.
+  }
+  customElements.define(tagName, RenderlessElement);
+}
+
+function mockNonZeroRect(element: Element): void {
+  element.getBoundingClientRect = (): DOMRect =>
+    ({
+      width: 100,
+      height: 50,
+      top: 0,
+      left: 0,
+      right: 100,
+      bottom: 50,
+    }) as DOMRect;
+}
+
+function mockZeroRect(element: Element): void {
+  element.getBoundingClientRect = (): DOMRect =>
+    ({ width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 }) as DOMRect;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  sendMessageMock.mockReset();
+  sendMessageMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  closedShadowRootAnnotateRule.teardown();
+});
+
+describe("closedShadowRootAnnotateRule.apply", () => {
+  it("stamps an sr-only landmark when a custom element with a closed shadow is present", () => {
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    const host = document.createElement(tag);
+    document.body.append(host);
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    const landmark = document.querySelector(LANDMARK_SELECTOR);
+    expect(landmark).not.toBeNull();
+    expect(landmark?.getAttribute("role")).toBe("note");
+    expect(landmark?.classList.contains("sr-only")).toBe(true);
+    expect(landmark?.textContent).toContain("closed shadow root");
+  });
+
+  it("applies the structural sr-only envelope inline", () => {
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    document.body.append(document.createElement(tag));
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    const landmark = document.querySelector<HTMLElement>(LANDMARK_SELECTOR);
+    expect(landmark).not.toBeNull();
+    expect(landmark?.style.position).toBe("absolute");
+    expect(landmark?.style.width).toBe("1px");
+    expect(landmark?.style.height).toBe("1px");
+    expect(landmark?.style.overflow).toBe("hidden");
+  });
+
+  it("is idempotent — multiple hosts do not stack landmarks", () => {
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    document.body.append(document.createElement(tag));
+    document.body.append(document.createElement(tag));
+    document.body.append(document.createElement(tag));
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    expect(document.querySelectorAll(LANDMARK_SELECTOR)).toHaveLength(1);
+  });
+
+  it("does not stamp a landmark when no custom elements are present", () => {
+    document.body.innerHTML = "<div><p>regular content</p></div>";
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    expect(document.querySelector(LANDMARK_SELECTOR)).toBeNull();
+  });
+
+  it("does not stamp when the custom element has an open shadow root", () => {
+    const tag = nextTagName();
+    class OpenShadowElement extends HTMLElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: "open" });
+      }
+    }
+    customElements.define(tag, OpenShadowElement);
+    document.body.append(document.createElement(tag));
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    expect(document.querySelector(LANDMARK_SELECTOR)).toBeNull();
+  });
+
+  it("does not stamp when the custom element has light-DOM children", () => {
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    const host = document.createElement(tag);
+    host.append(document.createElement("span"));
+    document.body.append(host);
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    // Light children mean the agent can see *some* of the content; the
+    // heuristic is intentionally conservative about flagging in that case.
+    expect(document.querySelector(LANDMARK_SELECTOR)).toBeNull();
+  });
+
+  it("does not stamp when the custom element has non-whitespace text content", () => {
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    const host = document.createElement(tag);
+    host.append(document.createTextNode("visible label"));
+    document.body.append(host);
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    expect(document.querySelector(LANDMARK_SELECTOR)).toBeNull();
+  });
+
+  it("ignores hyphenated tags that are not upgraded custom elements", () => {
+    // Hyphenated tag with no matching customElements.define — the constructor
+    // never ran, so it can't have called attachShadow.
+    const host = document.createElement("never-defined-element");
+    document.body.append(host);
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    expect(document.querySelector(LANDMARK_SELECTOR)).toBeNull();
+  });
+
+  it("ignores built-in elements with UA shadows (no hyphen in tag name)", () => {
+    // `<input type=range>` and `<details>` have UA shadow roots but their
+    // tag names don't contain hyphens, so the heuristic filters them out
+    // before any other check.
+    document.body.innerHTML = `
+      <input type="range" />
+      <details><summary>collapsed</summary><p>body</p></details>
+      <video></video>
+    `;
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    expect(document.querySelector(LANDMARK_SELECTOR)).toBeNull();
+  });
+
+  it("does not stamp when the host has zero size in a real browser", () => {
+    // Distinct from jsdom's default 0×0 — here we explicitly mock the rect
+    // to assert the "rendered" gate filters defined-but-invisible elements.
+    const tag = nextTagName();
+    defineRenderlessElement(tag);
+    const host = document.createElement(tag);
+    document.body.append(host);
+    // In jsdom, rect is 0×0 by default — the rule bypasses the gate there.
+    // Override to non-zero ZERO would still match; we instead simulate a
+    // browser-like 0-but-not-jsdom by mocking width=0/height=1 explicitly.
+    host.getBoundingClientRect = (): DOMRect =>
+      ({
+        width: 0,
+        height: 1,
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 1,
+      }) as DOMRect;
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    expect(document.querySelector(LANDMARK_SELECTOR)).toBeNull();
+  });
+
+  it("stamps when getBoundingClientRect reports a non-zero box (real browser path)", () => {
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    const host = document.createElement(tag);
+    document.body.append(host);
+    mockNonZeroRect(host);
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    expect(document.querySelector(LANDMARK_SELECTOR)).not.toBeNull();
+  });
+
+  it("bypasses the visibility gate when rect is exactly 0×0 (jsdom)", () => {
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    const host = document.createElement(tag);
+    document.body.append(host);
+    mockZeroRect(host);
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    // Same convention as newsletter-modal-hide: a 0×0 rect is treated as
+    // "we don't know" rather than "definitely hidden," so the rule does
+    // not refuse to stamp in jsdom.
+    expect(document.querySelector(LANDMARK_SELECTOR)).not.toBeNull();
+  });
+
+  it("teardown removes the landmark", () => {
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    document.body.append(document.createElement(tag));
+
+    closedShadowRootAnnotateRule.apply(document.body);
+    expect(document.querySelector(LANDMARK_SELECTOR)).not.toBeNull();
+
+    closedShadowRootAnnotateRule.teardown();
+    expect(document.querySelector(LANDMARK_SELECTOR)).toBeNull();
+  });
+
+  it("re-apply after teardown re-stamps on the same document", () => {
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    document.body.append(document.createElement(tag));
+
+    closedShadowRootAnnotateRule.apply(document.body);
+    closedShadowRootAnnotateRule.teardown();
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    expect(document.querySelector(LANDMARK_SELECTOR)).not.toBeNull();
+  });
+});
+
+describe("closedShadowRootAnnotateRule rule-detection emission", () => {
+  it("does not emit on apply when no hosts match", () => {
+    document.body.innerHTML = "<p>plain content</p>";
+    closedShadowRootAnnotateRule.apply(document.body);
+    expect(detectionCalls()).toHaveLength(0);
+  });
+
+  it("emits exactly one detection on first match", () => {
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    document.body.append(document.createElement(tag));
+    document.body.append(document.createElement(tag));
+
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    expect(detectionCalls()).toHaveLength(1);
+    expect(detectionCalls()[0]).toEqual({
+      type: "rule-detection",
+      payload: {
+        kind: "closed-shadow-root",
+        host: globalThis.location.hostname,
+        url: globalThis.location.href,
+      },
+    });
+  });
+
+  it("does not re-emit on subsequent apply calls (landmark short-circuit)", () => {
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    document.body.append(document.createElement(tag));
+
+    closedShadowRootAnnotateRule.apply(document.body);
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    expect(detectionCalls()).toHaveLength(1);
+  });
+
+  it("swallows sendMessage rejections", () => {
+    sendMessageMock.mockRejectedValueOnce(new Error("no receiver"));
+    const tag = nextTagName();
+    defineClosedShadowElement(tag);
+    document.body.append(document.createElement(tag));
+
+    expect(() => {
+      closedShadowRootAnnotateRule.apply(document.body);
+    }).not.toThrow();
+  });
+});

--- a/extension/src/rules/closed-shadow-root-annotate.ts
+++ b/extension/src/rules/closed-shadow-root-annotate.ts
@@ -120,9 +120,9 @@ function looksLikeClosedShadowHost(element: Element): boolean {
 
 function findClosedShadowHosts(root: ParentNode): Element[] {
   const hosts: Element[] = [];
-  // Custom elements always have a hyphen, so the attribute selector
-  // narrows the scan to a small candidate set without walking every
-  // element on the page.
+  // No CSS selector matches "tag name contains a hyphen", so we iterate
+  // every descendant and let `looksLikeClosedShadowHost`'s hyphen check
+  // short-circuit the non-custom cases on the first conjunct.
   const candidates = root.querySelectorAll("*");
   for (const candidate of candidates) {
     if (looksLikeClosedShadowHost(candidate)) {
@@ -172,6 +172,11 @@ function ensureLandmark(): void {
 }
 
 function scan(root: ParentNode): void {
+  // The landmark is per-document and idempotent; once it's stamped, every
+  // subsequent mutation can skip the descendant walk and rect query.
+  if (document.querySelector(LANDMARK_SELECTOR)) {
+    return;
+  }
   if (findClosedShadowHosts(root).length > 0) {
     ensureLandmark();
   }

--- a/extension/src/rules/closed-shadow-root-annotate.ts
+++ b/extension/src/rules/closed-shadow-root-annotate.ts
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Heuristically flag pages that render content inside closed shadow roots so
+// the agent's accessibility-tree view of the document carries an explicit
+// note that ABS has a blind spot here. Closed shadow roots are opt-out of
+// every external JS API by spec — `host.shadowRoot` returns `null`, adopted
+// stylesheets and MutationObserver do not cross the boundary, and no
+// supported API undoes that. Documented as a coverage gap in
+// `docs/src/content/docs/rules.md`; this rule lets the agent learn the same
+// thing at read-time.
+//
+// Detection is heuristic, not definitive. We cannot enumerate closed shadow
+// roots directly — the entire point of `mode: "closed"` is that the page
+// is indistinguishable from an element with no shadow root at all from
+// outside JS. Instead, the rule looks for a structural shape that's
+// strongly correlated with "this element has a closed shadow root":
+//
+//   1. Tag name contains a hyphen — required for valid custom element names
+//      (per the Web Components spec). UA-shadowed built-ins (`<input>`,
+//      `<details>`, `<video>`, `<select>`, `<textarea>`) are filtered out
+//      for free because they don't have hyphenated names.
+//   2. `customElements.get(tagName.toLowerCase())` returns a constructor —
+//      the element has been upgraded. Unupgraded custom elements haven't
+//      had their constructor run yet, so they can't have called
+//      `attachShadow`.
+//   3. `element.shadowRoot === null` — there's no open shadow root for
+//      ABS to scan into. (Open-shadow elements are handled by the
+//      Tier-1/2/3 shadow-piercing plumbing — issue #164.)
+//   4. No light-DOM children — `element.children.length === 0` and no
+//      non-whitespace direct text. A custom element with no light children
+//      that still renders something is almost certainly using shadow DOM
+//      for its UI, and combined with (3) that shadow must be closed.
+//   5. Visibly rendering — `getBoundingClientRect()` reports a non-zero
+//      box. Avoids flagging custom elements that are defined but unused
+//      (zero-sized stubs). In jsdom the rect is always zero, so this
+//      gate is bypassed when both dimensions are zero — same convention
+//      as `newsletter-modal-hide`.
+//
+// Known false positive: a custom element that renders via canvas/WebGL or
+// `::before` background-image without any shadow DOM still trips the
+// heuristic. We accept this — the landmark text says "may contain
+// content ABS cannot see," not "this is definitely a closed shadow root."
+//
+// Known false negatives:
+//   - Declarative shadow DOM (`<template shadowrootmode="closed">`) — the
+//     template is consumed during HTML parsing, never goes through
+//     `Element.prototype.attachShadow`, and the materialized closed root
+//     is indistinguishable from "no shadow" the same as imperative
+//     closed shadows.
+//   - Closed shadows on non-custom elements (e.g., a page that attaches a
+//     closed shadow to a `<div>`). Rare in practice — closed mode is
+//     almost always paired with the custom element pattern — and a
+//     hyphen-less filter would balloon false positives across the whole
+//     document.
+//
+// Future work: a main-world probe that wraps `Element.prototype.attachShadow`
+// in the page realm and reports calls with `init.mode === "closed"`, the
+// same delivery pattern as `webdriver-probe-annotate`. Would catch the
+// non-custom-element case (3) above with high specificity. Skipped for
+// now to keep the rule a single-file isolated-world change; revisit if
+// the heuristic produces too much noise in the wild.
+
+import type { RuleDetectionMessage } from "../lib/detection-messages";
+import { RULE_ATTR } from "../lib/dom-markers";
+import { log } from "../lib/log";
+import { SR_ONLY_INLINE_STYLE } from "../lib/sr-only";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import type { Rule } from "./types";
+
+const RULE_ID = "closed-shadow-root-annotate" as const;
+
+const LANDMARK_SELECTOR = `section[${RULE_ATTR}="${RULE_ID}"]`;
+
+const LANDMARK_TEXT =
+  "This page renders content inside one or more closed shadow roots. The contents of those shadow roots are invisible to this extension and may include text, controls, or instructions that are not reflected in the rest of the page's accessible content.";
+
+function hasLightContent(element: Element): boolean {
+  if (element.children.length > 0) {
+    return true;
+  }
+  for (const node of element.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isVisiblyRendered(element: Element): boolean {
+  const rect = element.getBoundingClientRect();
+  // jsdom returns 0×0 for every rect — bypass the gate there so tests
+  // don't have to mock layout. Same convention used in
+  // `newsletter-modal-hide`.
+  if (rect.width === 0 && rect.height === 0) {
+    return true;
+  }
+  return rect.width > 0 && rect.height > 0;
+}
+
+function looksLikeClosedShadowHost(element: Element): boolean {
+  const tagName = element.tagName;
+  if (!tagName.includes("-")) {
+    return false;
+  }
+  if (!customElements.get(tagName.toLowerCase())) {
+    return false;
+  }
+  if (element.shadowRoot !== null) {
+    return false;
+  }
+  if (hasLightContent(element)) {
+    return false;
+  }
+  if (!isVisiblyRendered(element)) {
+    return false;
+  }
+  return true;
+}
+
+function findClosedShadowHosts(root: ParentNode): Element[] {
+  const hosts: Element[] = [];
+  // Custom elements always have a hyphen, so the attribute selector
+  // narrows the scan to a small candidate set without walking every
+  // element on the page.
+  const candidates = root.querySelectorAll("*");
+  for (const candidate of candidates) {
+    if (looksLikeClosedShadowHost(candidate)) {
+      hosts.push(candidate);
+    }
+  }
+  return hosts;
+}
+
+function buildLandmark(): HTMLElement {
+  const note = document.createElement("section");
+  note.setAttribute("role", "note");
+  note.setAttribute("aria-label", "abs closed shadow root notice");
+  note.setAttribute(RULE_ATTR, RULE_ID);
+  note.className = "sr-only";
+  Object.assign(note.style, SR_ONLY_INLINE_STYLE);
+  note.textContent = LANDMARK_TEXT;
+  return note;
+}
+
+function ensureLandmark(): void {
+  if (document.querySelector(LANDMARK_SELECTOR)) {
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!document.body) {
+    return;
+  }
+  document.body.prepend(buildLandmark());
+  log("closed-shadow-root-annotate landmark added", {
+    host: globalThis.location.hostname,
+  });
+  // Per-document dedupe: the landmark short-circuit above ensures we only
+  // get here once, no matter how many hosts the page mounts.
+  const message: RuleDetectionMessage = {
+    type: "rule-detection",
+    payload: {
+      kind: "closed-shadow-root",
+      host: globalThis.location.hostname,
+      url: globalThis.location.href,
+    },
+  };
+  chrome.runtime.sendMessage(message).catch(() => {
+    // noop — service worker may be asleep; the landmark is the load-bearing
+    // signal and survives a missed detection emit.
+  });
+}
+
+function scan(root: ParentNode): void {
+  if (findClosedShadowHosts(root).length > 0) {
+    ensureLandmark();
+  }
+}
+
+const watcher = createSubtreeWatcher({
+  onSubtrees: (roots) => {
+    for (const root of roots) {
+      scan(root);
+    }
+  },
+});
+
+function apply(root: ParentNode): void {
+  scan(root);
+  watcher.start(root);
+}
+
+function teardown(): void {
+  watcher.stop();
+  for (const node of document.querySelectorAll(LANDMARK_SELECTOR)) {
+    node.remove();
+  }
+}
+
+export const closedShadowRootAnnotateRule = {
+  id: RULE_ID,
+  label: "Flag Closed Shadow Roots",
+  description:
+    "Heuristically detect when a page renders content inside closed shadow roots (custom elements that visibly render with no light-DOM children). If detected, add a screen-reader-only landmark noting that the extension cannot see inside those shadow trees.",
+  // Closed shadow roots in cross-origin iframes are handled — or not — by
+  // the iframe's own document; injecting a per-frame landmark there isn't
+  // useful since the agent reads the top frame's a11y tree.
+  topFrameOnly: true,
+  apply,
+  teardown,
+} satisfies Rule;

--- a/extension/src/rules/index.ts
+++ b/extension/src/rules/index.ts
@@ -6,6 +6,7 @@ import { attributeInjectionSanitizeRule } from "./attribute-injection-sanitize";
 import { cartAddonAnnotateRule } from "./cart-addon-annotate";
 import { chatWidgetHideRule } from "./chat-widget-hide";
 import { checkoutCheckboxSanitizeRule } from "./checkout-checkbox-sanitize";
+import { closedShadowRootAnnotateRule } from "./closed-shadow-root-annotate";
 import { commentsRedactRule } from "./comments-redact";
 import { confirmshameSanitizeRule } from "./confirmshame-sanitize";
 import { cookieBannerHideRule } from "./cookie-banner-hide";
@@ -88,6 +89,7 @@ const RULES_TUPLE = [
   disguisedAdFlagRule,
   encodedPayloadRedactRule,
   webdriverProbeAnnotateRule,
+  closedShadowRootAnnotateRule,
 ] as const satisfies readonly Rule[];
 
 export type RuleId = (typeof RULES_TUPLE)[number]["id"];

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -42,6 +42,7 @@ export const RULE_DEFAULTS = {
   "disguised-ad-flag": true,
   "encoded-payload-redact": true,
   "webdriver-probe-annotate": false,
+  "closed-shadow-root-annotate": false,
 } as const satisfies Readonly<Record<string, boolean>>;
 
 export type RuleId = keyof typeof RULE_DEFAULTS;


### PR DESCRIPTION
## Summary

- New off-by-default rule `closed-shadow-root-annotate` that prepends a screen-reader-only landmark when the page looks like it's rendering content inside a closed shadow root. Complements the Tier-1/2/3 open-shadow plumbing from #164 by surfacing the remaining gap to the agent at read-time.
- Heuristic: upgraded custom element (hyphenated tag, defined in `customElements`) with `shadowRoot === null`, no light-DOM content, non-zero rendered box. UA-shadowed built-ins drop out for free because their tag names contain no hyphen. Header comment documents the known false positive (canvas / `::before`-rendering custom elements) and false negatives (declarative shadow DOM, closed shadows on non-custom hosts).
- A main-world `attachShadow` probe (same delivery pattern as `webdriver-probe-annotate`) would give a definitive signal and catch closed shadows on non-custom hosts. Flagged as future work in the rule header; deferred to keep this a single-file isolated-world change while the heuristic's false-positive rate is characterized in the wild.

## Test plan

- [ ] Toggle the rule on in the popup; load a page with a real closed-shadow widget (e.g., a hardened chat embed); confirm the popup shows a `closed-shadow-root` detection and the screen-reader landmark is reachable in the a11y tree.
- [ ] Load a page with only `<input type=range>` / `<details>` / `<video>` (UA shadows); confirm no detection fires.
- [ ] Load a page with a regular open-shadow custom element (e.g., a Lit widget with `mode: "open"`); confirm no detection fires.
- [ ] Toggle the rule off; confirm the landmark is removed.
- [x] `bun run preflight` (1353 tests, lint, typecheck, knip all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)