### PR TITLE
Feat: add Configure rules button in popup

### DIFF
--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -110,6 +110,27 @@
         outline: 2px solid #2563eb;
         outline-offset: 2px;
       }
+      .open-options {
+        display: block;
+        width: 100%;
+        margin: 0 0 12px;
+        padding: 8px 10px;
+        font: inherit;
+        font-weight: 600;
+        color: #fff;
+        background: #2563eb;
+        border: 1px solid #2563eb;
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      .open-options:hover {
+        background: #1d4ed8;
+        border-color: #1d4ed8;
+      }
+      .open-options:focus-visible {
+        outline: 2px solid #2563eb;
+        outline-offset: 2px;
+      }
       .detections {
         margin: 0 0 12px;
       }

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -51,6 +51,17 @@ export function Popup() {
           </p>
         )}
       </div>
+      <button
+        type="button"
+        className="open-options"
+        onClick={() => {
+          chrome.runtime.openOptionsPage(() => {
+            window.close();
+          });
+        }}
+      >
+        Configure rules
+      </button>
       <DetectionsSection />
       <label className="options-button-toggle">
         <span className="options-button-toggle__text">


### PR DESCRIPTION
## Summary
- Adds a primary **Configure rules** button to the popup that opens the options page and closes the popup, since rule toggles now live there (follow-up to #171).

## Test plan
- [ ] Load the unpacked extension, open the popup, click **Configure rules** — options page opens, popup closes.
- [ ] Keyboard focus reaches the button and the focus ring is visible.