### PR TITLE
Docs: sync config skill + rule counts to current behavior

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: agent-browser-shield
-description: Browser extension with 30+ rules for keeping your AI agent safe while browsing.
+description: Browser extension with 35+ rules for keeping your AI agent safe while browsing.
 ---
 
 import { Aside, Card, CardGrid, LinkButton } from "@astrojs/starlight/components";

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -3,7 +3,7 @@ title: Rules reference
 description: The defense rules shipped with agent-browser-shield, what each one does, and its default state.
 ---
 
-The extension ships 35 rules, each independently toggleable from the extension's
+The extension ships 36 rules, each independently toggleable from the extension's
 options page. Rules marked **default: on** are active on fresh install;
 **default: off** rules must be enabled manually.
 

--- a/skills/agent-browser-shield-config/SKILL.md
+++ b/skills/agent-browser-shield-config/SKILL.md
@@ -11,8 +11,9 @@ on the next page load.
 ## Opening the options page
 
 Humans: right-click the toolbar icon → *Options*, or go to `chrome://extensions`
-→ *Details* → *Extension options*. The popup (toolbar icon click) exposes the
-same per-rule toggles.
+→ *Details* → *Extension options*. The popup (toolbar icon click) shows the
+enforcement switch, per-rule activity counts, and a *Configure rules* button
+that opens the options page — per-rule toggles live only on the options page.
 
 Builds may also enable a floating **shield-icon badge** in the bottom-right
 corner of every page — a circular button with `[data-abs="open-options"]` and


### PR DESCRIPTION
## Summary
- **Config skill**: drop the stale claim that the popup exposes per-rule toggles. #171 moved them to the options page; the popup now shows the enforcement switch, per-rule activity counts (#174), and a *Configure rules* button (#172) that opens options.
- **rules.md**: bump count 35 → 36 for `closed-shadow-root-annotate` (added in #169 but the header count wasn't updated).
- **index.mdx**: bump marketing floor 30+ → 35+ so the site description matches the rules reference.

## Test plan
- [x] `bun run check` in `extension/`
- [x] `bun run check` in `docs/` (astro check + biome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)