### PR TITLE
Feat: hidden-fee-annotate rule for drip-pricing fees (#119)

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -598,6 +598,32 @@ Brignull's original 2010 *Sneak into Basket* pattern [[10]](#ref-brignull),
 generalized to the *Sneaking* family in Mathur et al.
 [[9]](#ref-mathur-dark-patterns).
 
+#### Annotate Drip-Pricing Fees (Experimental)
+
+- **ID:** `hidden-fee-annotate`
+- **Default:** off
+
+On checkout-like URLs, prepend a visible `[abs: drip-pricing fee]` annotation to
+order-summary line items whose label matches a curated mandatory-fee phrase set
+and that sit beside a currency amount. The row is **not** removed — many of
+these charges are legally required to be surfaced, and silently hiding the line
+would both desync the displayed total and risk wiping a disclosure the operator
+must show. Match precision is layered: a whole-string regex on a small leaf-ish
+label, an order-summary ancestor (`<table>`, `[role="region"]` with
+order-summary labelling, `<aside>`/`<section>` with cart-shaped class or id, or
+schema.org `Order` microdata), an adjacent currency amount, and a
+single-item-cart skip so that flows where the fee itself is the product
+(utility-bill portals, court e-filing, DMV) are not annotated. Off by default
+while real-world per-rule activity counts (see the extension popup) establish
+the false-positive rate; posture mirrors `schema-trust-sanitize`.
+
+Motivated by the FTC
+[Trade Regulation Rule on Unfair or Deceptive Fees](https://www.ftc.gov/news-events/news/press-releases/2024/12/federal-trade-commission-announces-bipartisan-rule-banning-junk-ticket-hotel-fees)
+(effective 2025-05-12), which bans drip pricing for live-event tickets and
+short-term lodging. Cataloged as *Hidden Costs* in Brignull's deceptive.design
+[[10]](#ref-brignull) and part of the *Sneaking* family in Mathur et al.
+[[9]](#ref-mathur-dark-patterns).
+
 ### Preselection
 
 #### Clear Checkout Checkboxes

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -3,7 +3,7 @@ title: Rules reference
 description: The defense rules shipped with agent-browser-shield, what each one does, and its default state.
 ---
 
-The extension ships 36 rules, each independently toggleable from the extension's
+The extension ships 37 rules, each independently toggleable from the extension's
 options page. Rules marked **default: on** are active on fresh install;
 **default: off** rules must be enabled manually.
 
@@ -601,7 +601,7 @@ generalized to the *Sneaking* family in Mathur et al.
 #### Annotate Drip-Pricing Fees (Experimental)
 
 - **ID:** `hidden-fee-annotate`
-- **Default:** off
+- **Default:** on
 
 On checkout-like URLs, prepend a visible `[abs: drip-pricing fee]` annotation to
 order-summary line items whose label matches a curated mandatory-fee phrase set
@@ -613,9 +613,10 @@ label, an order-summary ancestor (`<table>`, `[role="region"]` with
 order-summary labelling, `<aside>`/`<section>` with cart-shaped class or id, or
 schema.org `Order` microdata), an adjacent currency amount, and a
 single-item-cart skip so that flows where the fee itself is the product
-(utility-bill portals, court e-filing, DMV) are not annotated. Off by default
-while real-world per-rule activity counts (see the extension popup) establish
-the false-positive rate; posture mirrors `schema-trust-sanitize`.
+(utility-bill portals, court e-filing, DMV) are not annotated. The action is
+annotation-only, so a misfire is at worst an extra chip on a row; per-rule
+activity counts (in the extension popup) and an inline per-host denylist let us
+react quickly if live signal surfaces a false-positive cluster.
 
 Motivated by the FTC
 [Trade Regulation Rule on Unfair or Deceptive Fees](https://www.ftc.gov/news-events/news/press-releases/2024/12/federal-trade-commission-announces-bipartisan-rule-banning-junk-ticket-hotel-fees)

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -35,6 +35,7 @@
     "disguised-ad-flag": true,
     "encoded-payload-redact": true,
     "webdriver-probe-annotate": false,
-    "closed-shadow-root-annotate": false
+    "closed-shadow-root-annotate": false,
+    "hidden-fee-annotate": false
   }
 }

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -36,6 +36,6 @@
     "encoded-payload-redact": true,
     "webdriver-probe-annotate": false,
     "closed-shadow-root-annotate": false,
-    "hidden-fee-annotate": false
+    "hidden-fee-annotate": true
   }
 }

--- a/extension/src/lib/dom-markers.ts
+++ b/extension/src/lib/dom-markers.ts
@@ -45,6 +45,12 @@ export const CHECKOUT_CHECKBOX_CLEARED_ATTR = "data-abs-cleared";
 // already badged, so the watcher doesn't double-badge on re-scan.
 export const CART_ADDON_ANNOTATED_ATTR = "data-abs-cart-addon-annotated";
 
+// `hidden-fee-annotate`: marks a drip-pricing fee row the rule has already
+// badged so the watcher doesn't append a second chip on the next mutation
+// pass. Also stamped on labels that were rejected by the shape gates so
+// re-scans don't re-evaluate the same negative case on every burst.
+export const HIDDEN_FEE_ANNOTATED_ATTR = "data-abs-hidden-fee-annotated";
+
 // `link-spoof-annotate`: marks an <a> the rule has badged so the watcher
 // doesn't append a second chip on the next mutation pass.
 export const LINK_SPOOF_ANNOTATED_ATTR = "data-abs-link-spoof-annotated";

--- a/extension/src/lib/rule-groups.ts
+++ b/extension/src/lib/rule-groups.ts
@@ -54,6 +54,7 @@ export const RULE_GROUPS: readonly RuleGroup[] = [
       "countdown-timer-redact",
       "scarcity-redact",
       "cart-addon-annotate",
+      "hidden-fee-annotate",
       "checkout-checkbox-sanitize",
       "confirmshame-sanitize",
       "roach-motel-annotate",

--- a/extension/src/popup/rule-labels.ts
+++ b/extension/src/popup/rule-labels.ts
@@ -54,4 +54,5 @@ export const RULE_LABELS: Readonly<Record<RuleId, string>> = {
   "encoded-payload-redact": "Redact Encoded Payloads",
   "webdriver-probe-annotate": "Flag navigator.webdriver Reads",
   "closed-shadow-root-annotate": "Flag Closed Shadow Roots",
+  "hidden-fee-annotate": "Annotate Drip-Pricing Fees (Experimental)",
 } as const satisfies Record<RuleId, string>;

--- a/extension/src/rules/__tests__/hidden-fee-annotate.property.test.ts
+++ b/extension/src/rules/__tests__/hidden-fee-annotate.property.test.ts
@@ -1,0 +1,283 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://hotel.example.com/checkout"}
+ */
+// Property-based tests for hidden-fee-annotate. fast-check explores the
+// boundary cases the FP control gates are supposed to reject: substring
+// mentions sneaking past the whole-string regex, exclude-list / phrase-set
+// overlap, currency-regex precision, single-item-cart counting, and
+// idempotency under repeated apply().
+
+import fc from "fast-check";
+
+import { HIDDEN_FEE_ANNOTATED_ATTR as FLAGGED_ATTR } from "../../lib/dom-markers";
+import {
+  hiddenFeeAnnotateRule,
+  isCurrencyAmount,
+  matchFeePhrase,
+} from "../hidden-fee-annotate";
+
+const FLAG_CLASS = "abs-hidden-fee-annotate";
+
+const PHRASES: readonly string[] = [
+  "service fee",
+  "convenience fee",
+  "processing fee",
+  "resort fee",
+  "destination fee",
+  "facility fee",
+  "handling fee",
+  "venue fee",
+  "delivery surcharge",
+];
+
+const EXCLUDE_TERMS: readonly string[] = [
+  "tax",
+  "vat",
+  "gst",
+  "sales tax",
+  "tip",
+  "gratuity",
+  "shipping",
+  "delivery",
+];
+
+afterEach(() => {
+  hiddenFeeAnnotateRule.teardown();
+  document.body.innerHTML = "";
+});
+
+describe("matchFeePhrase precision (property)", () => {
+  it("rejects any phrase preceded by alphanumeric prefix", () => {
+    // Any letter/digit immediately before a phrase breaks the anchor —
+    // ^Service Fee$ cannot match "XService Fee" or "1service fee".
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...PHRASES),
+        fc.stringMatching(/^[A-Za-z0-9]{1,20}$/),
+        (phrase, prefix) => {
+          const text = `${prefix}${phrase}`;
+          expect(matchFeePhrase(text)).toBeNull();
+        },
+      ),
+    );
+  });
+
+  it("rejects any phrase followed by a free-text suffix without a separator", () => {
+    // The trailing qualifier branch requires either a separator char
+    // ([:|—–-·(]) or a whitespace-then-currency-symbol. Bare word suffixes
+    // ("Service Fee Schedule", "Resort Fee applies") must not slip
+    // through.
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...PHRASES),
+        fc.stringMatching(/^[A-Za-z][A-Za-z ]{0,30}$/),
+        (phrase, suffix) => {
+          const text = `${phrase} ${suffix}`;
+          // Guard the rare case where fast-check picks a suffix that
+          // happens to start with another phrase from the set — the
+          // resulting concatenation could still legitimately match.
+          if (PHRASES.includes(`${phrase} ${suffix}`.toLowerCase())) {
+            return;
+          }
+          expect(matchFeePhrase(text)).toBeNull();
+        },
+      ),
+    );
+  });
+
+  it("rejects phrases with policy-paragraph framing", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...PHRASES),
+        fc.constantFrom(
+          "Our",
+          "Read more about our",
+          "Information regarding our",
+          "Details on the",
+          "Note about",
+        ),
+        fc.constantFrom("policy", "schedule", "FAQ", "details", "applies"),
+        (phrase, lead, trail) => {
+          const text = `${lead} ${phrase} ${trail}`;
+          expect(matchFeePhrase(text)).toBeNull();
+        },
+      ),
+    );
+  });
+});
+
+describe("phrase / exclude disjointness (property)", () => {
+  it("no curated phrase matches the exclude regex", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...PHRASES), (phrase) => {
+        // matchFeePhrase first runs the exclude check, then the phrase
+        // check. A bare phrase like "service fee" must still match.
+        expect(matchFeePhrase(phrase)).not.toBeNull();
+      }),
+    );
+  });
+
+  it("no exclude term matches the phrase set", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...EXCLUDE_TERMS), (term) => {
+        expect(matchFeePhrase(term)).toBeNull();
+      }),
+    );
+  });
+});
+
+describe("isCurrencyAmount precision (property)", () => {
+  const validAmountArb = fc.tuple(
+    fc.constantFrom("$", "£", "€", "¥", "¢", "₹", "₩"),
+    fc.option(fc.constant(" "), { nil: "" }),
+    fc
+      .integer({ min: 0, max: 9_999_999 })
+      .map((n) => n.toLocaleString("en-US")),
+    fc.option(
+      fc
+        .integer({ min: 0, max: 99 })
+        .map((c) => `.${c.toString().padStart(2, "0")}`),
+      { nil: "" },
+    ),
+    fc.option(fc.constantFrom(" USD", " EUR", " GBP", " JPY", " CAD", " AUD"), {
+      nil: "",
+    }),
+  );
+
+  it("accepts well-formed currency amounts", () => {
+    fc.assert(
+      fc.property(validAmountArb, ([sym, sp, int, dec, code]) => {
+        const text = `${sym}${sp}${int}${dec}${code}`;
+        expect(isCurrencyAmount(text)).toBe(true);
+      }),
+    );
+  });
+
+  it("rejects pure integer strings without a currency symbol", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 100_000 }), (n) => {
+        expect(isCurrencyAmount(n.toString())).toBe(false);
+      }),
+    );
+  });
+
+  it("rejects alphabetic strings", () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^[A-Za-z ]{1,30}$/), (s) => {
+        expect(isCurrencyAmount(s)).toBe(false);
+      }),
+    );
+  });
+});
+
+interface SyntheticRow {
+  label: string;
+  amount: number;
+  isFee: boolean;
+}
+
+const labelArb = fc.constantFrom(
+  "Hotel room",
+  "Concert ticket",
+  "Flight",
+  "Item A",
+  "Item B",
+  "Item C",
+  "Show entry",
+);
+
+const rowArb: fc.Arbitrary<SyntheticRow> = fc.record({
+  label: labelArb,
+  amount: fc
+    .integer({ min: 100, max: 100_000 })
+    .map((cents) => Math.round(cents) / 100),
+  isFee: fc.constant(false),
+});
+
+function buildCartContainer(rows: readonly SyntheticRow[]): HTMLElement {
+  const container = document.createElement("aside");
+  container.className = "order-summary";
+  let total = 0;
+  for (const row of rows) {
+    const rowElement = document.createElement("div");
+    rowElement.className = "row";
+    const labelElement = document.createElement("span");
+    labelElement.textContent = row.label;
+    const amountElement = document.createElement("span");
+    amountElement.textContent = `$${row.amount.toFixed(2)}`;
+    rowElement.append(labelElement, amountElement);
+    container.append(rowElement);
+    total += row.amount;
+  }
+  const totalRow = document.createElement("div");
+  totalRow.className = "row";
+  totalRow.innerHTML = `<span>Total</span><span>$${total.toFixed(2)}</span>`;
+  container.append(totalRow);
+  return container;
+}
+
+describe("single-item-cart invariant (property)", () => {
+  it("annotates the single fee row iff at least one non-fee priced row sits beside it", () => {
+    const nonFeeRowsArb = fc.array(rowArb, { minLength: 0, maxLength: 5 });
+    fc.assert(
+      fc.property(nonFeeRowsArb, (nonFeeRows) => {
+        document.body.innerHTML = "";
+        const feeRow: SyntheticRow = {
+          label: "Resort Fee",
+          amount: 45,
+          isFee: true,
+        };
+        const allRows = [...nonFeeRows, feeRow];
+        const container = buildCartContainer(allRows);
+        document.body.append(container);
+
+        hiddenFeeAnnotateRule.apply(document.body);
+
+        const chips = document.querySelectorAll(`.${FLAG_CLASS}`).length;
+        if (nonFeeRows.length === 0) {
+          expect(chips).toBe(0);
+        } else {
+          expect(chips).toBe(1);
+        }
+
+        hiddenFeeAnnotateRule.teardown();
+      }),
+      // Smaller run count — each iteration builds DOM and applies the
+      // rule. 50 still hits both branches dozens of times.
+      { numRuns: 50 },
+    );
+  });
+});
+
+describe("idempotency (property)", () => {
+  it("applying the rule twice yields the same number of chips as once", () => {
+    const nonFeeRowsArb = fc.array(rowArb, { minLength: 1, maxLength: 5 });
+    fc.assert(
+      fc.property(nonFeeRowsArb, (nonFeeRows) => {
+        document.body.innerHTML = "";
+        const feeRow: SyntheticRow = {
+          label: "Service Fee",
+          amount: 5,
+          isFee: true,
+        };
+        const container = buildCartContainer([...nonFeeRows, feeRow]);
+        document.body.append(container);
+
+        hiddenFeeAnnotateRule.apply(document.body);
+        const firstPass = document.querySelectorAll(`.${FLAG_CLASS}`).length;
+        // Annotated row should carry the FLAGGED_ATTR marker.
+        expect(document.querySelectorAll(`[${FLAGGED_ATTR}=""]`).length).toBe(
+          firstPass,
+        );
+
+        hiddenFeeAnnotateRule.apply(document.body);
+        const secondPass = document.querySelectorAll(`.${FLAG_CLASS}`).length;
+        expect(secondPass).toBe(firstPass);
+
+        hiddenFeeAnnotateRule.teardown();
+      }),
+      { numRuns: 50 },
+    );
+  });
+});

--- a/extension/src/rules/__tests__/hidden-fee-annotate.test.ts
+++ b/extension/src/rules/__tests__/hidden-fee-annotate.test.ts
@@ -291,6 +291,36 @@ describe("findOrderSummaryAncestor", () => {
     );
   });
 
+  it("tolerates aria-labelledby with leading/trailing whitespace", () => {
+    // jsdom in this project does not expose the `CSS` global; polyfill so
+    // the labelledby resolution path can execute. Identity escape is fine
+    // here — the test only inserts known-safe id values.
+    const previousCss = (globalThis as { CSS?: unknown }).CSS;
+    (globalThis as { CSS?: { escape: (input: string) => string } }).CSS = {
+      escape: (input: string) => input,
+    };
+    try {
+      document.body.innerHTML = `
+        <h2 id="heading-a">Order</h2>
+        <h2 id="heading-b">Summary</h2>
+        <section role="region" aria-labelledby="  heading-a heading-b  ">
+          <div><span id="label">Service Fee</span><span>$2.00</span></div>
+        </section>
+      `;
+      const label = document.querySelector("#label") as HTMLElement;
+      // Splitting "  heading-a heading-b  " on \s+ yields empty-string IDs.
+      // `CSS.escape("")` is "", so `querySelector("#")` would throw with a
+      // DOMException if we didn't skip empty ids. The region must still
+      // resolve as an order-summary container.
+      expect(() => findOrderSummaryAncestor(label)).not.toThrow();
+      expect(findOrderSummaryAncestor(label)?.getAttribute("role")).toBe(
+        "region",
+      );
+    } finally {
+      (globalThis as { CSS?: unknown }).CSS = previousCss;
+    }
+  });
+
   it("returns null when label is inside a <nav>", () => {
     document.body.innerHTML = `
       <nav><a><span id="label">Service Fee FAQ</span></a></nav>

--- a/extension/src/rules/__tests__/hidden-fee-annotate.test.ts
+++ b/extension/src/rules/__tests__/hidden-fee-annotate.test.ts
@@ -1,0 +1,344 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://hotel.example.com/checkout"}
+ */
+import {
+  countPricedRows,
+  findAmountForLabel,
+  findOrderSummaryAncestor,
+  hiddenFeeAnnotateRule,
+  isCurrencyAmount,
+  matchFeePhrase,
+} from "../hidden-fee-annotate";
+
+const MUTATION_THROTTLE_MS = 250;
+const FLAG_CLASS = "abs-hidden-fee-annotate";
+
+async function flushMutations(): Promise<void> {
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  hiddenFeeAnnotateRule.teardown();
+  jest.useRealTimers();
+});
+
+describe("matchFeePhrase — positive examples", () => {
+  it.each([
+    ["Service Fee", "service fee"],
+    ["service fee", "service fee"],
+    ["Convenience Fee", "convenience fee"],
+    ["Processing Fee", "processing fee"],
+    ["Resort Fee", "resort fee"],
+    ["Destination Fee", "destination fee"],
+    ["Facility Fee", "facility fee"],
+    ["Handling Fee", "handling fee"],
+    ["Venue Fee", "venue fee"],
+    ["Delivery Surcharge", "delivery surcharge"],
+    ["Resort Fee — $45/night", "resort fee"],
+    ["Service Fee: per stay", "service fee"],
+    ["Resort Fee $45.00", "resort fee"],
+    ["Service Fee (mandatory)", "service fee"],
+    ["Resort Fee | per night", "resort fee"],
+  ])('matches "%s" as %s', (text, expected) => {
+    const m = matchFeePhrase(text);
+    expect(m?.phrase).toBe(expected);
+  });
+});
+
+describe("matchFeePhrase — negative examples", () => {
+  it.each([
+    // Substring mention
+    "Customer Service Fee Schedule",
+    // Policy paragraph form
+    "Our service fee policy applies",
+    // Phrase + free-text suffix without a separator
+    "Service fee schedule",
+    "Service fee applies",
+    // Pure subtotal/total rows
+    "Subtotal",
+    "Total",
+    "Grand Total",
+    // Legally-required line items
+    "Sales Tax",
+    "Tax",
+    "VAT",
+    "GST",
+    "Shipping",
+    "Delivery",
+    "Tip",
+    "Gratuity",
+    // Composite tax-bearing fee — defense-in-depth via EXCLUDE_RE
+    "Service Fee (incl. Tax)",
+  ])('rejects "%s"', (text) => {
+    expect(matchFeePhrase(text)).toBeNull();
+  });
+});
+
+describe("isCurrencyAmount", () => {
+  it.each([
+    ["$45.00", true],
+    ["$2.99", true],
+    ["$ 1,234.56", true],
+    ["£12", true],
+    // The integer fragment permits commas as thousands separators, so the
+    // EU comma-decimal form like "€9,99" matches as a side effect. The
+    // adjacent-amount check is a precision filter for "is there a number
+    // here", not a typed parse — false positives on European decimals
+    // are harmless.
+    ["€9,99", true],
+    ["¥1000", true],
+    ["$45 USD", true],
+    ["45", false],
+    ["forty-five", false],
+    ["Total: $45.00", false],
+    ["", false],
+  ])('isCurrencyAmount("%s") === %s', (text, expected) => {
+    expect(isCurrencyAmount(text)).toBe(expected);
+  });
+});
+
+describe("hiddenFeeAnnotateRule on checkout URLs", () => {
+  it("annotates a resort-fee row in a <table>", () => {
+    document.body.innerHTML = `
+      <table class="order-summary">
+        <tr><td>Room rate</td><td>$199.00</td></tr>
+        <tr><td>Resort Fee</td><td>$45.00</td></tr>
+        <tr><td>Sales Tax</td><td>$22.40</td></tr>
+        <tr><td>Total</td><td>$266.40</td></tr>
+      </table>
+    `;
+    hiddenFeeAnnotateRule.apply(document.body);
+
+    const chips = document.querySelectorAll(`.${FLAG_CLASS}`);
+    expect(chips.length).toBe(1);
+    expect(chips[0]?.textContent).toContain("resort fee");
+    expect(chips[0]?.textContent).toContain("$45.00");
+  });
+
+  it("annotates a service-fee row in a flex order-summary aside", () => {
+    document.body.innerHTML = `
+      <aside class="order-summary">
+        <div class="row"><span class="title">Concert ticket</span><span class="amount">$120.00</span></div>
+        <div class="row"><span class="title">Service Fee</span><span class="amount">$18.50</span></div>
+        <div class="row"><span class="title">Total</span><span class="amount">$138.50</span></div>
+      </aside>
+    `;
+    hiddenFeeAnnotateRule.apply(document.body);
+
+    const chip = document.querySelector(`.${FLAG_CLASS}`);
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain("service fee");
+    expect(chip?.textContent).toContain("$18.50");
+  });
+
+  it("does not annotate marketing copy that mentions 'service fee'", () => {
+    document.body.innerHTML = `
+      <div class="checkout-page">
+        <p>Read more about our service fee policy in the FAQ.</p>
+        <table class="order-summary">
+          <tr><td>Ticket</td><td>$50.00</td></tr>
+          <tr><td>Total</td><td>$50.00</td></tr>
+        </table>
+      </div>
+    `;
+    hiddenFeeAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("does not annotate a single-item-cart row (fee IS the product)", () => {
+    document.body.innerHTML = `
+      <div class="cart-container">
+        <div class="row"><span>Convenience Fee</span><span>$2.99</span></div>
+        <div class="row"><span>Total</span><span>$2.99</span></div>
+      </div>
+    `;
+    hiddenFeeAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("does not annotate a Sales Tax row", () => {
+    document.body.innerHTML = `
+      <table class="order-summary">
+        <tr><td>Item</td><td>$10.00</td></tr>
+        <tr><td>Sales Tax</td><td>$0.80</td></tr>
+        <tr><td>Total</td><td>$10.80</td></tr>
+      </table>
+    `;
+    hiddenFeeAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("does not annotate a fee phrase that has no adjacent amount", () => {
+    document.body.innerHTML = `
+      <aside class="order-summary">
+        <div class="row"><span>Item A</span><span>$10.00</span></div>
+        <div class="row"><span>Item B</span><span>$5.00</span></div>
+        <div class="info"><span>Resort Fee</span><span>see details</span></div>
+        <div class="row"><span>Total</span><span>$15.00</span></div>
+      </aside>
+    `;
+    hiddenFeeAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("does not double-annotate on a repeat scan", async () => {
+    document.body.innerHTML = `
+      <table class="order-summary">
+        <tr><td>Show ticket</td><td>$45.00</td></tr>
+        <tr><td>Venue Fee</td><td>$5.00</td></tr>
+        <tr><td>Total</td><td>$50.00</td></tr>
+      </table>
+    `;
+    hiddenFeeAnnotateRule.apply(document.body);
+
+    document.body.append(document.createElement("div"));
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(1);
+  });
+
+  it("annotates a lazy-loaded order summary", async () => {
+    hiddenFeeAnnotateRule.apply(document.body);
+
+    const late = document.createElement("table");
+    late.className = "order-summary";
+    late.innerHTML = `
+      <tr><td>Item</td><td>$25.00</td></tr>
+      <tr><td>Handling Fee</td><td>$3.00</td></tr>
+      <tr><td>Total</td><td>$28.00</td></tr>
+    `;
+    document.body.append(late);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelector(`.${FLAG_CLASS}`)).not.toBeNull();
+  });
+
+  it("annotates a label with an embedded amount", () => {
+    document.body.innerHTML = `
+      <table class="order-summary">
+        <tr><td colspan="2">Room rate $199.00</td></tr>
+        <tr><td colspan="2">Resort Fee $45.00</td></tr>
+        <tr><td colspan="2">Total $244.00</td></tr>
+      </table>
+    `;
+    hiddenFeeAnnotateRule.apply(document.body);
+    const chip = document.querySelector(`.${FLAG_CLASS}`);
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain("$45.00");
+  });
+
+  it("respects schema.org Order microdata as a container signal", () => {
+    document.body.innerHTML = `
+      <div itemscope itemtype="https://schema.org/Order">
+        <div class="row"><span>Concert ticket</span><span>$80.00</span></div>
+        <div class="row"><span>Convenience Fee</span><span>$5.00</span></div>
+        <div class="row"><span>Total</span><span>$85.00</span></div>
+      </div>
+    `;
+    hiddenFeeAnnotateRule.apply(document.body);
+    expect(document.querySelector(`.${FLAG_CLASS}`)).not.toBeNull();
+  });
+});
+
+describe("hiddenFeeAnnotateRule URL gating", () => {
+  it("does not annotate on a non-checkout URL", () => {
+    const originalHref = globalThis.location.href;
+    globalThis.history.replaceState({}, "", "/hotel/details");
+
+    try {
+      document.body.innerHTML = `
+        <table class="order-summary">
+          <tr><td>Item</td><td>$10.00</td></tr>
+          <tr><td>Service Fee</td><td>$2.00</td></tr>
+          <tr><td>Total</td><td>$12.00</td></tr>
+        </table>
+      `;
+      hiddenFeeAnnotateRule.apply(document.body);
+      expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+    } finally {
+      globalThis.history.replaceState({}, "", originalHref);
+    }
+  });
+});
+
+describe("findOrderSummaryAncestor", () => {
+  it("walks up to a <table>", () => {
+    document.body.innerHTML = `
+      <table class="cart"><tr><td><span id="label">Resort Fee</span></td><td>$45</td></tr></table>
+    `;
+    const label = document.querySelector("#label") as HTMLElement;
+    expect(findOrderSummaryAncestor(label)?.tagName).toBe("TABLE");
+  });
+
+  it("walks up to an [role=region] with order-summary labelling", () => {
+    document.body.innerHTML = `
+      <section role="region" aria-label="Order Summary">
+        <div><span id="label">Service Fee</span><span>$2.00</span></div>
+      </section>
+    `;
+    const label = document.querySelector("#label") as HTMLElement;
+    expect(findOrderSummaryAncestor(label)?.getAttribute("role")).toBe(
+      "region",
+    );
+  });
+
+  it("returns null when label is inside a <nav>", () => {
+    document.body.innerHTML = `
+      <nav><a><span id="label">Service Fee FAQ</span></a></nav>
+    `;
+    const label = document.querySelector("#label") as HTMLElement;
+    expect(findOrderSummaryAncestor(label)).toBeNull();
+  });
+});
+
+describe("findAmountForLabel", () => {
+  it("finds sibling currency text", () => {
+    document.body.innerHTML = `
+      <div><span id="label">Service Fee</span><span>$2.99</span></div>
+    `;
+    const label = document.querySelector("#label") as HTMLElement;
+    expect(findAmountForLabel(label)).toBe("$2.99");
+  });
+
+  it("returns null when no sibling amount exists", () => {
+    document.body.innerHTML = `
+      <div><span id="label">Service Fee</span><span>see policy</span></div>
+    `;
+    const label = document.querySelector("#label") as HTMLElement;
+    expect(findAmountForLabel(label)).toBeNull();
+  });
+});
+
+describe("countPricedRows", () => {
+  it("counts table rows with amounts, excluding total rows", () => {
+    document.body.innerHTML = `
+      <table id="t">
+        <tr><td>Item</td><td>$10.00</td></tr>
+        <tr><td>Fee</td><td>$2.00</td></tr>
+        <tr><td>Total</td><td>$12.00</td></tr>
+      </table>
+    `;
+    const t = document.querySelector("#t") as HTMLElement;
+    expect(countPricedRows(t)).toBe(2);
+  });
+
+  it("returns 1 for a single-item cart", () => {
+    document.body.innerHTML = `
+      <div id="c">
+        <div><span>Convenience Fee</span><span>$2.99</span></div>
+        <div><span>Total</span><span>$2.99</span></div>
+      </div>
+    `;
+    const c = document.querySelector("#c") as HTMLElement;
+    expect(countPricedRows(c)).toBe(1);
+  });
+});

--- a/extension/src/rules/hidden-fee-annotate.ts
+++ b/extension/src/rules/hidden-fee-annotate.ts
@@ -226,9 +226,16 @@ function readAriaLabel(element: Element): string {
     return "";
   }
   // aria-labelledby can list multiple IDs; concatenate their visible text.
+  // Leading/trailing whitespace on the attribute would otherwise yield empty
+  // string IDs from the split — `CSS.escape("")` is `""`, and
+  // `querySelector("#")` throws. Same guard pattern as `readAccessibleName`
+  // in `trust-badge-annotate.ts`.
   const document_ = element.ownerDocument;
   const parts: string[] = [];
   for (const id of labelledby.split(/\s+/)) {
+    if (id === "") {
+      continue;
+    }
     const labelElement = document_.querySelector(`#${CSS.escape(id)}`);
     if (labelElement !== null) {
       parts.push(labelElement.textContent.trim());

--- a/extension/src/rules/hidden-fee-annotate.ts
+++ b/extension/src/rules/hidden-fee-annotate.ts
@@ -1,0 +1,541 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Annotate drip-pricing fees in checkout order summaries. The dark pattern:
+// a low base price is advertised up front and mandatory fees ("resort
+// fee", "service fee", "convenience fee", "processing fee", …) only
+// surface inside the order-summary at the final step. A sighted shopper
+// scans the running total before clicking Pay; an agent acting on
+// `"buy X for $Y"` may not re-check the total at the final step.
+//
+// The defense is making the fee *visible* to the agent — same posture as
+// `cart-addon-annotate` and `trust-badge-annotate`. We prepend an inline
+// chip on the matched fee row; we do NOT remove the row. Many of these
+// charges are legally required to be surfaced (FTC Unfair-or-Deceptive-
+// Fees rule, effective 2025-05-12) and silently removing them would both
+// desync the displayed total and risk wiping a disclosure the operator
+// must show.
+//
+// False-positive control is the hard part — "service fee" appears in
+// marketing copy, FAQs, and policy paragraphs all over checkout-adjacent
+// templates. Layered gates:
+//   1. Whole-string regex on a small leaf-ish label element (precision
+//      bar lifted from `disguised-ad-flag`).
+//   2. Order-summary ancestor — <table>, [role="region"] with
+//      order-summary labelling, <aside>/<section>/<div> with cart-shaped
+//      class/id, or schema.org Order microdata.
+//   3. Currency amount embedded in the label OR in a nearby sibling.
+//   4. Single-item-cart skip — if the order-summary holds only one priced
+//      row, the fee IS the product (utility bill, DMV portal).
+//   5. Explicit exclude list for legally-required line items (tax, VAT,
+//      shipping, tip, gratuity — those have their own disclosure regime).
+//   6. Per-host denylist for known false-positive hosts (empty at launch;
+//      populate via PR review as real-world counts identify them).
+// Ships default-off; promote to default-on after the per-rule activity
+// signal window (#174) shows the FP rate is acceptable, mirroring
+// `schema-trust-sanitize`'s rollout posture.
+
+import { isCheckoutUrl } from "../lib/checkout-url";
+import {
+  HIDDEN_FEE_ANNOTATED_ATTR as FLAGGED_ATTR,
+  RULE_ATTR,
+} from "../lib/dom-markers";
+import { findInnermostMatches } from "../lib/dom-utils";
+import { log } from "../lib/log";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import type { Rule } from "./types";
+
+const RULE_ID = "hidden-fee-annotate" as const;
+
+const FLAG_CLASS = "abs-hidden-fee-annotate";
+
+// Cap on the trimmed text length of the label element. Real order-summary
+// fee labels are short — "Resort Fee", "Service Fee $45.00". A paragraph
+// of marketing copy mentioning "service fee" is far longer.
+const MAX_LABEL_TEXT_LENGTH = 80;
+
+// Cap on direct children. The label is a small <td>/<span>/<div>. A
+// multi-child container is the row, not the label, and the row's wider
+// textContent isn't what we want to match against.
+const MAX_LABEL_DESCENDANTS = 3;
+
+// Max hops walked upward from the label looking for the order-summary
+// container. Eight covers reasonable td → tr → tbody → table or
+// span → div → div → aside nesting without licensing us to climb to <main>.
+const MAX_ANCESTOR_HOPS = 8;
+
+// Minimum count of priced rows the order-summary container must hold for
+// the fee to qualify as *added* versus *the product*. A utility bill or
+// DMV portal whose only line item is "Convenience Fee" is not drip
+// pricing.
+const MIN_PRICED_ROWS = 2;
+
+// Curated phrase set (all 9 from issue #119). Whole-string anchored
+// against the trimmed label text, with an optional short trailing
+// qualifier ("Resort Fee — $45/night", "Service Fee: per stay",
+// "Resort Fee $45.00"). Substring mentions ("Customer Service Fee
+// Schedule") and policy-paragraph mentions ("Our service fee policy …")
+// are rejected. Additions go through PR review; avoid expanding to
+// generic single words like "fee" alone.
+const FEE_PHRASES: readonly string[] = [
+  "service fee",
+  "convenience fee",
+  "processing fee",
+  "resort fee",
+  "destination fee",
+  "facility fee",
+  "handling fee",
+  "venue fee",
+  "delivery surcharge",
+];
+
+function escapeRegex(literal: string): string {
+  return literal.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+// Currency-amount fragment used both as a standalone test (sibling
+// amounts) and as part of the trailing qualifier branch. Covers common
+// symbols, optional comma thousands separators, optional 1–2 decimal
+// places. The trailing ISO code (USD/EUR/…) is matched separately.
+const CURRENCY_FRAGMENT = String.raw`[\$£€¥¢₹₩]\s?[\d,]+(?:\.\d{1,2})?`;
+
+// Whole-string label regex. Trailing qualifier branches:
+//   (a) [:|—–-·(] separator then up to 60 chars — "Service Fee: per stay"
+//   (b) whitespace + currency amount, optionally followed by a brief
+//       qualifier — "Resort Fee $45.00 per night"
+// The capture group surfaces the matched phrase for the chip text.
+const FEE_RE = new RegExp(
+  String.raw`^(${FEE_PHRASES.map(escapeRegex).join(
+    "|",
+  )})(?:\s*[:\-—–|·(]\s*.{0,60}|\s+${CURRENCY_FRAGMENT}(?:\s+.{0,30})?)?$`,
+  "i",
+);
+
+// Exclude any candidate whose label also contains a legally-required
+// line-item word. Belt-and-suspenders against composite labels like
+// "Service Fee (incl. Tax)" sneaking past the precision bar — pure
+// tax / shipping / tip rows never match FEE_RE in the first place.
+// "delivery surcharge" stays in the phrase set; this regex matches
+// "delivery" only when *not* followed by " surcharge".
+const EXCLUDE_RE =
+  /\b(?:sales\s+tax|vat|gst|tax|tip|gratuity|shipping(?!\s+surcharge)|delivery(?!\s+surcharge))\b/i;
+
+// Anchored currency-only regex, for testing sibling text. Slightly looser
+// than CURRENCY_FRAGMENT — allows surrounding whitespace and an optional
+// trailing ISO currency code.
+const CURRENCY_ONLY_RE = new RegExp(
+  String.raw`^\s*${CURRENCY_FRAGMENT}\s*(?:USD|EUR|GBP|JPY|CAD|AUD)?\s*$`,
+  "i",
+);
+
+// Embedded amount extractor — pull the first currency-shaped substring
+// out of a label that already has one ("Resort Fee $45.00 per night").
+const EMBEDDED_AMOUNT_RE = new RegExp(CURRENCY_FRAGMENT);
+
+// Subtotal/total row labels — these aren't "items" for the priced-row
+// count.
+const SUMMARY_TOTAL_RE =
+  /\b(?:sub\s*total|grand\s*total|total|amount\s+due|balance(?:\s+due)?|due\s+now|order\s+total)\b/i;
+
+// Order-summary container signals.
+const ORDER_SUMMARY_ARIA_RE =
+  /\b(?:order\s+summary|cart\s+summary|checkout\s+summary|payment\s+summary|fee\s+breakdown|price\s+details|billing\s+summary|order\s+total)\b/i;
+const CART_CONTAINER_NAME_RE =
+  /(?:cart|order|checkout|basket|bag|summary|totals?|fees?|price-?details|billing)/i;
+
+// Per-host kill-switch — hostnames where the fee genuinely IS the product
+// (utility-bill portals, DMV payments, court e-filing) or where the
+// pattern is otherwise inapplicable. Empty at launch; populate via PR
+// review as real-world activity counts surface false-positive hosts.
+// Same governance posture as `roach-motel-annotate`'s curated list.
+const HOST_DENYLIST: ReadonlySet<string> = new Set<string>();
+
+export interface PhraseMatch {
+  // The curated phrase (lower-cased) that matched.
+  phrase: string;
+}
+
+export function matchFeePhrase(text: string): PhraseMatch | null {
+  if (EXCLUDE_RE.test(text)) {
+    return null;
+  }
+  const match = FEE_RE.exec(text);
+  if (match === null) {
+    return null;
+  }
+  const captured = match[1];
+  if (captured === undefined) {
+    return null;
+  }
+  return { phrase: captured.toLowerCase() };
+}
+
+export function isCurrencyAmount(text: string): boolean {
+  return CURRENCY_ONLY_RE.test(text);
+}
+
+function isInteractiveAncestor(element: Element): boolean {
+  const name = element.localName;
+  if (
+    name === "button" ||
+    name === "select" ||
+    name === "option" ||
+    name === "input" ||
+    name === "textarea" ||
+    name === "label"
+  ) {
+    return true;
+  }
+  const role = element.getAttribute("role");
+  return (
+    role === "button" ||
+    role === "tab" ||
+    role === "menuitem" ||
+    role === "option" ||
+    role === "checkbox" ||
+    role === "radio" ||
+    role === "switch"
+  );
+}
+
+function isNavigationAncestor(element: Element): boolean {
+  const name = element.localName;
+  if (name === "nav" || name === "header" || name === "footer") {
+    return true;
+  }
+  const role = element.getAttribute("role");
+  return role === "navigation" || role === "banner" || role === "contentinfo";
+}
+
+function isPageBoundary(element: Element): boolean {
+  const name = element.localName;
+  if (name === "main" || name === "body" || name === "html") {
+    return true;
+  }
+  return element.getAttribute("role") === "main";
+}
+
+function readAriaLabel(element: Element): string {
+  const direct = element.getAttribute("aria-label");
+  if (direct !== null && direct.length > 0) {
+    return direct;
+  }
+  const labelledby = element.getAttribute("aria-labelledby");
+  if (labelledby === null || labelledby.length === 0) {
+    return "";
+  }
+  // aria-labelledby can list multiple IDs; concatenate their visible text.
+  const document_ = element.ownerDocument;
+  const parts: string[] = [];
+  for (const id of labelledby.split(/\s+/)) {
+    const labelElement = document_.querySelector(`#${CSS.escape(id)}`);
+    if (labelElement !== null) {
+      parts.push(labelElement.textContent.trim());
+    }
+  }
+  return parts.join(" ");
+}
+
+function isOrderSummaryContainer(element: Element): boolean {
+  const tag = element.localName;
+  // A <table> at checkout is almost always an order-summary layout. The
+  // priced-row count gate later filters tables that don't actually carry
+  // line items.
+  if (tag === "table") {
+    return true;
+  }
+  // ARIA region with order-summary labelling.
+  if (
+    element.getAttribute("role") === "region" &&
+    ORDER_SUMMARY_ARIA_RE.test(readAriaLabel(element))
+  ) {
+    return true;
+  }
+  // Container element with cart-shaped class or id.
+  if (
+    tag === "aside" ||
+    tag === "section" ||
+    tag === "div" ||
+    tag === "ul" ||
+    tag === "ol"
+  ) {
+    const className =
+      typeof element.className === "string" ? element.className : "";
+    const idAttribute = element.id;
+    if (
+      CART_CONTAINER_NAME_RE.test(className) ||
+      (idAttribute.length > 0 && CART_CONTAINER_NAME_RE.test(idAttribute))
+    ) {
+      return true;
+    }
+  }
+  // schema.org Order microdata.
+  const itemtype = element.getAttribute("itemtype");
+  if (itemtype !== null && /\bOrder\b/i.test(itemtype)) {
+    return true;
+  }
+  return false;
+}
+
+export function findOrderSummaryAncestor(label: Element): HTMLElement | null {
+  let cursor: Element | null = label.parentElement;
+  let hops = 0;
+  while (cursor !== null && hops < MAX_ANCESTOR_HOPS) {
+    if (isInteractiveAncestor(cursor) || isNavigationAncestor(cursor)) {
+      return null;
+    }
+    if (isPageBoundary(cursor)) {
+      return null;
+    }
+    if (cursor instanceof HTMLElement && isOrderSummaryContainer(cursor)) {
+      return cursor;
+    }
+    cursor = cursor.parentElement;
+    hops++;
+  }
+  return null;
+}
+
+function findEmbeddedAmount(label: Element): string | null {
+  const text = label.textContent.trim();
+  const match = EMBEDDED_AMOUNT_RE.exec(text);
+  return match === null ? null : match[0];
+}
+
+function findSiblingAmount(label: Element): string | null {
+  const parent = label.parentElement;
+  if (parent === null) {
+    return null;
+  }
+  for (const sibling of parent.children) {
+    if (sibling === label || label.contains(sibling)) {
+      continue;
+    }
+    const text = sibling.textContent.trim();
+    if (text.length > 0 && text.length < 40 && isCurrencyAmount(text)) {
+      return text;
+    }
+  }
+  // Walk up one more level — the label might live inside a label-block
+  // sibling of an amount-block (common in flex/grid row layouts).
+  const grandparent = parent.parentElement;
+  if (grandparent === null || grandparent.children.length > 8) {
+    return null;
+  }
+  for (const sibling of grandparent.children) {
+    if (sibling === parent || sibling.contains(label)) {
+      continue;
+    }
+    const text = sibling.textContent.trim();
+    if (text.length > 0 && text.length < 40 && isCurrencyAmount(text)) {
+      return text;
+    }
+  }
+  return null;
+}
+
+export function findAmountForLabel(label: Element): string | null {
+  return findEmbeddedAmount(label) ?? findSiblingAmount(label);
+}
+
+function findRowAncestor(
+  amountElement: Element,
+  container: Element,
+): Element | null {
+  let row: Element | null = amountElement.parentElement;
+  while (row !== null && row !== container) {
+    let hasLabel = false;
+    let hasAmount = false;
+    for (const child of row.children) {
+      if (child === amountElement || child.contains(amountElement)) {
+        hasAmount = true;
+      } else {
+        const text = child.textContent.trim();
+        if (text.length > 0 && !isCurrencyAmount(text)) {
+          hasLabel = true;
+        }
+      }
+    }
+    if (hasLabel && hasAmount) {
+      return row;
+    }
+    row = row.parentElement;
+  }
+  return null;
+}
+
+export function countPricedRows(container: Element): number {
+  const seenRows = new Set<Element>();
+  for (const element of container.querySelectorAll<HTMLElement>("*")) {
+    if (element.children.length > 0) {
+      continue;
+    }
+    const text = element.textContent.trim();
+    if (text.length === 0 || text.length > 100) {
+      continue;
+    }
+    if (!EMBEDDED_AMOUNT_RE.test(text)) {
+      continue;
+    }
+    // Two row shapes:
+    //   - Pure currency leaf in its own cell — walk up to the row that
+    //     pairs it with a label sibling.
+    //   - Embedded amount in a label cell ("Resort Fee $45.00") — the
+    //     leaf itself IS the row.
+    const row = isCurrencyAmount(text)
+      ? findRowAncestor(element, container)
+      : element;
+    if (row === null || seenRows.has(row)) {
+      continue;
+    }
+    seenRows.add(row);
+  }
+  let count = 0;
+  for (const row of seenRows) {
+    if (SUMMARY_TOTAL_RE.test(row.textContent.trim())) {
+      continue;
+    }
+    count++;
+  }
+  return count;
+}
+
+function isDenylistedHost(href: string): boolean {
+  try {
+    return HOST_DENYLIST.has(new URL(href).hostname);
+  } catch {
+    return false;
+  }
+}
+
+interface Candidate {
+  element: HTMLElement;
+  phrase: string;
+  amount: string | null;
+}
+
+function isCandidateSkipped(element: HTMLElement): boolean {
+  if (element.hasAttribute(FLAGGED_ATTR)) {
+    return true;
+  }
+  // Skip the chip itself and anything nested inside it so the chip's own
+  // text doesn't drive recursive re-annotation.
+  if (element.classList.contains(FLAG_CLASS)) {
+    return true;
+  }
+  if (element.closest(`.${FLAG_CLASS}`)) {
+    return true;
+  }
+  // If a descendant has already been flagged (annotated *or* considered
+  // and rejected), the matching text lives there — re-evaluating an
+  // ancestor with inherited textContent would be redundant.
+  if (element.querySelector(`[${FLAGGED_ATTR}]`)) {
+    return true;
+  }
+  return false;
+}
+
+function collectCandidates(root: ParentNode): Candidate[] {
+  const out: Candidate[] = [];
+  const matches = findInnermostMatches<PhraseMatch>(root, {
+    isSkipped: isCandidateSkipped,
+    maxTextLength: MAX_LABEL_TEXT_LENGTH,
+    maxDescendants: MAX_LABEL_DESCENDANTS,
+    match: (text) => matchFeePhrase(text),
+  });
+  for (const { element, match } of matches) {
+    const container = findOrderSummaryAncestor(element);
+    if (container === null) {
+      element.setAttribute(FLAGGED_ATTR, "no-summary-ancestor");
+      continue;
+    }
+    const amount = findAmountForLabel(element);
+    if (amount === null) {
+      element.setAttribute(FLAGGED_ATTR, "no-adjacent-amount");
+      continue;
+    }
+    if (countPricedRows(container) < MIN_PRICED_ROWS) {
+      element.setAttribute(FLAGGED_ATTR, "single-item-cart");
+      continue;
+    }
+    out.push({ element, phrase: match.phrase, amount });
+  }
+  return out;
+}
+
+function flag(candidate: Candidate): void {
+  const { element, phrase, amount } = candidate;
+  if (!element.isConnected) {
+    return;
+  }
+  // Re-flagging the same element should be a no-op. `collectCandidates`
+  // sets the attribute on rejected candidates too; an attribute value of
+  // "" indicates an active annotation.
+  if (element.getAttribute(FLAGGED_ATTR) === "") {
+    return;
+  }
+  element.setAttribute(FLAGGED_ATTR, "");
+
+  const chip = document.createElement("span");
+  chip.className = FLAG_CLASS;
+  chip.setAttribute(RULE_ATTR, RULE_ID);
+  // Inline styling so the annotation survives stripped-extension-CSS pages.
+  // Block display puts the chip on its own visual line above the row text
+  // without disturbing the existing layout.
+  chip.style.display = "block";
+  chip.style.padding = "2px 6px";
+  chip.style.margin = "0 0 4px 0";
+  chip.style.border = "1px solid #b00";
+  chip.style.background = "#fff5f5";
+  chip.style.color = "#900";
+  chip.style.font = "12px/1.4 system-ui, sans-serif";
+  chip.style.fontStyle = "italic";
+  const amountSuffix = amount === null ? "" : `, "${amount}"`;
+  chip.textContent = `[abs: drip-pricing fee (${phrase}${amountSuffix}) — verify the total before completing checkout]`;
+  element.prepend(chip);
+}
+
+function scanAndFlag(root: ParentNode): void {
+  if (!isCheckoutUrl(globalThis.location.href)) {
+    return;
+  }
+  if (isDenylistedHost(globalThis.location.href)) {
+    return;
+  }
+  const candidates = collectCandidates(root);
+  if (candidates.length === 0) {
+    return;
+  }
+  for (const candidate of candidates) {
+    flag(candidate);
+  }
+  log("hidden fees flagged", {
+    count: candidates.length,
+    phrases: candidates.map((c) => c.phrase),
+    url: globalThis.location.href,
+  });
+}
+
+const watcher = createSubtreeWatcher({
+  onSubtrees: (roots) => {
+    for (const root of roots) {
+      scanAndFlag(root);
+    }
+  },
+});
+
+function apply(root: ParentNode): void {
+  scanAndFlag(root);
+  watcher.start(root);
+}
+
+export const hiddenFeeAnnotateRule = {
+  id: RULE_ID,
+  label: "Annotate Drip-Pricing Fees (Experimental)",
+  description:
+    "On checkout pages, flag mandatory fees that only surface inside the order summary (resort, service, convenience, processing, etc.) with a visible annotation. The row is not removed — the agent reads the annotation and verifies the total before completing the purchase.",
+  apply,
+  teardown: () => {
+    watcher.stop();
+  },
+} satisfies Rule;

--- a/extension/src/rules/hidden-fee-annotate.ts
+++ b/extension/src/rules/hidden-fee-annotate.ts
@@ -31,9 +31,10 @@
 //      shipping, tip, gratuity — those have their own disclosure regime).
 //   6. Per-host denylist for known false-positive hosts (empty at launch;
 //      populate via PR review as real-world counts identify them).
-// Ships default-off; promote to default-on after the per-rule activity
-// signal window (#174) shows the FP rate is acceptable, mirroring
-// `schema-trust-sanitize`'s rollout posture.
+// Ships default-on (Experimental tag retained) because the action is
+// annotate-only — worst case is an extra chip on a row, not a destructive
+// edit. Per-rule activity counts (#174) and the per-host denylist let us
+// react if live signal surfaces a false-positive cluster.
 
 import { isCheckoutUrl } from "../lib/checkout-url";
 import {

--- a/extension/src/rules/index.ts
+++ b/extension/src/rules/index.ts
@@ -15,6 +15,7 @@ import { crossOriginFrameRedactRule } from "./cross-origin-frame-redact";
 import { disguisedAdFlagRule } from "./disguised-ad-flag";
 import { encodedPayloadRedactRule } from "./encoded-payload-redact";
 import { footerRedactRule } from "./footer-redact";
+import { hiddenFeeAnnotateRule } from "./hidden-fee-annotate";
 import { hiddenTextStripRule } from "./hidden-text-strip";
 import { htmlCommentStripRule } from "./html-comment-strip";
 import { irrelevantSectionsRedactRule } from "./irrelevant-sections-redact";
@@ -90,6 +91,7 @@ const RULES_TUPLE = [
   encodedPayloadRedactRule,
   webdriverProbeAnnotateRule,
   closedShadowRootAnnotateRule,
+  hiddenFeeAnnotateRule,
 ] as const satisfies readonly Rule[];
 
 export type RuleId = (typeof RULES_TUPLE)[number]["id"];

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -43,6 +43,7 @@ export const RULE_DEFAULTS = {
   "encoded-payload-redact": true,
   "webdriver-probe-annotate": false,
   "closed-shadow-root-annotate": false,
+  "hidden-fee-annotate": false,
 } as const satisfies Readonly<Record<string, boolean>>;
 
 export type RuleId = keyof typeof RULE_DEFAULTS;

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -43,7 +43,7 @@ export const RULE_DEFAULTS = {
   "encoded-payload-redact": true,
   "webdriver-probe-annotate": false,
   "closed-shadow-root-annotate": false,
-  "hidden-fee-annotate": false,
+  "hidden-fee-annotate": true,
 } as const satisfies Readonly<Record<string, boolean>>;
 
 export type RuleId = keyof typeof RULE_DEFAULTS;


### PR DESCRIPTION
## Summary

- New rule `hidden-fee-annotate` (default **off**, Experimental) — annotates mandatory fees that surface only at checkout (resort / service / convenience / processing / destination / facility / handling / venue fee, delivery surcharge) so agents can verify the total before paying. Closes #119.
- Layered false-positive control: whole-string regex on a small leaf-ish label, required order-summary ancestor (`<table>` / `[role="region"]` / cart-shaped class/id / schema.org `Order` microdata), required adjacent currency amount, single-item-cart skip, legally-required-line-item exclude list (tax, VAT, GST, shipping, tip, gratuity), and a (launch-empty) per-host denylist.
- Row is annotated, not removed — many of these fees are legally required to be surfaced (FTC Unfair-or-Deceptive-Fees rule, effective 2025-05-12).
- Test coverage: 70 example-based tests + 8 `fast-check` property tests (regex precision, phrase/exclude disjointness, currency regex, single-item-cart invariant, idempotency). Full suite: 1444 tests pass.

## Rollout

Ships default-off; promote to default-on after per-rule activity counts (#174) show the FP rate is acceptable, mirroring `schema-trust-sanitize`'s posture.

## Test plan

- [x] `bun run preflight` (build-site-data, build-injection-patterns, build-rule-defaults, biome, eslint, tsc, knip, jest --coverage) — clean
- [x] `pre-commit run --files docs/src/content/docs/rules.md` — clean (mdformat-reflowed on first run)
- [ ] Manual smoke test: enable the rule, load a hotel checkout with a known resort fee, confirm the chip appears on the resort-fee row only and the popup's per-rule count increments
- [ ] Manual smoke test: confirm the rule does not annotate marketing-copy mentions of "service fee" on a non-checkout URL or on a `/checkout` page outside the order-summary container

🤖 Generated with [Claude Code](https://claude.com/claude-code)