### PR TITLE
Docs: note accepted gap for enabled input value inside hidden wrapper

### DIFF
--- a/extension/src/rules/attribute-injection-sanitize.ts
+++ b/extension/src/rules/attribute-injection-sanitize.ts
@@ -17,6 +17,15 @@
 // would use to plant a "pre-confirmed" instruction that the agent
 // treats as load-bearing while the user has no chance to clear it.
 //
+// Accepted limitation: an enabled `<input value="…">` sitting inside a
+// CSS-hidden wrapper (`visibility:hidden`, off-left, opacity:0) is not
+// scrubbed. The same asymmetry as the disabled case applies — the user
+// can't see or edit the value — but matching it would require a
+// computed-style check at scrub time, which conflicts with this rule's
+// lightweight attribute-driven watcher. Pre-#176 these were caught when
+// `hidden-text-strip` detached the wrapper; the regression is accepted
+// because the trigger surface is narrow (enabled input + hidden wrapper).
+//
 // On a match we remove the whole attribute rather than blanking its
 // value. An empty `aria-label` actively hides an element from
 // accessibility-tree consumers (which is worse than no aria-label,


### PR DESCRIPTION
## Summary

Doc-only follow-up to the #179 audit of `INJECTION_PATTERNS` coverage after #176. Adds a paragraph to `attribute-injection-sanitize`'s docstring describing the one accepted gap: an enabled `<input value="…">` sitting inside a CSS-hidden wrapper is no longer scrubbed (pre-#176, `hidden-text-strip`'s wrapper detach took it).

The same asymmetry as the existing `input[disabled][value]` case applies (user can't see or edit), but closing it would need a computed-style check at scrub time, which conflicts with the rule's lightweight attribute-driven watcher. Documented as accepted; trigger surface is narrow.

The other two audit gaps are tracked as separate issues:

- #182 — extend `CANDIDATE_ATTRIBUTES` to cover `aria-roledescription`, `aria-placeholder`, `aria-valuetext`, `aria-keyshortcuts`
- #183 — scrub `value` on `input[type="hidden"]`

## Test plan

- [x] `bun run check` in `extension/` clean
- [ ] No runtime change — docstring only