### PR TITLE
Feat: scrub value on input[type=hidden] in attribute-injection-sanitize

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -252,11 +252,12 @@ HTML metadata is enumerated among the non-rendered carriers in Greshake et al.
 
 Walk every element and, for a small allowlist of agent-readable attributes —
 `aria-label`, `aria-description`, `alt`, `title`, `placeholder`, `data-tooltip`,
-and `value` on disabled `<input>` elements — remove the attribute outright when
-its value matches the prompt-injection pattern set (the same regex bundle used
-by `prompt-injection-redact`). Clean attributes are preserved. Attributes
-outside the allowlist are not inspected. We remove the whole attribute rather
-than blank it because an empty `aria-label` actively hides an element from
+and `value` on `<input>` elements the user cannot reach (`disabled` or
+`type="hidden"`) — remove the attribute outright when its value matches the
+prompt-injection pattern set (the same regex bundle used by
+`prompt-injection-redact`). Clean attributes are preserved. Attributes outside
+the allowlist are not inspected. We remove the whole attribute rather than blank
+it because an empty `aria-label` actively hides an element from
 accessibility-tree consumers, whereas a missing `aria-label` lets fallback name
 computation (visible text, `alt`, associated label) proceed normally.
 

--- a/extension/src/rules/__tests__/attribute-injection-sanitize.property.test.ts
+++ b/extension/src/rules/__tests__/attribute-injection-sanitize.property.test.ts
@@ -6,8 +6,8 @@
 // random benign prefix/suffix noise to confirm the regex set still fires
 // when the payload is embedded inside surrounding text. A negative
 // property covers attributes outside the allowlist (the rule must not
-// touch them) and another covers enabled-input `value` (only `disabled`
-// inputs get their value stripped).
+// touch them) and another covers enabled visible-input `value` (only
+// `disabled` or `type="hidden"` inputs get their value stripped).
 
 import fc from "fast-check";
 
@@ -115,20 +115,24 @@ describe("attribute-injection-sanitize (property)", () => {
     );
   });
 
-  it("strips value on a disabled input carrying injection, leaves enabled inputs alone", () => {
+  it("strips value on disabled and hidden inputs, leaves enabled visible inputs alone", () => {
     fc.assert(
       fc.property(ADVERSARIAL, (payload) => {
         document.body.innerHTML = "";
         const disabled = document.createElement("input");
         disabled.setAttribute("disabled", "");
         disabled.setAttribute("value", payload);
+        const hidden = document.createElement("input");
+        hidden.setAttribute("type", "hidden");
+        hidden.setAttribute("value", payload);
         const enabled = document.createElement("input");
         enabled.setAttribute("value", payload);
-        document.body.append(disabled, enabled);
+        document.body.append(disabled, hidden, enabled);
 
         attributeInjectionSanitizeRule.apply(document.body);
 
         expect(disabled.hasAttribute("value")).toBe(false);
+        expect(hidden.hasAttribute("value")).toBe(false);
         expect(enabled.getAttribute("value")).toBe(payload);
       }),
     );

--- a/extension/src/rules/__tests__/attribute-injection-sanitize.test.ts
+++ b/extension/src/rules/__tests__/attribute-injection-sanitize.test.ts
@@ -111,6 +111,50 @@ describe("attribute-injection-sanitize disabled input value", () => {
   });
 });
 
+describe("attribute-injection-sanitize hidden input value", () => {
+  it("removes a poisoned value on input[type=hidden]", () => {
+    document.body.innerHTML = `<input type="hidden" value="${FIXTURES.NEW_INSTRUCTIONS}">`;
+
+    attributeInjectionSanitizeRule.apply(document.body);
+
+    const input = document.body.querySelector("input");
+    expect(input?.hasAttribute("value")).toBe(false);
+  });
+
+  it("treats Type='HIDDEN' case-insensitively", () => {
+    document.body.innerHTML = `<input type="HIDDEN" value="${FIXTURES.DISREGARD}">`;
+
+    attributeInjectionSanitizeRule.apply(document.body);
+
+    expect(document.body.querySelector("input")?.hasAttribute("value")).toBe(
+      false,
+    );
+  });
+
+  it("leaves a clean hidden input value alone", () => {
+    document.body.innerHTML = `<input type="hidden" name="csrf" value="abc123">`;
+
+    attributeInjectionSanitizeRule.apply(document.body);
+
+    expect(document.body.querySelector("input")?.getAttribute("value")).toBe(
+      "abc123",
+    );
+  });
+
+  it("scrubs a hidden input added in a lazy subtree", async () => {
+    attributeInjectionSanitizeRule.apply(document.body);
+
+    const route = document.createElement("section");
+    route.innerHTML = `<input type="hidden" value="${FIXTURES.IGNORE_HACKED}">`;
+    document.body.append(route);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(route.querySelector("input")?.hasAttribute("value")).toBe(false);
+  });
+});
+
 describe("attribute-injection-sanitize lazy subtrees", () => {
   it("scrubs an attribute on a subtree added after apply", async () => {
     attributeInjectionSanitizeRule.apply(document.body);

--- a/extension/src/rules/attribute-injection-sanitize.ts
+++ b/extension/src/rules/attribute-injection-sanitize.ts
@@ -11,18 +11,20 @@
 // element. That asymmetry makes attributes a clean carrier for
 // instruction-shaped text the page operator never has to render.
 //
-// We also scrub `value` on disabled `<input>` elements: those values
-// are rendered to humans (and so generally honest), but a disabled
-// input cannot be edited, which is the exact shape an adversarial page
-// would use to plant a "pre-confirmed" instruction that the agent
-// treats as load-bearing while the user has no chance to clear it.
+// We also scrub `value` on `<input>` elements the user cannot reach:
+// `disabled` inputs render to humans but cannot be edited, and
+// `type="hidden"` inputs are not user-facing at all. Both shapes give
+// an adversarial page a "pre-confirmed" slot for instruction text that
+// the agent treats as load-bearing while the user has no way to clear
+// or even see it. The trigger is attribute-/type-based so the existing
+// lightweight watcher catches it with no computed-style work.
 //
 // Accepted limitation: an enabled `<input value="…">` sitting inside a
 // CSS-hidden wrapper (`visibility:hidden`, off-left, opacity:0) is not
-// scrubbed. The same asymmetry as the disabled case applies — the user
-// can't see or edit the value — but matching it would require a
-// computed-style check at scrub time, which conflicts with this rule's
-// lightweight attribute-driven watcher. Pre-#176 these were caught when
+// scrubbed. The same asymmetry applies — the user can't see or edit
+// the value — but matching it would require a computed-style check at
+// scrub time, which conflicts with this rule's lightweight
+// attribute-driven watcher. Pre-#176 these were caught when
 // `hidden-text-strip` detached the wrapper; the regression is accepted
 // because the trigger surface is narrow (enabled input + hidden wrapper).
 //
@@ -53,6 +55,7 @@ const CANDIDATE_ATTRIBUTES = [
 const ATTRIBUTE_SELECTOR = [
   ...CANDIDATE_ATTRIBUTES.map((name) => `[${name}]`),
   "input[disabled][value]",
+  'input[type="hidden"][value]',
 ].join(",");
 
 function containsInjection(value: string): boolean {
@@ -66,14 +69,15 @@ function scrubElement(element: Element): void {
       element.removeAttribute(name);
     }
   }
-  if (
-    element.tagName === "INPUT" &&
-    element.hasAttribute("disabled") &&
-    element.hasAttribute("value")
-  ) {
-    const value = element.getAttribute("value");
-    if (value !== null && containsInjection(value)) {
-      element.removeAttribute("value");
+  if (element.tagName === "INPUT" && element.hasAttribute("value")) {
+    const isUnreachable =
+      element.hasAttribute("disabled") ||
+      element.getAttribute("type")?.toLowerCase() === "hidden";
+    if (isUnreachable) {
+      const value = element.getAttribute("value");
+      if (value !== null && containsInjection(value)) {
+        element.removeAttribute("value");
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #183.

## Summary

- Extend `attribute-injection-sanitize` to also scrub `value` on `input[type="hidden"]` — same asymmetry as the existing `input[disabled]` case (not user-facing, not editable in the UI, read by browser-use agents directly off the DOM).
- Selector and scrub branch updated; type check is case-insensitive. Enabled visible `<input value>` remains untouched (documented accepted limitation for the "enabled input inside CSS-hidden wrapper" shape).
- Docstring + `docs/src/content/docs/rules.md` updated to reflect the extended trigger.
- New unit tests covering the hidden case (matching value, case-insensitive `type`, clean value preserved, lazy-subtree mutation), and the property test now exercises a disabled / hidden / enabled triplet.

## Test plan

- [x] `bun run test src/rules/__tests__/attribute-injection-sanitize.test.ts` — 23 passing
- [x] `bun run test src/rules/__tests__/attribute-injection-sanitize.property.test.ts` — 4 passing
- [x] `bun run check` (biome + eslint)
- [x] `bun run typecheck`
- [x] `pre-commit run` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)