### PR TITLE
Feat: form-prefill-annotate rule for preselected form controls (#121)

### DIFF
--- a/demo-site/src/pages/Checkout.tsx
+++ b/demo-site/src/pages/Checkout.tsx
@@ -44,7 +44,92 @@ export default function Checkout() {
 
           <div className="rounded border border-stone-200 bg-white p-6">
             <h2 className="mb-3 text-lg font-semibold text-slate-900">
-              4. Final options
+              4. Shipping & contact
+            </h2>
+            <form className="space-y-3 text-sm text-stone-700">
+              <label className="block">
+                <span className="block font-medium text-stone-800">
+                  Marketing email
+                </span>
+                {/* `autocomplete="off"` so browsers don't paper over this
+                    server-prefilled value; the rule should chip it. */}
+                <input
+                  type="email"
+                  name="marketing_email"
+                  autoComplete="off"
+                  defaultValue="jordan@example.com"
+                  className="mt-1 w-full rounded border border-stone-300 px-2 py-1"
+                />
+              </label>
+              <label className="block">
+                <span className="block font-medium text-stone-800">
+                  SMS contact
+                </span>
+                <input
+                  type="tel"
+                  name="sms_contact"
+                  autoComplete="off"
+                  defaultValue="555-867-5309"
+                  className="mt-1 w-full rounded border border-stone-300 px-2 py-1"
+                />
+              </label>
+              <label className="block">
+                <span className="block font-medium text-stone-800">
+                  Shipping speed
+                </span>
+                {/* Default is the costliest option — annotate, don't reset. */}
+                <select
+                  name="shipping_speed"
+                  defaultValue="overnight"
+                  className="mt-1 w-full rounded border border-stone-300 px-2 py-1"
+                >
+                  <option value="standard">Standard — Free</option>
+                  <option value="express">Express — $9.99</option>
+                  <option value="overnight">Overnight — $24.99</option>
+                </select>
+              </label>
+              <label className="block">
+                <span className="block font-medium text-stone-800">
+                  Shipping country
+                </span>
+                {/* Geo select — geo-IP defaults are legitimate, rule skips. */}
+                <select
+                  name="country"
+                  defaultValue="US"
+                  className="mt-1 w-full rounded border border-stone-300 px-2 py-1"
+                >
+                  <option value="US">United States</option>
+                  <option value="CA">Canada</option>
+                  <option value="MX">Mexico</option>
+                </select>
+              </label>
+              <fieldset className="rounded border border-stone-200 p-2">
+                <legend className="px-1 text-stone-800">Driver tip</legend>
+                <label className="mr-3 inline-flex items-center gap-1">
+                  <input type="radio" name="driver_tip" value="18" /> 18%
+                </label>
+                <label className="mr-3 inline-flex items-center gap-1">
+                  <input type="radio" name="driver_tip" value="20" /> 20%
+                </label>
+                <label className="mr-3 inline-flex items-center gap-1">
+                  <input
+                    type="radio"
+                    name="driver_tip"
+                    value="22"
+                    defaultChecked
+                  />{" "}
+                  22%
+                </label>
+                <label className="mr-3 inline-flex items-center gap-1">
+                  <input type="radio" name="driver_tip" value="0" /> No tip
+                </label>
+              </fieldset>
+            </form>
+          </div>
+
+          <div className="rounded border border-stone-200 bg-white p-6">
+            <h2 className="mb-3 text-lg font-semibold text-slate-900">
+              5. Final options
             </h2>
             <div className="space-y-2 text-sm text-stone-700">
               <label className="flex items-start gap-2">

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -3,7 +3,7 @@ title: Rules reference
 description: The defense rules shipped with agent-browser-shield, what each one does, and its default state.
 ---
 
-The extension ships 37 rules, each independently toggleable from the extension's
+The extension ships 38 rules, each independently toggleable from the extension's
 options page. Rules marked **default: on** are active on fresh install;
 **default: off** rules must be enabled manually.
 
@@ -656,6 +656,55 @@ including required agreements. `role="checkbox"` widgets and radio groups are
 out of scope.
 
 Pre-checked opt-ins are *Preselection* in Mathur et al.
+[[9]](#ref-mathur-dark-patterns) and Brignull's deceptive.design catalog
+[[10]](#ref-brignull).
+
+#### Annotate Form Prefills (Experimental)
+
+- **ID:** `form-prefill-annotate`
+- **Default:** on
+
+On checkout-like URLs, prepend a visible `[abs: pre-populated …]` annotation to
+form controls that ship with a server-rendered default the agent might silently
+inherit. Covers three shapes: text / email / tel / number / url inputs whose
+`value` attribute is non-empty, `<select>` elements whose explicitly-`selected`
+option is not the first one, and radio groups with an initially-`checked`
+option. The control's value is **not** changed — annotation preserves agency, so
+the agent reads the chip in its DOM snapshot and decides whether to overwrite.
+Required-selection radio groups stay submittable because nothing is unchecked.
+
+False-positive control is layered: text inputs with a recognized browser-
+autofill `autocomplete` token (`name`, `email`, `tel`, `street-address`,
+`postal-code`, etc.) are treated as legitimate autofill targets and skipped;
+selects whose name, id, or label suggests a geo field (country / state /
+province / region / currency) are skipped because geo-IP defaults are
+legitimate; controls the user has focused since the page loaded are skipped;
+disabled / readonly controls are skipped; per-form chip count is capped so a
+long form (saved-card manager, admin panel) doesn't accumulate clutter. The
+attribute (not the live property) is read so server-rendered prefills are
+flagged even when a page script has already overwritten the live value.
+
+Hidden inputs are out of scope for this rule — the value is submitted regardless
+of any chip and the agent never reads hidden inputs into a decision, so
+annotation would not change behavior.
+
+Future work tracked in issue
+[#121](https://github.com/pixiebrix/agent-browser-shield/issues/121):
+
+- A narrow sanitize companion that clears `value` on `<input type="hidden">`
+  whose `name` matches a curated affiliate / UTM / promo allowlist, behind a
+  hard CSRF / cart / session denylist. Different toggle so the FP profile is
+  controllable separately.
+- Optionally include the prefilled value in the chip text. The chip flags
+  presence only today, to avoid leaking remembered PII into a logging snapshot.
+- Synthetic blur / change event after annotation so sites that recalc totals on
+  input events can re-render. Today the rule never touches values.
+- Sanitize-mode toggle for `<select>` defaults on sneaking-prone fields
+  (shipping speed, tip percent, donation amount, insurance plan). Annotation is
+  the default action because the FP profile across visible defaults is harder to
+  bound than for hidden-input metadata.
+
+Pre-populated form fields are *Preselection* in Mathur et al.
 [[9]](#ref-mathur-dark-patterns) and Brignull's deceptive.design catalog
 [[10]](#ref-brignull).
 

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -680,9 +680,11 @@ selects whose name, id, or label suggests a geo field (country / state /
 province / region / currency) are skipped because geo-IP defaults are
 legitimate; controls the user has focused since the page loaded are skipped;
 disabled / readonly controls are skipped; per-form chip count is capped so a
-long form (saved-card manager, admin panel) doesn't accumulate clutter. The
-attribute (not the live property) is read so server-rendered prefills are
-flagged even when a page script has already overwritten the live value.
+long form (saved-card manager, admin panel) doesn't accumulate clutter. The live
+property (not the HTML attribute) is read so framework-rendered defaults (React
+`defaultValue`, Vue `v-model` initialState, jQuery `.val()`) are flagged the
+same way the agent's DOM snapshot would see them; the focused-control skip above
+keeps user-entered values out of the flag set.
 
 Hidden inputs are out of scope for this rule — the value is submitted regardless
 of any chip and the agent never reads hidden inputs into a decision, so

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -36,6 +36,7 @@
     "encoded-payload-redact": true,
     "webdriver-probe-annotate": false,
     "closed-shadow-root-annotate": false,
-    "hidden-fee-annotate": true
+    "hidden-fee-annotate": true,
+    "form-prefill-annotate": true
   }
 }

--- a/extension/src/lib/dom-markers.ts
+++ b/extension/src/lib/dom-markers.ts
@@ -78,3 +78,10 @@ export const CONFIRMSHAME_ORIGINAL_ARIA_ATTR =
   "data-abs-confirmshame-orig-aria";
 export const CONFIRMSHAME_ORIGINAL_TITLE_ATTR =
   "data-abs-confirmshame-orig-title";
+
+// `form-prefill-annotate`: marks a form control (or its annotation target —
+// wrapper, label, fieldset, submit row) that the rule has already badged so
+// the watcher doesn't append a second chip on the next mutation pass. Also
+// stamped on controls that were considered and rejected by the FP-control
+// gates so re-scans skip them on every burst.
+export const FORM_PREFILL_ANNOTATED_ATTR = "data-abs-form-prefill-annotated";

--- a/extension/src/lib/rule-groups.ts
+++ b/extension/src/lib/rule-groups.ts
@@ -56,6 +56,7 @@ export const RULE_GROUPS: readonly RuleGroup[] = [
       "cart-addon-annotate",
       "hidden-fee-annotate",
       "checkout-checkbox-sanitize",
+      "form-prefill-annotate",
       "confirmshame-sanitize",
       "roach-motel-annotate",
       "newsletter-modal-hide",

--- a/extension/src/popup/rule-labels.ts
+++ b/extension/src/popup/rule-labels.ts
@@ -55,4 +55,5 @@ export const RULE_LABELS: Readonly<Record<RuleId, string>> = {
   "webdriver-probe-annotate": "Flag navigator.webdriver Reads",
   "closed-shadow-root-annotate": "Flag Closed Shadow Roots",
   "hidden-fee-annotate": "Annotate Drip-Pricing Fees (Experimental)",
+  "form-prefill-annotate": "Annotate Form Prefills (Experimental)",
 } as const satisfies Record<RuleId, string>;

--- a/extension/src/rules/__tests__/form-prefill-annotate.property.test.ts
+++ b/extension/src/rules/__tests__/form-prefill-annotate.property.test.ts
@@ -1,0 +1,280 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://shop.example.com/checkout"}
+ */
+// Property-based tests for form-prefill-annotate. fast-check explores the
+// boundary cases the FP control gates are supposed to reject:
+//   - autocomplete-token allowlist (recognized tokens never flag, off /
+//     unrecognized tokens still flag if the value is present),
+//   - <select> first-option vs. non-first-option default detection,
+//   - geo-select skip across name/id/aria,
+//   - idempotency under repeated apply().
+
+import fc from "fast-check";
+
+import { FORM_PREFILL_ANNOTATED_ATTR as FLAGGED_ATTR } from "../../lib/dom-markers";
+import { formPrefillAnnotateRule, isGeoSelect } from "../form-prefill-annotate";
+
+const FLAG_CLASS = "abs-form-prefill-annotate";
+
+// Mirror of the AUTOFILL_TOKENS set in form-prefill-annotate.ts. Tests
+// here are not required to exhaustively match — that's what the unit
+// suite covers — but fast-check needs a concrete sample to draw from.
+const AUTOFILL_TOKENS: readonly string[] = [
+  "name",
+  "given-name",
+  "family-name",
+  "email",
+  "tel",
+  "street-address",
+  "address-line1",
+  "address-line2",
+  "address-level1",
+  "address-level2",
+  "country",
+  "country-name",
+  "postal-code",
+  "bday",
+  "organization",
+];
+
+// Token-shaped strings the autocomplete attribute might carry that
+// are NOT in the allowlist. We want the rule to still flag a prefilled
+// value when the site set one of these (custom or off-by-typo tokens).
+const NON_AUTOFILL_TOKENS: readonly string[] = [
+  "off",
+  "shipping-notes",
+  "promo-code",
+  "referral-source",
+  "marketing-opt-in",
+  "loyalty-id",
+];
+
+const GEO_NAMES: readonly string[] = [
+  "country",
+  "state",
+  "province",
+  "region",
+  "county",
+  "locale",
+  "language",
+  "currency",
+  "territory",
+  "prefecture",
+];
+
+const NON_GEO_SELECT_NAMES: readonly string[] = [
+  "shipping",
+  "shipping_speed",
+  "tip",
+  "tip_percent",
+  "donation_amount",
+  "insurance_plan",
+  "delivery_slot",
+  "gift_wrap_style",
+];
+
+afterEach(() => {
+  formPrefillAnnotateRule.teardown();
+  document.body.innerHTML = "";
+});
+
+describe("autocomplete-token gating (property)", () => {
+  it("never flags a text input whose autocomplete is a recognized autofill token", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...AUTOFILL_TOKENS),
+        fc.stringMatching(/^[A-Za-z][A-Za-z0-9 @.-]{0,30}$/),
+        (token, value) => {
+          document.body.innerHTML = "";
+          const form = document.createElement("form");
+          const label = document.createElement("label");
+          const input = document.createElement("input");
+          input.type = "text";
+          input.name = "x";
+          input.setAttribute("autocomplete", token);
+          input.setAttribute("value", value);
+          label.append(input);
+          form.append(label);
+          document.body.append(form);
+
+          formPrefillAnnotateRule.apply(document.body);
+          const chips = document.querySelectorAll(`.${FLAG_CLASS}`).length;
+          formPrefillAnnotateRule.teardown();
+          expect(chips).toBe(0);
+        },
+      ),
+    );
+  });
+
+  it("flags a text input whose autocomplete is unrecognized and value is non-empty", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...NON_AUTOFILL_TOKENS),
+        fc.stringMatching(/^[A-Za-z][A-Za-z0-9 @.-]{0,30}$/),
+        (token, value) => {
+          document.body.innerHTML = "";
+          const form = document.createElement("form");
+          const label = document.createElement("label");
+          const input = document.createElement("input");
+          input.type = "text";
+          input.name = "y";
+          input.setAttribute("autocomplete", token);
+          input.setAttribute("value", value);
+          label.append(input);
+          form.append(label);
+          document.body.append(form);
+
+          formPrefillAnnotateRule.apply(document.body);
+          const chips = document.querySelectorAll(`.${FLAG_CLASS}`).length;
+          formPrefillAnnotateRule.teardown();
+          expect(chips).toBe(1);
+        },
+      ),
+    );
+  });
+});
+
+describe("isGeoSelect (property)", () => {
+  it("returns true for selects whose name/id/aria contains a geo token", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...GEO_NAMES),
+        fc.constantFrom("name", "id", "aria-label"),
+        (geo, where) => {
+          document.body.innerHTML = "";
+          const select = document.createElement("select");
+          select.setAttribute(where, `user_${geo}_picker`);
+          document.body.append(select);
+          const result = isGeoSelect(select);
+          expect(result).toBe(true);
+        },
+      ),
+    );
+  });
+
+  it("returns false for non-geo select names", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...NON_GEO_SELECT_NAMES),
+        fc.constantFrom("name", "id", "aria-label"),
+        (nonGeo, where) => {
+          document.body.innerHTML = "";
+          const select = document.createElement("select");
+          select.setAttribute(where, nonGeo);
+          document.body.append(select);
+          const result = isGeoSelect(select);
+          expect(result).toBe(false);
+        },
+      ),
+    );
+  });
+});
+
+describe("<select> first-option invariant (property)", () => {
+  // Build a select with N options and explicitly mark one as `selected`.
+  // The rule flags iff the selected index is > 0 AND the select isn't a
+  // geo field. Total chip count must equal the number of selects whose
+  // `selected` index is > 0.
+  const selectArb = fc.record({
+    name: fc.constantFrom(...NON_GEO_SELECT_NAMES),
+    optionCount: fc.integer({ min: 2, max: 6 }),
+    selectedIndex: fc.integer({ min: 0, max: 5 }),
+  });
+
+  it("annotates exactly the selects whose selected index is > 0", () => {
+    fc.assert(
+      fc.property(
+        fc.array(selectArb, { minLength: 1, maxLength: 6 }),
+        (specs) => {
+          document.body.innerHTML = "";
+          const form = document.createElement("form");
+          let expected = 0;
+          for (const spec of specs) {
+            const select = document.createElement("select");
+            select.name = spec.name;
+            const index = spec.selectedIndex % spec.optionCount;
+            for (let i = 0; i < spec.optionCount; i++) {
+              const option = document.createElement("option");
+              option.value = `v${i}`;
+              option.textContent = `Option ${i}`;
+              if (i === index) {
+                option.setAttribute("selected", "");
+              }
+              select.append(option);
+            }
+            form.append(select);
+            if (index > 0) {
+              expected++;
+            }
+          }
+          document.body.append(form);
+          formPrefillAnnotateRule.apply(document.body);
+          const chips = document.querySelectorAll(`.${FLAG_CLASS}`).length;
+          formPrefillAnnotateRule.teardown();
+          expect(chips).toBe(expected);
+        },
+      ),
+      { numRuns: 40 },
+    );
+  });
+});
+
+describe("idempotency (property)", () => {
+  it("applying twice yields the same chip count as once", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            kind: fc.constantFrom("text", "select"),
+            value: fc.stringMatching(/^[A-Za-z0-9]{1,15}$/),
+            sneaky: fc.boolean(),
+          }),
+          { minLength: 1, maxLength: 6 },
+        ),
+        (specs) => {
+          document.body.innerHTML = "";
+          const form = document.createElement("form");
+          for (const [i, spec] of specs.entries()) {
+            if (spec.kind === "text") {
+              const input = document.createElement("input");
+              input.type = "text";
+              input.name = `f${i}`;
+              if (spec.sneaky) {
+                input.setAttribute("value", spec.value);
+              }
+              form.append(input);
+            } else {
+              const select = document.createElement("select");
+              select.name = `f${i}`;
+              for (let j = 0; j < 3; j++) {
+                const option = document.createElement("option");
+                option.value = `o${j}`;
+                option.textContent = `O${j}`;
+                if (spec.sneaky && j === 2) {
+                  option.setAttribute("selected", "");
+                }
+                select.append(option);
+              }
+              form.append(select);
+            }
+          }
+          document.body.append(form);
+
+          formPrefillAnnotateRule.apply(document.body);
+          const firstPass = document.querySelectorAll(`.${FLAG_CLASS}`).length;
+          expect(
+            document.querySelectorAll(`[${FLAGGED_ATTR}=""]`).length,
+          ).toBeGreaterThanOrEqual(firstPass);
+
+          formPrefillAnnotateRule.apply(document.body);
+          const secondPass = document.querySelectorAll(`.${FLAG_CLASS}`).length;
+          expect(secondPass).toBe(firstPass);
+
+          formPrefillAnnotateRule.teardown();
+        },
+      ),
+      { numRuns: 40 },
+    );
+  });
+});

--- a/extension/src/rules/__tests__/form-prefill-annotate.test.ts
+++ b/extension/src/rules/__tests__/form-prefill-annotate.test.ts
@@ -1,0 +1,406 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://shop.example.com/checkout"}
+ */
+import { FORM_PREFILL_ANNOTATED_ATTR as FLAGGED_ATTR } from "../../lib/dom-markers";
+import { formPrefillAnnotateRule, isGeoSelect } from "../form-prefill-annotate";
+
+const MUTATION_THROTTLE_MS = 250;
+const FLAG_CLASS = "abs-form-prefill-annotate";
+
+async function flushMutations(): Promise<void> {
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  formPrefillAnnotateRule.teardown();
+  jest.useRealTimers();
+});
+
+describe("formPrefillAnnotateRule — text/email/tel/number inputs", () => {
+  it("annotates a pre-populated email field", () => {
+    document.body.innerHTML = `
+      <form>
+        <label>Email
+          <input type="email" name="email_marketing" value="jordan@example.com">
+        </label>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(1);
+    expect(
+      document.querySelectorAll(`[${FLAGGED_ATTR}=""]`).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("skips an email field with autocomplete='email' (legitimate autofill target)", () => {
+    document.body.innerHTML = `
+      <form>
+        <label>Email
+          <input type="email" name="email" autocomplete="email" value="jordan@example.com">
+        </label>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("annotates an autocomplete='off' field that ships with a value (the interesting case)", () => {
+    document.body.innerHTML = `
+      <form>
+        <label>Promo code
+          <input type="text" name="promo" autocomplete="off" value="SUMMER25">
+        </label>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(1);
+  });
+
+  it("skips an empty input", () => {
+    document.body.innerHTML = `
+      <form><input type="text" name="referral" value=""></form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("skips a hidden, disabled, or readonly input", () => {
+    document.body.innerHTML = `
+      <form>
+        <input type="hidden" name="ref" value="abc">
+        <input type="text" name="a" value="x" disabled>
+        <input type="text" name="b" value="y" readonly>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("skips a password field", () => {
+    document.body.innerHTML = `
+      <form><input type="password" value="hunter2"></form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("uses the live value, matching what the agent's snapshot would see", () => {
+    // Framework defaults (React `defaultValue`, Vue `v-model`) populate
+    // the live property without writing an attribute. Reading the
+    // attribute would miss those; reading `.value` flags them.
+    document.body.innerHTML = `
+      <form>
+        <label>Notes
+          <input id="notes" type="text" name="notes">
+        </label>
+      </form>
+    `;
+    (document.querySelector("#notes") as HTMLInputElement).value =
+      "framework-prefilled";
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(1);
+  });
+});
+
+describe("formPrefillAnnotateRule — <select>", () => {
+  it("annotates a select whose default isn't the first option", () => {
+    document.body.innerHTML = `
+      <form>
+        <label>Shipping speed
+          <select name="shipping">
+            <option value="standard">Standard (free)</option>
+            <option value="express">Express ($9.99)</option>
+            <option value="overnight" selected>Overnight ($24.99)</option>
+          </select>
+        </label>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    const chip = document.querySelector(`.${FLAG_CLASS}`);
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain("Overnight");
+  });
+
+  it("skips a select where the first option is the default (no signal)", () => {
+    document.body.innerHTML = `
+      <form>
+        <select name="size">
+          <option selected>Small</option>
+          <option>Medium</option>
+          <option>Large</option>
+        </select>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("flags a select where the framework set the default via the live property", () => {
+    // Mimic React's `<select defaultValue="overnight">` — no `selected`
+    // attribute on the option, just a property-level selection.
+    document.body.innerHTML = `
+      <form>
+        <select id="shipping" name="shipping">
+          <option value="standard">Standard</option>
+          <option value="express">Express</option>
+          <option value="overnight">Overnight</option>
+        </select>
+      </form>
+    `;
+    (document.querySelector("#shipping") as HTMLSelectElement).value =
+      "overnight";
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(1);
+  });
+
+  it("skips a geo select (country)", () => {
+    document.body.innerHTML = `
+      <form>
+        <label>Country
+          <select name="country">
+            <option value="US">United States</option>
+            <option value="CA" selected>Canada</option>
+          </select>
+        </label>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("skips a multi-select", () => {
+    document.body.innerHTML = `
+      <form>
+        <select name="interests" multiple>
+          <option selected>Books</option>
+          <option selected>Music</option>
+          <option>Games</option>
+        </select>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("isGeoSelect returns true for country / state / province / region / currency selects", () => {
+    document.body.innerHTML = `
+      <form>
+        <select id="s1" name="country"></select>
+        <select id="s2" name="state"></select>
+        <select id="s3" name="province"></select>
+        <select id="s4" name="region"></select>
+        <select id="s5" name="currency"></select>
+        <select id="s6" aria-label="Choose your shipping state"></select>
+      </form>
+    `;
+    for (const id of ["s1", "s2", "s3", "s4", "s5", "s6"]) {
+      const select = document.querySelector(`#${id}`) as HTMLSelectElement;
+      expect(isGeoSelect(select)).toBe(true);
+    }
+  });
+
+  it("isGeoSelect returns false for shipping-speed / tip / donation selects", () => {
+    document.body.innerHTML = `
+      <form>
+        <select id="s1" name="shipping"></select>
+        <select id="s2" name="tip_percent"></select>
+        <select id="s3" name="donation_amount"></select>
+        <select id="s4" name="insurance_plan"></select>
+      </form>
+    `;
+    for (const id of ["s1", "s2", "s3", "s4"]) {
+      const select = document.querySelector(`#${id}`) as HTMLSelectElement;
+      expect(isGeoSelect(select)).toBe(false);
+    }
+  });
+});
+
+describe("formPrefillAnnotateRule — radio groups", () => {
+  it("annotates a radio group with a pre-selected option (once at the fieldset)", () => {
+    document.body.innerHTML = `
+      <form>
+        <fieldset>
+          <legend>Tip amount</legend>
+          <label><input type="radio" name="tip" value="18">18%</label>
+          <label><input type="radio" name="tip" value="20">20%</label>
+          <label><input type="radio" name="tip" value="22" checked>22%</label>
+        </fieldset>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(1);
+    const fieldset = document.querySelector("fieldset");
+    expect(fieldset?.firstElementChild?.classList.contains(FLAG_CLASS)).toBe(
+      true,
+    );
+  });
+
+  it("uses a role='radiogroup' wrapper when no fieldset", () => {
+    document.body.innerHTML = `
+      <form>
+        <div role="radiogroup" aria-label="Delivery slot">
+          <label><input type="radio" name="slot" value="am">Morning</label>
+          <label><input type="radio" name="slot" value="pm" checked>Afternoon</label>
+        </div>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    const group = document.querySelector('[role="radiogroup"]');
+    expect(group?.firstElementChild?.classList.contains(FLAG_CLASS)).toBe(true);
+  });
+
+  it("does not annotate a radio group where no option is checked", () => {
+    document.body.innerHTML = `
+      <form>
+        <fieldset>
+          <legend>Tip amount</legend>
+          <label><input type="radio" name="tip" value="18">18%</label>
+          <label><input type="radio" name="tip" value="20">20%</label>
+        </fieldset>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("annotates each form's radio group independently (same `name` across forms)", () => {
+    document.body.innerHTML = `
+      <form id="a">
+        <fieldset>
+          <input type="radio" name="tip" value="22" checked>
+        </fieldset>
+      </form>
+      <form id="b">
+        <fieldset>
+          <input type="radio" name="tip" value="22" checked>
+        </fieldset>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(2);
+  });
+
+  it("skips a radio without a name attribute (standalone toggle)", () => {
+    document.body.innerHTML = `
+      <form>
+        <fieldset><input type="radio" checked></fieldset>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+});
+
+describe("formPrefillAnnotateRule — focus interaction", () => {
+  it("does not annotate a control the user has already focused", async () => {
+    document.body.innerHTML = `
+      <form>
+        <label>Notes
+          <input id="focused" type="text" name="notes" value="server-default">
+        </label>
+        <label>Other
+          <input id="quiet" type="text" name="other" value="">
+        </label>
+      </form>
+    `;
+    // Start observing — installs the focusin listener.
+    formPrefillAnnotateRule.apply(document.body);
+    // First scan already flagged the prefilled field. Strip the chip
+    // and FLAG_ATTR so the next pass re-evaluates.
+    for (const chip of document.querySelectorAll(`.${FLAG_CLASS}`)) {
+      chip.remove();
+    }
+    for (const node of document.querySelectorAll(`[${FLAGGED_ATTR}]`)) {
+      node.removeAttribute(FLAGGED_ATTR);
+    }
+    // Simulate the user clicking into the field.
+    const focused = document.querySelector("#focused") as HTMLInputElement;
+    focused.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    // Trigger a re-scan via a mutation.
+    document.body.querySelector("form")?.append(document.createElement("div"));
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+});
+
+describe("formPrefillAnnotateRule — chip cap", () => {
+  it("caps chips at MAX_CHIPS_PER_FORM per form", () => {
+    const form = document.createElement("form");
+    for (let i = 0; i < 20; i++) {
+      const label = document.createElement("label");
+      const input = document.createElement("input");
+      input.type = "text";
+      input.name = `field_${i}`;
+      input.setAttribute("value", `prefilled-${i}`);
+      label.append(input);
+      form.append(label);
+    }
+    document.body.append(form);
+    formPrefillAnnotateRule.apply(document.body);
+    // MAX_CHIPS_PER_FORM = 8 in form-prefill-annotate.ts
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(8);
+  });
+});
+
+describe("formPrefillAnnotateRule URL gating", () => {
+  it("does not annotate on a non-checkout URL", () => {
+    const originalHref = globalThis.location.href;
+    globalThis.history.replaceState({}, "", "/profile/edit");
+    try {
+      document.body.innerHTML = `
+        <form>
+          <input type="text" name="nickname" value="Jordan">
+        </form>
+      `;
+      formPrefillAnnotateRule.apply(document.body);
+      expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+    } finally {
+      globalThis.history.replaceState({}, "", originalHref);
+    }
+  });
+});
+
+describe("formPrefillAnnotateRule idempotency", () => {
+  it("does not double-flag on a repeat scan", async () => {
+    document.body.innerHTML = `
+      <form>
+        <label>Email
+          <input type="email" name="newsletter" value="jordan@example.com">
+        </label>
+      </form>
+    `;
+    formPrefillAnnotateRule.apply(document.body);
+    // Trigger another scan via an unrelated mutation.
+    document.body.append(document.createElement("div"));
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(1);
+  });
+
+  it("annotates a lazy-loaded form", async () => {
+    formPrefillAnnotateRule.apply(document.body);
+    const late = document.createElement("div");
+    late.innerHTML = `
+      <form>
+        <label>Phone
+          <input type="tel" name="contact_phone" value="555-867-5309">
+        </label>
+      </form>
+    `;
+    document.body.append(late);
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(document.querySelector(`.${FLAG_CLASS}`)).not.toBeNull();
+  });
+});

--- a/extension/src/rules/form-prefill-annotate.ts
+++ b/extension/src/rules/form-prefill-annotate.ts
@@ -199,18 +199,17 @@ function hasRecognizedAutofillToken(element: HTMLElement): boolean {
   return false;
 }
 
-// `autocomplete="off"` and `autocomplete="on"` are not field-target
-// tokens. We treat the absence of a recognized target as "unspecified"
-// and proceed.
-function isExplicitAutofillOff(element: HTMLElement): boolean {
-  const tokens = readAutocompleteTokens(element);
-  return tokens.length === 1 && tokens[0] === "off";
-}
-
 // Read the field's accessible label-ish text for the GEO check on
 // <select>. Cheap concatenation across name/id/aria-label and a single
 // associated <label> if reachable. We don't walk the full a11y tree —
 // the GEO check only needs a recognizable signal.
+//
+// `Element.textContent` is typed `string` (not `string | null`) by the
+// project's TypeScript lib, and `@typescript-eslint/no-unnecessary-
+// condition` flags `?? ""` as a redundant guard. Per the DOM spec only
+// `Document` and `DocumentType` nodes ever return `null`, neither of
+// which can flow through these selectors. Same convention as
+// `hidden-fee-annotate.ts` and `cart-addon-annotate.ts`.
 function readSelectLabelHints(element: HTMLSelectElement): string {
   const parts: string[] = [];
   const name = element.getAttribute("name");
@@ -348,10 +347,9 @@ function readTextCandidate(input: HTMLInputElement): TextCandidate | null {
   if (hasRecognizedAutofillToken(input)) {
     return null;
   }
-  // `autocomplete="off"` on a pre-filled field is the most interesting
-  // case — the site disabled browser autofill yet still served a value.
-  // Don't skip it just because the attribute was set; fall through.
-  isExplicitAutofillOff(input);
+  // `autocomplete="off"` is intentionally not a skip signal — a site
+  // disabling browser autofill while still serving a value is exactly
+  // the prefill case we want to flag, so we fall through here.
   // Read live `.value` rather than the `value` attribute. The attribute
   // is only set when SSR templated the prefill in HTML; framework-
   // rendered defaults (React `defaultValue`, Vue `v-model` initialState,

--- a/extension/src/rules/form-prefill-annotate.ts
+++ b/extension/src/rules/form-prefill-annotate.ts
@@ -1,0 +1,640 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Annotate pre-populated form controls on checkout pages so the agent
+// reads "pre-populated" in its snapshot and decides whether to overwrite.
+// Three control shapes are covered:
+//
+//   1. <input type="text|email|tel|number"> with a non-empty initial value
+//      that doesn't look like a legitimate browser-autofill target.
+//   2. <select> whose initial selectedIndex !== 0 and that isn't a geo /
+//      country / state field.
+//   3. Radio group with an initially-checked option (covered as the
+//      group's enclosing fieldset / wrapper, never the individual radio,
+//      so we don't suggest the agent uncheck and break a required-
+//      selection submit).
+//
+// Companion to `checkout-checkbox-sanitize` (preselection on checkboxes)
+// and to `hidden-affiliate-sanitize` (the hidden-input arm split out into
+// its own rule because the value-clear contract differs). The split
+// follows issue #121: visible inputs have a high FP profile against
+// legitimate autofill / multi-step persistence, so annotation is the
+// right action; hidden-input clearing is allowlist-narrow and can be
+// sanitize-and-forget.
+//
+// Action is annotation-only — no values are changed and no nodes are
+// detached. Worst case is one extra chip on a form field.
+//
+// FP control is layered:
+//   - URL gate (`isCheckoutUrl`) — never fires off checkout-shape paths.
+//   - Per-form chip cap so a long form (e.g. saved-card management) gets
+//     at most `MAX_CHIPS_PER_FORM` chips total.
+//   - Skip when `document.activeElement` matches the control, or when
+//     the control has already been focused (tracked via a focusin
+//     listener) — cooperates with autofill that runs after our scan.
+//   - For text/email/tel/number: skip when the `autocomplete` attribute
+//     names a recognized browser-autofill target (name, email, tel,
+//     given-name, family-name, street-address, postal-code, etc.).
+//     This is intentionally permissive — accept FPs on the autofill
+//     side rather than risk annotating real autofill output.
+//   - For <select>: skip the GEO allowlist (country / state / region /
+//     province / county / locale / currency). Country-of-residence
+//     defaults set by geo-IP are legitimate.
+//   - For radio groups: only annotate when at least one radio in the
+//     group reports `checked` at scan time. The group-focused skip
+//     covers the case where the user clicked a sibling before our
+//     scan.
+
+import { isCheckoutUrl } from "../lib/checkout-url";
+import {
+  FORM_PREFILL_ANNOTATED_ATTR as FLAGGED_ATTR,
+  RULE_ATTR,
+} from "../lib/dom-markers";
+import { log } from "../lib/log";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import type { Rule } from "./types";
+
+const RULE_ID = "form-prefill-annotate" as const;
+
+const FLAG_CLASS = "abs-form-prefill-annotate";
+
+// Reject after this many chips per form. Long forms (saved-card managers,
+// admin panels that happen to live under /order/*) would otherwise carry
+// chip clutter that drowns out the signal. Eight is well above the
+// typical checkout (name / email / phone / address line × few / postal /
+// shipping speed / tip).
+const MAX_CHIPS_PER_FORM = 8;
+
+// Recognized autocomplete tokens that imply browser/password-manager
+// autofill. When the `autocomplete` attribute names one of these, we
+// treat the prefill as legitimate. List intentionally short — we cover
+// the common shipping/billing checkout fields and skip more exotic
+// tokens (`cc-*`, `one-time-code`, etc.) because the rule never runs on
+// payment iframes anyway and a credit-card autofill is already off-
+// scope.
+const AUTOFILL_TOKENS: ReadonlySet<string> = new Set([
+  "name",
+  "given-name",
+  "additional-name",
+  "family-name",
+  "honorific-prefix",
+  "honorific-suffix",
+  "nickname",
+  "username",
+  "email",
+  "tel",
+  "tel-national",
+  "tel-area-code",
+  "tel-local",
+  "street-address",
+  "address-line1",
+  "address-line2",
+  "address-line3",
+  "address-level1",
+  "address-level2",
+  "address-level3",
+  "address-level4",
+  "country",
+  "country-name",
+  "postal-code",
+  "bday",
+  "bday-day",
+  "bday-month",
+  "bday-year",
+  "organization",
+  "organization-title",
+]);
+
+// Names / ids / labels that indicate a geo-driven <select> (country,
+// state, province, region, etc.). Geo-IP defaults are legitimate and
+// annotating them would generate noise on every international checkout.
+//
+// The boundary class is `[^A-Za-z]` instead of `\b` because real-world
+// selects use snake_case ids like `user_country_picker` — `\b` doesn't
+// fire at `_country_` since `_` is a word character.
+const GEO_SELECT_RE =
+  /(?:^|[^A-Za-z])(?:country|state|province|region|county|locale|language|currency|territory|prefecture)(?:[^A-Za-z]|$)/i;
+
+// Text input types we consider. `password` is excluded — a pre-filled
+// password is either restored by a password manager (legitimate) or a
+// site bug we shouldn't comment on. `search` is excluded — search boxes
+// aren't preselection vectors. `hidden` is handled by the companion
+// `hidden-affiliate-sanitize` rule.
+const TEXT_INPUT_TYPES: ReadonlySet<string> = new Set([
+  "text",
+  "email",
+  "tel",
+  "number",
+  "url",
+]);
+
+// jsdom (the test runtime) doesn't expose the global `CSS` object, so
+// `CSS.escape` would throw `ReferenceError` in unit tests that build a
+// <select> with an `id` attribute. Fall back to a conservative literal
+// matcher when CSS.escape isn't available — element ids in real pages
+// rarely contain quote chars and any id with quotes was never going to
+// pair with a `<label for>` lookup anyway.
+function escapeAttributeValue(value: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(value);
+  }
+  return value.replaceAll(/["\\]/g, String.raw`\$&`);
+}
+
+// Track controls that have been focused (or are currently focused) at
+// any point since the rule started observing. We don't annotate a
+// control the user has already interacted with — what's in the value
+// then is user-entered, not a server-pushed prefill.
+const focusedControls = new WeakSet<HTMLElement>();
+let focusInListener: ((event: FocusEvent) => void) | null = null;
+
+function ensureFocusTracking(): void {
+  if (focusInListener !== null) {
+    return;
+  }
+  focusInListener = (event) => {
+    const target = event.target;
+    if (target instanceof HTMLElement) {
+      focusedControls.add(target);
+    }
+  };
+  // capture:true so we record focusin before any page handler can stop
+  // propagation.
+  document.addEventListener("focusin", focusInListener, true);
+  const active = document.activeElement;
+  if (active instanceof HTMLElement) {
+    focusedControls.add(active);
+  }
+}
+
+function teardownFocusTracking(): void {
+  if (focusInListener === null) {
+    return;
+  }
+  document.removeEventListener("focusin", focusInListener, true);
+  focusInListener = null;
+}
+
+function isFlaggedAlready(element: Element): boolean {
+  return element.hasAttribute(FLAGGED_ATTR);
+}
+
+function readAutocompleteTokens(element: HTMLElement): readonly string[] {
+  const attribute = element.getAttribute("autocomplete");
+  if (attribute === null) {
+    return [];
+  }
+  return attribute
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+}
+
+function hasRecognizedAutofillToken(element: HTMLElement): boolean {
+  for (const token of readAutocompleteTokens(element)) {
+    if (AUTOFILL_TOKENS.has(token)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// `autocomplete="off"` and `autocomplete="on"` are not field-target
+// tokens. We treat the absence of a recognized target as "unspecified"
+// and proceed.
+function isExplicitAutofillOff(element: HTMLElement): boolean {
+  const tokens = readAutocompleteTokens(element);
+  return tokens.length === 1 && tokens[0] === "off";
+}
+
+// Read the field's accessible label-ish text for the GEO check on
+// <select>. Cheap concatenation across name/id/aria-label and a single
+// associated <label> if reachable. We don't walk the full a11y tree —
+// the GEO check only needs a recognizable signal.
+function readSelectLabelHints(element: HTMLSelectElement): string {
+  const parts: string[] = [];
+  const name = element.getAttribute("name");
+  if (name !== null) {
+    parts.push(name);
+  }
+  const id = element.id;
+  if (id.length > 0) {
+    parts.push(id);
+  }
+  const aria = element.getAttribute("aria-label");
+  if (aria !== null) {
+    parts.push(aria);
+  }
+  if (id.length > 0) {
+    const document_ = element.ownerDocument;
+    const label = document_.querySelector(
+      `label[for="${escapeAttributeValue(id)}"]`,
+    );
+    if (label !== null) {
+      parts.push(label.textContent);
+    }
+  }
+  // <select> inside a wrapping <label>.
+  const wrappingLabel = element.closest("label");
+  if (wrappingLabel !== null) {
+    parts.push(wrappingLabel.textContent);
+  }
+  return parts.join(" ");
+}
+
+export function isGeoSelect(element: HTMLSelectElement): boolean {
+  return GEO_SELECT_RE.test(readSelectLabelHints(element));
+}
+
+function isVisibleControl(element: HTMLElement): boolean {
+  // Cheap check: tab a hidden-by-type input out, and skip explicit
+  // `display:none` / `visibility:hidden` styles. We don't compute the
+  // full rendered box — that'd cost layout. The chip we'd attach
+  // wouldn't render on an invisible form anyway.
+  if (element instanceof HTMLInputElement && element.type === "hidden") {
+    return false;
+  }
+  if (element.hidden) {
+    return false;
+  }
+  const style = element.ownerDocument.defaultView?.getComputedStyle(element);
+  if (style === undefined) {
+    return true;
+  }
+  return style.display !== "none" && style.visibility !== "hidden";
+}
+
+function findChipTarget(element: HTMLElement): HTMLElement {
+  // The chip goes just above the field rather than inside it because
+  // <input>/<select> have no child text rendering. Walk up to the first
+  // useful insertion point — a wrapping <label>, a `.field` / `.form-
+  // row` wrapper, or just the parent element.
+  const wrappingLabel = element.closest("label");
+  if (wrappingLabel !== null && wrappingLabel instanceof HTMLElement) {
+    return wrappingLabel;
+  }
+  const parent = element.parentElement;
+  return parent ?? element;
+}
+
+function buildChip(text: string): HTMLSpanElement {
+  const chip = document.createElement("span");
+  chip.className = FLAG_CLASS;
+  chip.setAttribute(RULE_ATTR, RULE_ID);
+  // Inline styling so the chip is visible even on pages that strip
+  // extension stylesheets. Block layout puts the chip on its own line
+  // above the field.
+  chip.style.display = "block";
+  chip.style.padding = "2px 6px";
+  chip.style.margin = "0 0 4px 0";
+  chip.style.border = "1px solid #b00";
+  chip.style.background = "#fff5f5";
+  chip.style.color = "#900";
+  chip.style.font = "12px/1.4 system-ui, sans-serif";
+  chip.style.fontStyle = "italic";
+  chip.textContent = text;
+  return chip;
+}
+
+function countChipsInForm(form: HTMLElement | null): number {
+  if (form === null) {
+    return 0;
+  }
+  return form.querySelectorAll(`.${FLAG_CLASS}`).length;
+}
+
+function getEnclosingForm(element: HTMLElement): HTMLElement | null {
+  const form = element.closest("form");
+  return form instanceof HTMLElement ? form : null;
+}
+
+interface TextCandidate {
+  kind: "text";
+  control: HTMLInputElement;
+  inputType: string;
+}
+
+interface SelectCandidate {
+  kind: "select";
+  control: HTMLSelectElement;
+  selectedLabel: string;
+}
+
+interface RadioCandidate {
+  kind: "radio";
+  // The fieldset / wrapper that we'll chip. Picked once per radio group.
+  target: HTMLElement;
+  control: HTMLInputElement;
+  groupName: string;
+  selectedLabel: string;
+}
+
+type Candidate = TextCandidate | SelectCandidate | RadioCandidate;
+
+function readTextCandidate(input: HTMLInputElement): TextCandidate | null {
+  const type = input.type.toLowerCase();
+  if (!TEXT_INPUT_TYPES.has(type)) {
+    return null;
+  }
+  if (input.disabled || input.readOnly) {
+    return null;
+  }
+  if (!isVisibleControl(input)) {
+    return null;
+  }
+  if (focusedControls.has(input)) {
+    return null;
+  }
+  if (hasRecognizedAutofillToken(input)) {
+    return null;
+  }
+  // `autocomplete="off"` on a pre-filled field is the most interesting
+  // case — the site disabled browser autofill yet still served a value.
+  // Don't skip it just because the attribute was set; fall through.
+  isExplicitAutofillOff(input);
+  // Read live `.value` rather than the `value` attribute. The attribute
+  // is only set when SSR templated the prefill in HTML; framework-
+  // rendered defaults (React `defaultValue`, Vue `v-model` initialState,
+  // jQuery `.val()`) populate the live property without writing an
+  // attribute. The agent's DOM snapshot reads the live property too, so
+  // our scan should match what the agent will see. The focused-set
+  // skip above already covers the "user typed it" case.
+  if (input.value.trim().length === 0) {
+    return null;
+  }
+  return { kind: "text", control: input, inputType: type };
+}
+
+function readSelectCandidate(
+  select: HTMLSelectElement,
+): SelectCandidate | null {
+  if (select.disabled) {
+    return null;
+  }
+  if (!isVisibleControl(select)) {
+    return null;
+  }
+  if (focusedControls.has(select)) {
+    return null;
+  }
+  if (isGeoSelect(select)) {
+    return null;
+  }
+  // Multi-selects don't have a "default option" notion in the same way;
+  // they ship with whatever rows the page chose to mark `selected`.
+  // Annotating those would add noise without surfacing a sneak pattern.
+  if (select.multiple) {
+    return null;
+  }
+  // Use the live `selectedIndex` rather than scanning for `<option
+  // selected>` because framework defaults (React `<select
+  // defaultValue=…>`, Vue `v-model` initialState) populate the property
+  // without writing the attribute. The focused-set skip above already
+  // covers the "user changed it" case before our scan.
+  if (select.selectedIndex <= 0) {
+    return null;
+  }
+  const option = select.options[select.selectedIndex];
+  if (option === undefined) {
+    return null;
+  }
+  const text = option.textContent.trim();
+  const selectedLabel = text.length > 0 ? text : option.value.trim();
+  return { kind: "select", control: select, selectedLabel };
+}
+
+function findRadioGroupTarget(radio: HTMLInputElement): HTMLElement {
+  const fieldset = radio.closest("fieldset");
+  if (fieldset instanceof HTMLElement) {
+    return fieldset;
+  }
+  // role="radiogroup" container — common in ARIA-styled designs that
+  // wrap native radios in a div.
+  let cursor: HTMLElement | null = radio.parentElement;
+  while (cursor !== null) {
+    if (cursor.getAttribute("role") === "radiogroup") {
+      return cursor;
+    }
+    cursor = cursor.parentElement;
+  }
+  return radio.parentElement ?? radio;
+}
+
+function readRadioCandidate(radio: HTMLInputElement): RadioCandidate | null {
+  if (radio.type.toLowerCase() !== "radio") {
+    return null;
+  }
+  if (radio.disabled) {
+    return null;
+  }
+  if (!isVisibleControl(radio)) {
+    return null;
+  }
+  // Live property covers framework-rendered defaults (React
+  // `defaultChecked`, Vue `v-model`) the same way the agent's snapshot
+  // would see them. The group-focused skip below covers the case
+  // where the user clicked any sibling in the group before our scan.
+  if (!radio.checked) {
+    return null;
+  }
+  const groupName = radio.name;
+  // Radios without a `name` aren't a group — they're standalone
+  // toggles. We don't have the "did the agent need to keep some option
+  // selected?" concern for those, so leave them to the checkbox rule's
+  // domain (it doesn't touch them either; see issue #121).
+  if (groupName.length === 0) {
+    return null;
+  }
+  const target = findRadioGroupTarget(radio);
+  // Multiple checked radios with the same `name` is a malformed group
+  // — the browser will resolve to the last-checked one, but we only
+  // annotate once.
+  if (isFlaggedAlready(target)) {
+    return null;
+  }
+  // If the user clicked any radio in the group before our scan, treat
+  // the group's selection as user-driven. `radio.form` scopes the
+  // lookup so distinct `<form>`s with the same `name` don't collide.
+  const root = radio.form ?? radio.ownerDocument;
+  for (const sibling of root.querySelectorAll<HTMLInputElement>(
+    `input[type="radio"][name="${escapeAttributeValue(groupName)}"]`,
+  )) {
+    if (focusedControls.has(sibling)) {
+      return null;
+    }
+  }
+  let selectedLabel = radio.value;
+  if (radio.id.length > 0) {
+    const label = radio.ownerDocument.querySelector(
+      `label[for="${escapeAttributeValue(radio.id)}"]`,
+    );
+    if (label !== null) {
+      const text = label.textContent.trim();
+      if (text.length > 0) {
+        selectedLabel = text;
+      }
+    }
+  } else {
+    const wrappingLabel = radio.closest("label");
+    if (wrappingLabel !== null) {
+      const text = wrappingLabel.textContent.trim();
+      if (text.length > 0) {
+        selectedLabel = text;
+      }
+    }
+  }
+  return {
+    kind: "radio",
+    target,
+    control: radio,
+    groupName,
+    selectedLabel,
+  };
+}
+
+function collectCandidates(root: ParentNode): Candidate[] {
+  const out: Candidate[] = [];
+  const seenRadioGroups = new Set<string>();
+
+  for (const input of root.querySelectorAll<HTMLInputElement>(
+    `input:not([${FLAGGED_ATTR}])`,
+  )) {
+    if (!input.isConnected) {
+      continue;
+    }
+    const type = input.type.toLowerCase();
+    if (TEXT_INPUT_TYPES.has(type)) {
+      const candidate = readTextCandidate(input);
+      if (candidate !== null) {
+        out.push(candidate);
+      }
+      continue;
+    }
+    if (type === "radio") {
+      // Only consider the first checked radio per group; the chip lives
+      // on the group container, not on individual radios.
+      const formScope = getEnclosingForm(input);
+      const scopeKey =
+        formScope === null ? "" : `${formScope.id || "_form_"}::`;
+      const groupKey = `${scopeKey}${input.name}`;
+      if (seenRadioGroups.has(groupKey)) {
+        continue;
+      }
+      const candidate = readRadioCandidate(input);
+      if (candidate === null) {
+        continue;
+      }
+      seenRadioGroups.add(groupKey);
+      out.push(candidate);
+    }
+  }
+
+  for (const select of root.querySelectorAll<HTMLSelectElement>(
+    `select:not([${FLAGGED_ATTR}])`,
+  )) {
+    if (!select.isConnected) {
+      continue;
+    }
+    const candidate = readSelectCandidate(select);
+    if (candidate !== null) {
+      out.push(candidate);
+    }
+  }
+
+  return out;
+}
+
+function chipTextFor(candidate: Candidate): string {
+  switch (candidate.kind) {
+    case "text": {
+      return `[abs: pre-populated ${candidate.inputType} field — verify before submit]`;
+    }
+    case "select": {
+      // Quote the label so the agent's snapshot reader sees the
+      // specific default that was set — but without the field's name
+      // (preselection is about *what* is the default, not which field).
+      // Trim long labels so a verbose option doesn't explode the chip.
+      const label = candidate.selectedLabel.slice(0, 60);
+      return `[abs: select default "${label}" is not the first option — verify before submit]`;
+    }
+    case "radio": {
+      const label = candidate.selectedLabel.slice(0, 60);
+      return `[abs: radio "${label}" pre-selected — verify before submit]`;
+    }
+  }
+}
+
+function flag(candidate: Candidate): void {
+  const target =
+    candidate.kind === "radio"
+      ? candidate.target
+      : findChipTarget(candidate.control);
+  if (!target.isConnected) {
+    return;
+  }
+
+  const form = getEnclosingForm(target);
+  if (countChipsInForm(form) >= MAX_CHIPS_PER_FORM) {
+    return;
+  }
+
+  // Stamp the control itself so a later scan doesn't re-evaluate it,
+  // and stamp the target so we don't append a sibling chip in case the
+  // same target is selected by two different candidates (the
+  // seenRadioGroups guard already prevents that for radios within one
+  // scan; the target stamp is the cross-scan guard for radios).
+  candidate.control.setAttribute(FLAGGED_ATTR, "");
+  if (target !== candidate.control) {
+    target.setAttribute(FLAGGED_ATTR, "");
+  }
+
+  const chip = buildChip(chipTextFor(candidate));
+  target.prepend(chip);
+}
+
+function scanAndFlag(root: ParentNode): void {
+  if (!isCheckoutUrl(globalThis.location.href)) {
+    return;
+  }
+  const candidates = collectCandidates(root);
+  if (candidates.length === 0) {
+    return;
+  }
+  ensureFocusTracking();
+  let count = 0;
+  for (const candidate of candidates) {
+    flag(candidate);
+    count++;
+  }
+  log("form prefills flagged", {
+    count,
+    kinds: candidates.map((c) => c.kind),
+    url: globalThis.location.href,
+  });
+}
+
+const watcher = createSubtreeWatcher({
+  onSubtrees: (roots) => {
+    for (const root of roots) {
+      scanAndFlag(root);
+    }
+  },
+});
+
+function apply(root: ParentNode): void {
+  ensureFocusTracking();
+  scanAndFlag(root);
+  watcher.start(root);
+}
+
+export const formPrefillAnnotateRule = {
+  id: RULE_ID,
+  label: "Annotate Form Prefills (Experimental)",
+  description:
+    "On checkout pages, flag pre-populated text/email/tel/number fields, non-first <select> defaults, and pre-selected radio groups with a visible annotation. Values are not changed — the agent reads the chip and decides whether to overwrite.",
+  apply,
+  teardown: () => {
+    watcher.stop();
+    teardownFocusTracking();
+  },
+} satisfies Rule;

--- a/extension/src/rules/index.ts
+++ b/extension/src/rules/index.ts
@@ -15,6 +15,7 @@ import { crossOriginFrameRedactRule } from "./cross-origin-frame-redact";
 import { disguisedAdFlagRule } from "./disguised-ad-flag";
 import { encodedPayloadRedactRule } from "./encoded-payload-redact";
 import { footerRedactRule } from "./footer-redact";
+import { formPrefillAnnotateRule } from "./form-prefill-annotate";
 import { hiddenFeeAnnotateRule } from "./hidden-fee-annotate";
 import { hiddenTextStripRule } from "./hidden-text-strip";
 import { htmlCommentStripRule } from "./html-comment-strip";
@@ -92,6 +93,7 @@ const RULES_TUPLE = [
   webdriverProbeAnnotateRule,
   closedShadowRootAnnotateRule,
   hiddenFeeAnnotateRule,
+  formPrefillAnnotateRule,
 ] as const satisfies readonly Rule[];
 
 export type RuleId = (typeof RULES_TUPLE)[number]["id"];

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -44,6 +44,7 @@ export const RULE_DEFAULTS = {
   "webdriver-probe-annotate": false,
   "closed-shadow-root-annotate": false,
   "hidden-fee-annotate": true,
+  "form-prefill-annotate": true,
 } as const satisfies Readonly<Record<string, boolean>>;
 
 export type RuleId = keyof typeof RULE_DEFAULTS;


### PR DESCRIPTION
## Summary

- Splits issue [#121](https://github.com/pixiebrix/agent-browser-shield/issues/121) into an annotate-first rule (this PR) and a narrow sanitize companion (follow-up).
- `form-prefill-annotate` chips three control shapes on checkout URLs: text/email/tel/number/url inputs with a non-empty live value, `<select>`s whose `selectedIndex !== 0`, and radio groups with a checked option. Values are not changed.
- Layered FP control: URL gate, recognized-`autocomplete`-token allowlist, geo-select skiplist, focused-control + group-focused skip via `focusin`, per-form chip cap, visible-only filter.
- Ships default-on as Experimental — annotation-only, worst-case is an extra chip.
- Docs (`docs/src/content/docs/rules.md`) and demo Checkout page updated. Future-work bullets list the deferred hidden-input arm, include-value-in-chip, synthetic-blur-on-annotate, and sanitize-mode-for-`<select>` options.

## Test plan

- [x] `bun run test` (1498 tests)
- [x] `bun run check` (biome + eslint)
- [x] `pre-commit run --files docs/src/content/docs/rules.md`
- [x] `bun run build` in demo-site
- [x] Catalog invariants test passes (`rule-defaults.generated.ts` regenerated)
- [x] New unit tests cover all three control kinds, autofill-token gate, geo-select gate, focused-control skip, chip cap, URL gate, idempotency, lazy-loaded subtrees
- [x] Property tests assert autocomplete-allowlist disjointness, geo-select coverage across name/id/aria, `<select>` first-option invariant, and idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)