### PR TITLE
Feat: hidden-affiliate-sanitize rule for affiliate/UTM/referral metadata (#121)

### DIFF
--- a/demo-site/src/pages/Checkout.tsx
+++ b/demo-site/src/pages/Checkout.tsx
@@ -47,9 +47,11 @@ export default function Checkout() {
               4. Shipping & contact
             </h2>
             <form className="space-y-3 text-sm text-stone-700">
-              {/* Hidden affiliate / UTM / promo metadata — exercises
-                  hidden-affiliate-sanitize. The csrf_token must be
-                  preserved; everything else is cleared. */}
+              {/* Hidden affiliate / UTM attribution metadata — exercises
+                  hidden-affiliate-sanitize. utm_* / aff_id are cleared.
+                  csrf_token and coupon_code are preserved: CSRF would
+                  silently reject the submit, and coupon_code commonly
+                  carries a legitimate user-acquired discount. */}
               <input
                 type="hidden"
                 name="utm_source"

--- a/demo-site/src/pages/Checkout.tsx
+++ b/demo-site/src/pages/Checkout.tsx
@@ -47,6 +47,26 @@ export default function Checkout() {
               4. Shipping & contact
             </h2>
             <form className="space-y-3 text-sm text-stone-700">
+              {/* Hidden affiliate / UTM / promo metadata — exercises
+                  hidden-affiliate-sanitize. The csrf_token must be
+                  preserved; everything else is cleared. */}
+              <input
+                type="hidden"
+                name="utm_source"
+                defaultValue="email-newsletter"
+              />
+              <input
+                type="hidden"
+                name="utm_campaign"
+                defaultValue="winter25"
+              />
+              <input type="hidden" name="aff_id" defaultValue="affsite-42" />
+              <input type="hidden" name="coupon_code" defaultValue="SAVE10" />
+              <input
+                type="hidden"
+                name="csrf_token"
+                defaultValue="9f7d3c2a-CSRF"
+              />
               <label className="block">
                 <span className="block font-medium text-stone-800">
                   Marketing email

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -689,8 +689,7 @@ keeps user-entered values out of the flag set.
 Hidden inputs are out of scope for this rule — the value is submitted regardless
 of any chip and the agent never reads hidden inputs into a decision, so
 annotation would not change behavior. The hidden-input arm is handled by
-[Scrub Hidden Affiliate / Promo Metadata](#scrub-hidden-affiliate--promo-metadata)
-below.
+[Scrub Hidden Affiliate Metadata](#scrub-hidden-affiliate-metadata) below.
 
 Future work tracked in issue
 [#121](https://github.com/pixiebrix/agent-browser-shield/issues/121):
@@ -708,22 +707,29 @@ Pre-populated form fields are *Preselection* in Mathur et al.
 [[9]](#ref-mathur-dark-patterns) and Brignull's deceptive.design catalog
 [[10]](#ref-brignull).
 
-#### Scrub Hidden Affiliate / Promo Metadata
+#### Scrub Hidden Affiliate Metadata
 
 - **ID:** `hidden-affiliate-sanitize`
 - **Default:** on
 
 On checkout-like URLs, clear `value` on `<input type="hidden">` whose `name`
-matches a curated affiliate / UTM / promo / coupon allowlist (`utm_source` /
-`utm_medium` / `utm_campaign` / `utm_term` / `utm_content`, `aff` / `aff_id` /
-`affiliate_id`, `ref` / `ref_id` / `referrer` / `referral_code`, `promo` /
-`promo_code` / `promotion_id`, `coupon` / `coupon_code` / `coupon_id`,
-`discount_code` / `discount_id`, `source_id` / `campaign_id` / `partner_code`,
-`click_id`, `gclid` / `fbclid` / `msclkid`). The input is preserved — only its
-value is cleared — so the form's structure and the page's own scripts that read
-the input's existence still work. Annotation is the wrong tool here because
-hidden inputs are submitted regardless of any chip and never reach the agent's
-snapshot; sanitize-and-forget is the only useful action.
+matches a curated affiliate / UTM / referral attribution allowlist (`utm_source`
+/ `utm_medium` / `utm_campaign` / `utm_term` / `utm_content`, `aff` / `aff_id` /
+`affiliate_id`, `ref` / `ref_id` / `referrer` / `referral_code`, `source_id` /
+`campaign_id` / `partner_code`, `click_id`, `gclid` / `fbclid` / `msclkid`). The
+input is preserved — only its value is cleared — so the form's structure and the
+page's own scripts that read the input's existence still work. Annotation is the
+wrong tool here because hidden inputs are submitted regardless of any chip and
+never reach the agent's snapshot; sanitize-and-forget is the only useful action.
+
+Scope is attribution only — promo / coupon / discount names (`promo`,
+`promo_code`, `promotion_id`, `coupon`, `coupon_code`, `coupon_id`,
+`discount_code`, `discount_id`) are intentionally **not** in the allowlist.
+Hidden promo-code inputs commonly carry a legitimate user-acquired discount
+(email promo link, sticky session promo, "apply coupon" UI that writes to a
+hidden field at submit time). Clearing them would silently strip the user's
+discount with no visible recourse. Attribution has the opposite asymmetry —
+clearing it is invisible to the user and only costs the marketing trail.
 
 Hard CSRF / session / cart / order / nonce / state / signature denylist takes
 precedence: any name containing `csrf`, `nonce`, `signature`, `hmac`, `secret`,
@@ -741,9 +747,9 @@ trackers observe the change. No `input` or `change` event is dispatched — hidd
 inputs aren't expected to fire those, and firing one could trip
 totals-recalculation handlers that re-fetch attribution from the same source.
 
-Affiliate / UTM / promo metadata is part of the *Sneaking* family in Mathur et
-al. [[9]](#ref-mathur-dark-patterns) and the *Hidden costs / hidden information*
-catalog in Brignull's deceptive.design [[10]](#ref-brignull).
+Affiliate / UTM attribution metadata is part of the *Sneaking* family in Mathur
+et al. [[9]](#ref-mathur-dark-patterns) and the *Hidden costs / hidden
+information* catalog in Brignull's deceptive.design [[10]](#ref-brignull).
 
 ### Confirmshaming
 

--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -3,7 +3,7 @@ title: Rules reference
 description: The defense rules shipped with agent-browser-shield, what each one does, and its default state.
 ---
 
-The extension ships 38 rules, each independently toggleable from the extension's
+The extension ships 39 rules, each independently toggleable from the extension's
 options page. Rules marked **default: on** are active on fresh install;
 **default: off** rules must be enabled manually.
 
@@ -688,15 +688,13 @@ keeps user-entered values out of the flag set.
 
 Hidden inputs are out of scope for this rule — the value is submitted regardless
 of any chip and the agent never reads hidden inputs into a decision, so
-annotation would not change behavior.
+annotation would not change behavior. The hidden-input arm is handled by
+[Scrub Hidden Affiliate / Promo Metadata](#scrub-hidden-affiliate--promo-metadata)
+below.
 
 Future work tracked in issue
 [#121](https://github.com/pixiebrix/agent-browser-shield/issues/121):
 
-- A narrow sanitize companion that clears `value` on `<input type="hidden">`
-  whose `name` matches a curated affiliate / UTM / promo allowlist, behind a
-  hard CSRF / cart / session denylist. Different toggle so the FP profile is
-  controllable separately.
 - Optionally include the prefilled value in the chip text. The chip flags
   presence only today, to avoid leaking remembered PII into a logging snapshot.
 - Synthetic blur / change event after annotation so sites that recalc totals on
@@ -709,6 +707,43 @@ Future work tracked in issue
 Pre-populated form fields are *Preselection* in Mathur et al.
 [[9]](#ref-mathur-dark-patterns) and Brignull's deceptive.design catalog
 [[10]](#ref-brignull).
+
+#### Scrub Hidden Affiliate / Promo Metadata
+
+- **ID:** `hidden-affiliate-sanitize`
+- **Default:** on
+
+On checkout-like URLs, clear `value` on `<input type="hidden">` whose `name`
+matches a curated affiliate / UTM / promo / coupon allowlist (`utm_source` /
+`utm_medium` / `utm_campaign` / `utm_term` / `utm_content`, `aff` / `aff_id` /
+`affiliate_id`, `ref` / `ref_id` / `referrer` / `referral_code`, `promo` /
+`promo_code` / `promotion_id`, `coupon` / `coupon_code` / `coupon_id`,
+`discount_code` / `discount_id`, `source_id` / `campaign_id` / `partner_code`,
+`click_id`, `gclid` / `fbclid` / `msclkid`). The input is preserved — only its
+value is cleared — so the form's structure and the page's own scripts that read
+the input's existence still work. Annotation is the wrong tool here because
+hidden inputs are submitted regardless of any chip and never reach the agent's
+snapshot; sanitize-and-forget is the only useful action.
+
+Hard CSRF / session / cart / order / nonce / state / signature denylist takes
+precedence: any name containing `csrf`, `nonce`, `signature`, `hmac`, `secret`,
+`session`, `antiforgery`, etc. is preserved even if it also overlaps the
+allowlist by name shape. Failure mode for those is a silently-rejected submit —
+strictly worse than the original dark pattern. The input must live inside an
+enclosing `<form>` (either as a descendant or via a `form` attribute reference);
+free-floating hidden inputs are JS-only data carriers we leave alone. A per-host
+kill-switch (empty at launch) covers loyalty / Apple Pay / 1-Click flows where
+saved attribution is the user's intent; populate via PR review as live signal
+surfaces hosts where the affiliate id is load-bearing.
+
+`value` is cleared via the prototype's native setter so React / Vue value
+trackers observe the change. No `input` or `change` event is dispatched — hidden
+inputs aren't expected to fire those, and firing one could trip
+totals-recalculation handlers that re-fetch attribution from the same source.
+
+Affiliate / UTM / promo metadata is part of the *Sneaking* family in Mathur et
+al. [[9]](#ref-mathur-dark-patterns) and the *Hidden costs / hidden information*
+catalog in Brignull's deceptive.design [[10]](#ref-brignull).
 
 ### Confirmshaming
 

--- a/extension/data/rule-defaults.json
+++ b/extension/data/rule-defaults.json
@@ -37,6 +37,7 @@
     "webdriver-probe-annotate": false,
     "closed-shadow-root-annotate": false,
     "hidden-fee-annotate": true,
-    "form-prefill-annotate": true
+    "form-prefill-annotate": true,
+    "hidden-affiliate-sanitize": true
   }
 }

--- a/extension/src/lib/dom-markers.ts
+++ b/extension/src/lib/dom-markers.ts
@@ -85,3 +85,11 @@ export const CONFIRMSHAME_ORIGINAL_TITLE_ATTR =
 // stamped on controls that were considered and rejected by the FP-control
 // gates so re-scans skip them on every burst.
 export const FORM_PREFILL_ANNOTATED_ATTR = "data-abs-form-prefill-annotated";
+
+// `hidden-affiliate-sanitize`: marks a hidden input whose value the rule has
+// already cleared (or considered and rejected via denylist / per-host kill-
+// switch). Stamped on both outcomes so re-scans don't re-evaluate the same
+// node every mutation burst, and so a later page-script value-write doesn't
+// drive an infinite re-clear loop.
+export const HIDDEN_AFFILIATE_CLEARED_ATTR =
+  "data-abs-hidden-affiliate-cleared";

--- a/extension/src/lib/rule-groups.ts
+++ b/extension/src/lib/rule-groups.ts
@@ -57,6 +57,7 @@ export const RULE_GROUPS: readonly RuleGroup[] = [
       "hidden-fee-annotate",
       "checkout-checkbox-sanitize",
       "form-prefill-annotate",
+      "hidden-affiliate-sanitize",
       "confirmshame-sanitize",
       "roach-motel-annotate",
       "newsletter-modal-hide",

--- a/extension/src/popup/rule-labels.ts
+++ b/extension/src/popup/rule-labels.ts
@@ -56,4 +56,5 @@ export const RULE_LABELS: Readonly<Record<RuleId, string>> = {
   "closed-shadow-root-annotate": "Flag Closed Shadow Roots",
   "hidden-fee-annotate": "Annotate Drip-Pricing Fees (Experimental)",
   "form-prefill-annotate": "Annotate Form Prefills (Experimental)",
+  "hidden-affiliate-sanitize": "Scrub Hidden Affiliate / Promo Metadata",
 } as const satisfies Record<RuleId, string>;

--- a/extension/src/popup/rule-labels.ts
+++ b/extension/src/popup/rule-labels.ts
@@ -56,5 +56,5 @@ export const RULE_LABELS: Readonly<Record<RuleId, string>> = {
   "closed-shadow-root-annotate": "Flag Closed Shadow Roots",
   "hidden-fee-annotate": "Annotate Drip-Pricing Fees (Experimental)",
   "form-prefill-annotate": "Annotate Form Prefills (Experimental)",
-  "hidden-affiliate-sanitize": "Scrub Hidden Affiliate / Promo Metadata",
+  "hidden-affiliate-sanitize": "Scrub Hidden Affiliate Metadata",
 } as const satisfies Record<RuleId, string>;

--- a/extension/src/rules/__tests__/hidden-affiliate-sanitize.property.test.ts
+++ b/extension/src/rules/__tests__/hidden-affiliate-sanitize.property.test.ts
@@ -22,9 +22,10 @@ import {
   shouldClearName,
 } from "../hidden-affiliate-sanitize";
 
-// Mirror of the affiliate name set sufficient for property exploration.
-// The unit suite covers the exhaustive list; here we draw from a
-// representative sample.
+// Mirror of the attribution name set sufficient for property
+// exploration. The unit suite covers the exhaustive list; here we draw
+// from a representative sample. Promo / coupon / discount names are
+// deliberately absent — see PROMO_NAMES below.
 const AFFILIATE_NAMES: readonly string[] = [
   "utm_source",
   "utm_medium",
@@ -40,17 +41,29 @@ const AFFILIATE_NAMES: readonly string[] = [
   "refid",
   "referrer",
   "referral_code",
-  "promo",
-  "promo_code",
-  "promotion_id",
-  "coupon",
-  "coupon_code",
-  "coupon_id",
-  "discount_code",
+  "source_id",
+  "campaign_id",
+  "partner_code",
   "click_id",
   "gclid",
   "fbclid",
   "msclkid",
+];
+
+// Promo / coupon / discount names. The rule must preserve these — they
+// commonly carry a legitimate user-acquired discount and clearing them
+// would silently strip it.
+const PROMO_NAMES: readonly string[] = [
+  "promo",
+  "promo_code",
+  "promotion",
+  "promotion_id",
+  "coupon",
+  "coupon_code",
+  "coupon_id",
+  "discount",
+  "discount_code",
+  "discount_id",
 ];
 
 // Substring tokens that must always be preserved regardless of context.
@@ -109,6 +122,48 @@ describe("denylist precedence (property)", () => {
           // preserved.
           const name = `${allow}_${deny}_combined`;
           expect(shouldClearName(name)).toBe(false);
+        },
+      ),
+    );
+  });
+});
+
+describe("promo / coupon / discount preservation (property)", () => {
+  it("no promo name matches the allowlist or gets cleared", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...PROMO_NAMES), (name) => {
+        expect(isAffiliateName(name)).toBe(false);
+        expect(shouldClearName(name)).toBe(false);
+      }),
+    );
+  });
+
+  it("hidden promo inputs at checkout keep their value", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...PROMO_NAMES),
+        fc.stringMatching(/^[A-Z0-9-]{4,16}$/),
+        (name, code) => {
+          document.body.innerHTML = "";
+          const form = document.createElement("form");
+          const promo = document.createElement("input");
+          promo.type = "hidden";
+          promo.name = name;
+          promo.value = code;
+          const utm = document.createElement("input");
+          utm.type = "hidden";
+          utm.name = "utm_source";
+          utm.value = "email";
+          form.append(promo, utm);
+          document.body.append(form);
+
+          hiddenAffiliateSanitizeRule.apply(document.body);
+
+          // Promo value survives.
+          expect(promo.value).toBe(code);
+          // Attribution gets cleared.
+          expect(utm.value).toBe("");
+          hiddenAffiliateSanitizeRule.teardown();
         },
       ),
     );

--- a/extension/src/rules/__tests__/hidden-affiliate-sanitize.property.test.ts
+++ b/extension/src/rules/__tests__/hidden-affiliate-sanitize.property.test.ts
@@ -1,0 +1,203 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://shop.example.com/checkout"}
+ */
+// Property-based tests for hidden-affiliate-sanitize. fast-check
+// explores the boundary cases the FP control gates are supposed to
+// reject:
+//   - allowlist / denylist disjointness — no curated affiliate name
+//     should also match the denylist,
+//   - denylist precedence — any name containing a security-critical
+//     token must be preserved,
+//   - idempotency under repeated apply(),
+//   - URL-gate invariance off checkout.
+
+import fc from "fast-check";
+
+import { HIDDEN_AFFILIATE_CLEARED_ATTR as CLEARED_ATTR } from "../../lib/dom-markers";
+import {
+  hiddenAffiliateSanitizeRule,
+  isAffiliateName,
+  isDenylistedName,
+  shouldClearName,
+} from "../hidden-affiliate-sanitize";
+
+// Mirror of the affiliate name set sufficient for property exploration.
+// The unit suite covers the exhaustive list; here we draw from a
+// representative sample.
+const AFFILIATE_NAMES: readonly string[] = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "aff",
+  "aff_id",
+  "affid",
+  "affiliate_id",
+  "ref",
+  "ref_id",
+  "refid",
+  "referrer",
+  "referral_code",
+  "promo",
+  "promo_code",
+  "promotion_id",
+  "coupon",
+  "coupon_code",
+  "coupon_id",
+  "discount_code",
+  "click_id",
+  "gclid",
+  "fbclid",
+  "msclkid",
+];
+
+// Substring tokens that must always be preserved regardless of context.
+const SECURITY_TOKENS: readonly string[] = [
+  "csrf",
+  "nonce",
+  "signature",
+  "hmac",
+  "secret",
+  "session",
+  "antiforgery",
+];
+
+afterEach(() => {
+  hiddenAffiliateSanitizeRule.teardown();
+  document.body.innerHTML = "";
+});
+
+describe("allowlist / denylist disjointness (property)", () => {
+  it("no curated affiliate name matches the denylist", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...AFFILIATE_NAMES), (name) => {
+        expect(isAffiliateName(name)).toBe(true);
+        expect(isDenylistedName(name)).toBe(false);
+        expect(shouldClearName(name)).toBe(true);
+      }),
+    );
+  });
+});
+
+describe("denylist precedence (property)", () => {
+  it("any name containing a security token is preserved", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...SECURITY_TOKENS),
+        fc.constantFrom("", "_", "-", "__"),
+        fc.constantFrom("", "_v2", "_token", "1", "_id"),
+        (token, prefix, suffix) => {
+          const name = `${prefix}${token}${suffix}`;
+          expect(isDenylistedName(name)).toBe(true);
+          expect(shouldClearName(name)).toBe(false);
+        },
+      ),
+    );
+  });
+
+  it("a denied name overlapping the allowlist still does not clear", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...AFFILIATE_NAMES),
+        fc.constantFrom(...SECURITY_TOKENS),
+        (allow, deny) => {
+          // Compose a name that contains both — e.g. `utm_csrf_source`.
+          // The combination semantically conflicts with the allowlist
+          // intent (the field has CSRF in its purpose) and should be
+          // preserved.
+          const name = `${allow}_${deny}_combined`;
+          expect(shouldClearName(name)).toBe(false);
+        },
+      ),
+    );
+  });
+});
+
+describe("URL-gate invariance (property)", () => {
+  it("never clears on a non-checkout URL", () => {
+    const originalHref = globalThis.location.href;
+    globalThis.history.replaceState({}, "", "/account");
+    try {
+      fc.assert(
+        fc.property(fc.constantFrom(...AFFILIATE_NAMES), (name) => {
+          document.body.innerHTML = "";
+          const form = document.createElement("form");
+          const input = document.createElement("input");
+          input.type = "hidden";
+          input.name = name;
+          input.value = "some-tracker-id";
+          form.append(input);
+          document.body.append(form);
+
+          hiddenAffiliateSanitizeRule.apply(document.body);
+          // `.value` should be untouched.
+          expect(input.value).toBe("some-tracker-id");
+          // No CLEARED_ATTR stamp on a no-op URL.
+          expect(input.hasAttribute(CLEARED_ATTR)).toBe(false);
+          hiddenAffiliateSanitizeRule.teardown();
+        }),
+      );
+    } finally {
+      globalThis.history.replaceState({}, "", originalHref);
+    }
+  });
+});
+
+describe("idempotency (property)", () => {
+  it("applying twice yields the same cleared-set as once", () => {
+    // Build a form with a mix of allowlisted and denylisted names,
+    // each appearing at most once so we don't accidentally violate
+    // <input name> uniqueness invariants the rule doesn't promise to
+    // handle. Names are drawn verbatim (no suffix) so the allowlist
+    // actually matches.
+    const PRESERVED: readonly string[] = [
+      "csrf_token",
+      "cart_id",
+      "session_id",
+      "email",
+    ];
+    const NAMES_ARB = fc.uniqueArray(
+      fc.constantFrom(...AFFILIATE_NAMES, ...PRESERVED),
+      { minLength: 1, maxLength: 6 },
+    );
+    fc.assert(
+      fc.property(
+        NAMES_ARB,
+        fc.stringMatching(/^[A-Za-z0-9-]{1,15}$/),
+        (names, value) => {
+          document.body.innerHTML = "";
+          const form = document.createElement("form");
+          const inputs: HTMLInputElement[] = [];
+          for (const name of names) {
+            const input = document.createElement("input");
+            input.type = "hidden";
+            input.name = name;
+            input.value = value;
+            form.append(input);
+            inputs.push(input);
+          }
+          document.body.append(form);
+
+          hiddenAffiliateSanitizeRule.apply(document.body);
+          const firstSnapshot = inputs.map((input) => input.value);
+          // Allowlisted entries should be empty; denylisted/other names
+          // unchanged.
+          for (const [i, name] of names.entries()) {
+            if (shouldClearName(name)) {
+              expect(firstSnapshot[i]).toBe("");
+            } else {
+              expect(firstSnapshot[i]).toBe(value);
+            }
+          }
+          hiddenAffiliateSanitizeRule.apply(document.body);
+          const secondSnapshot = inputs.map((input) => input.value);
+          expect(secondSnapshot).toEqual(firstSnapshot);
+          hiddenAffiliateSanitizeRule.teardown();
+        },
+      ),
+      { numRuns: 40 },
+    );
+  });
+});

--- a/extension/src/rules/__tests__/hidden-affiliate-sanitize.property.test.ts
+++ b/extension/src/rules/__tests__/hidden-affiliate-sanitize.property.test.ts
@@ -75,6 +75,7 @@ const SECURITY_TOKENS: readonly string[] = [
   "secret",
   "session",
   "antiforgery",
+  "verify",
 ];
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/hidden-affiliate-sanitize.test.ts
+++ b/extension/src/rules/__tests__/hidden-affiliate-sanitize.test.ts
@@ -261,6 +261,28 @@ describe("hiddenAffiliateSanitizeRule on checkout URLs", () => {
     expect(node.value).toBe("");
   });
 
+  it("clears a hidden input that is itself the subtree root (appended directly into an existing form)", async () => {
+    // querySelectorAll only walks descendants — a single input appended
+    // straight into an existing form is delivered to the watcher as the
+    // root element, not as a descendant of a larger subtree. The rule
+    // must check the root itself or the input slips through unscrubbed.
+    document.body.innerHTML = `<form id="checkout"></form>`;
+    hiddenAffiliateSanitizeRule.apply(document.body);
+
+    const form = document.querySelector("#checkout") as HTMLFormElement;
+    const late = document.createElement("input");
+    late.type = "hidden";
+    late.name = "utm_source";
+    late.value = "email";
+    form.append(late);
+
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(late.value).toBe("");
+    expect(late.hasAttribute(CLEARED_ATTR)).toBe(true);
+  });
+
   it("does not run on a non-checkout URL", () => {
     const originalHref = globalThis.location.href;
     globalThis.history.replaceState({}, "", "/blog/post");

--- a/extension/src/rules/__tests__/hidden-affiliate-sanitize.test.ts
+++ b/extension/src/rules/__tests__/hidden-affiliate-sanitize.test.ts
@@ -192,9 +192,11 @@ describe("hiddenAffiliateSanitizeRule on checkout URLs", () => {
     expect(csrf.getAttribute(CLEARED_ATTR)).toBe("skipped");
   });
 
-  it("never clears a denylisted name that happens to overlap the allowlist", () => {
-    // A field literally named `state` would match the allowlist's
-    // overlap with denied names. Denylist takes precedence.
+  it("preserves OAuth `state` at checkout (whole-name denylist)", () => {
+    // `state` is a load-bearing OAuth / CSRF-style nonce on auth-flow
+    // checkout pages. It isn't in the allowlist regex — this test
+    // demonstrates the DENY_WHOLE_NAMES coverage, not allow/deny
+    // precedence (there's no overlap to resolve).
     document.body.innerHTML = `
       <form>
         <input type="hidden" name="state" value="OAUTH_NONCE_xyz">

--- a/extension/src/rules/__tests__/hidden-affiliate-sanitize.test.ts
+++ b/extension/src/rules/__tests__/hidden-affiliate-sanitize.test.ts
@@ -1,0 +1,301 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://shop.example.com/checkout"}
+ */
+import { HIDDEN_AFFILIATE_CLEARED_ATTR as CLEARED_ATTR } from "../../lib/dom-markers";
+import {
+  hiddenAffiliateSanitizeRule,
+  isAffiliateName,
+  isDenylistedName,
+  shouldClearName,
+} from "../hidden-affiliate-sanitize";
+
+const MUTATION_THROTTLE_MS = 250;
+
+async function flushMutations(): Promise<void> {
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  hiddenAffiliateSanitizeRule.teardown();
+  jest.useRealTimers();
+});
+
+describe("isAffiliateName — positive examples", () => {
+  it.each([
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "utm-source",
+    "UTM_SOURCE",
+    "aff",
+    "aff_id",
+    "affid",
+    "affiliate",
+    "affiliate_id",
+    "affiliate_code",
+    "ref",
+    "ref_id",
+    "refid",
+    "referrer",
+    "referral_code",
+    "promo",
+    "promo_code",
+    "promotion_id",
+    "promocode",
+    "coupon",
+    "coupon_code",
+    "coupon_id",
+    "discount_code",
+    "discount_id",
+    "source_id",
+    "campaign_id",
+    "partner_code",
+    "click_id",
+    "gclid",
+    "fbclid",
+    "msclkid",
+  ])("matches %s", (name) => {
+    expect(isAffiliateName(name)).toBe(true);
+  });
+});
+
+describe("isAffiliateName — negative examples", () => {
+  it.each([
+    "email",
+    "address",
+    "phone",
+    "first_name",
+    "last_name",
+    "quantity",
+    "item_id",
+    "product_sku",
+    "country",
+    "state",
+    "city",
+    "zipcode",
+    "subscribe",
+    // The word "refrigerator" contains "ref" but the regex is anchored
+    // and requires whole-name match — must reject.
+    "refrigerator",
+    // Substring sneaks
+    "preferred_payment",
+    "preferences",
+  ])("rejects %s", (name) => {
+    expect(isAffiliateName(name)).toBe(false);
+  });
+});
+
+describe("isDenylistedName — preserves CSRF/session/cart shapes", () => {
+  it.each([
+    "csrf",
+    "csrf_token",
+    "authenticity_token",
+    "_csrf",
+    "nonce",
+    "state",
+    "signature",
+    "sig",
+    "hmac",
+    "request_token",
+    "x_token",
+    "antiforgery",
+    "verification_token",
+    "verify_token",
+    "cart_id",
+    "order_id",
+    "session_id",
+    "session",
+    "_token",
+  ])("denies %s", (name) => {
+    expect(isDenylistedName(name)).toBe(true);
+  });
+});
+
+describe("shouldClearName — allowlist trimmed by denylist", () => {
+  it.each([
+    "utm_source",
+    "ref",
+    "promo_code",
+    "coupon_id",
+    "gclid",
+  ])("clears %s", (name) => {
+    expect(shouldClearName(name)).toBe(true);
+  });
+
+  it.each([
+    "csrf_token",
+    "authenticity_token",
+    "cart_id",
+    "order_id",
+    "session_id",
+    "nonce",
+    "state",
+    "_token",
+  ])("never clears %s, even if allowlisted by overlap", (name) => {
+    expect(shouldClearName(name)).toBe(false);
+  });
+
+  it("rejects empty name", () => {
+    expect(shouldClearName("")).toBe(false);
+  });
+});
+
+describe("hiddenAffiliateSanitizeRule on checkout URLs", () => {
+  it("clears value on an allowlisted hidden input", () => {
+    document.body.innerHTML = `
+      <form>
+        <input type="hidden" name="utm_source" value="email-newsletter">
+        <input type="hidden" name="csrf_token" value="abc123">
+        <button type="submit">Submit</button>
+      </form>
+    `;
+    hiddenAffiliateSanitizeRule.apply(document.body);
+
+    const utm = document.querySelector(
+      'input[name="utm_source"]',
+    ) as HTMLInputElement;
+    const csrf = document.querySelector(
+      'input[name="csrf_token"]',
+    ) as HTMLInputElement;
+    expect(utm.value).toBe("");
+    expect(utm.getAttribute(CLEARED_ATTR)).toBe("");
+    expect(csrf.value).toBe("abc123");
+    // CSRF should be stamped as skipped so we don't re-evaluate.
+    expect(csrf.getAttribute(CLEARED_ATTR)).toBe("skipped");
+  });
+
+  it("never clears a denylisted name that happens to overlap the allowlist", () => {
+    // A field literally named `state` would match the allowlist's
+    // overlap with denied names. Denylist takes precedence.
+    document.body.innerHTML = `
+      <form>
+        <input type="hidden" name="state" value="OAUTH_NONCE_xyz">
+      </form>
+    `;
+    hiddenAffiliateSanitizeRule.apply(document.body);
+    const state = document.querySelector(
+      'input[name="state"]',
+    ) as HTMLInputElement;
+    expect(state.value).toBe("OAUTH_NONCE_xyz");
+  });
+
+  it("preserves a value containing 'signature' in name", () => {
+    document.body.innerHTML = `
+      <form>
+        <input type="hidden" name="apple_pay_signature" value="MIIBxz...">
+      </form>
+    `;
+    hiddenAffiliateSanitizeRule.apply(document.body);
+    const node = document.querySelector(
+      'input[name="apple_pay_signature"]',
+    ) as HTMLInputElement;
+    expect(node.value).toBe("MIIBxz...");
+  });
+
+  it("skips hidden inputs outside a form (likely JS-only carriers)", () => {
+    document.body.innerHTML = `
+      <div>
+        <input type="hidden" name="utm_source" value="not-in-form">
+      </div>
+    `;
+    hiddenAffiliateSanitizeRule.apply(document.body);
+    const node = document.querySelector(
+      'input[name="utm_source"]',
+    ) as HTMLInputElement;
+    expect(node.value).toBe("not-in-form");
+  });
+
+  it("clears via the prototype's native setter so React/Vue see the change", () => {
+    document.body.innerHTML = `
+      <form>
+        <input id="utm" type="hidden" name="utm_source" value="email">
+      </form>
+    `;
+    const utm = document.querySelector("#utm") as HTMLInputElement;
+    // Wrap the native setter to detect that we're calling it. The rule
+    // resolves the setter at module load via getOwnPropertyDescriptor,
+    // so we can't trivially mock that out — instead, after the rule
+    // runs, the live `.value` must be the empty string.
+    hiddenAffiliateSanitizeRule.apply(document.body);
+    expect(utm.value).toBe("");
+  });
+
+  it("does not double-clear on a repeat scan", async () => {
+    document.body.innerHTML = `
+      <form>
+        <input id="utm" type="hidden" name="utm_source" value="email">
+      </form>
+    `;
+    hiddenAffiliateSanitizeRule.apply(document.body);
+    const utm = document.querySelector("#utm") as HTMLInputElement;
+    expect(utm.value).toBe("");
+    // Re-set the value as if a page script tried to repopulate it.
+    utm.removeAttribute(CLEARED_ATTR);
+    utm.value = "repopulated";
+    // Restore CLEARED_ATTR — the actual marker that prevents re-clear.
+    utm.setAttribute(CLEARED_ATTR, "");
+
+    document.body.append(document.createElement("div"));
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+
+    expect(utm.value).toBe("repopulated");
+  });
+
+  it("clears a lazy-loaded hidden affiliate input", async () => {
+    hiddenAffiliateSanitizeRule.apply(document.body);
+    const late = document.createElement("form");
+    late.innerHTML = `<input id="late" type="hidden" name="ref" value="affsite-42">`;
+    document.body.append(late);
+    await flushMutations();
+    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
+    const node = document.querySelector("#late") as HTMLInputElement;
+    expect(node.value).toBe("");
+  });
+
+  it("does not run on a non-checkout URL", () => {
+    const originalHref = globalThis.location.href;
+    globalThis.history.replaceState({}, "", "/blog/post");
+    try {
+      document.body.innerHTML = `
+        <form>
+          <input id="utm" type="hidden" name="utm_source" value="email">
+        </form>
+      `;
+      hiddenAffiliateSanitizeRule.apply(document.body);
+      const utm = document.querySelector("#utm") as HTMLInputElement;
+      expect(utm.value).toBe("email");
+    } finally {
+      globalThis.history.replaceState({}, "", originalHref);
+    }
+  });
+
+  it("skips empty values (already-empty short-circuit)", () => {
+    document.body.innerHTML = `
+      <form>
+        <input id="utm" type="hidden" name="utm_source" value="">
+      </form>
+    `;
+    hiddenAffiliateSanitizeRule.apply(document.body);
+    const utm = document.querySelector("#utm") as HTMLInputElement;
+    expect(utm.getAttribute(CLEARED_ATTR)).toBe("already-empty");
+  });
+
+  it("works for inputs associated with a form via the `form` attribute", () => {
+    document.body.innerHTML = `
+      <form id="checkout"></form>
+      <input id="utm" type="hidden" name="utm_source" value="email" form="checkout">
+    `;
+    hiddenAffiliateSanitizeRule.apply(document.body);
+    const utm = document.querySelector("#utm") as HTMLInputElement;
+    expect(utm.value).toBe("");
+  });
+});

--- a/extension/src/rules/__tests__/hidden-affiliate-sanitize.test.ts
+++ b/extension/src/rules/__tests__/hidden-affiliate-sanitize.test.ts
@@ -46,15 +46,6 @@ describe("isAffiliateName — positive examples", () => {
     "refid",
     "referrer",
     "referral_code",
-    "promo",
-    "promo_code",
-    "promotion_id",
-    "promocode",
-    "coupon",
-    "coupon_code",
-    "coupon_id",
-    "discount_code",
-    "discount_id",
     "source_id",
     "campaign_id",
     "partner_code",
@@ -88,6 +79,21 @@ describe("isAffiliateName — negative examples", () => {
     // Substring sneaks
     "preferred_payment",
     "preferences",
+    // Promo / coupon / discount fields are intentionally NOT
+    // attribution — they commonly carry a legitimate user-acquired
+    // discount and clearing them would silently strip it. See the rule
+    // header.
+    "promo",
+    "promo_code",
+    "promocode",
+    "promotion",
+    "promotion_id",
+    "coupon",
+    "coupon_code",
+    "coupon_id",
+    "discount",
+    "discount_code",
+    "discount_id",
   ])("rejects %s", (name) => {
     expect(isAffiliateName(name)).toBe(false);
   });
@@ -123,9 +129,9 @@ describe("shouldClearName — allowlist trimmed by denylist", () => {
   it.each([
     "utm_source",
     "ref",
-    "promo_code",
-    "coupon_id",
+    "affiliate_id",
     "gclid",
+    "click_id",
   ])("clears %s", (name) => {
     expect(shouldClearName(name)).toBe(true);
   });
@@ -140,6 +146,20 @@ describe("shouldClearName — allowlist trimmed by denylist", () => {
     "state",
     "_token",
   ])("never clears %s, even if allowlisted by overlap", (name) => {
+    expect(shouldClearName(name)).toBe(false);
+  });
+
+  it.each([
+    // Promo / coupon / discount preservation — legitimate user
+    // discount, never cleared regardless of checkout context.
+    "promo_code",
+    "promotion_id",
+    "coupon",
+    "coupon_code",
+    "coupon_id",
+    "discount_code",
+    "discount_id",
+  ])("preserves promo/coupon/discount field %s", (name) => {
     expect(shouldClearName(name)).toBe(false);
   });
 
@@ -309,6 +329,38 @@ describe("hiddenAffiliateSanitizeRule on checkout URLs", () => {
     hiddenAffiliateSanitizeRule.apply(document.body);
     const utm = document.querySelector("#utm") as HTMLInputElement;
     expect(utm.getAttribute(CLEARED_ATTR)).toBe("already-empty");
+  });
+
+  it.each([
+    ["promo_code", "FALL15"],
+    ["promotion_id", "summer-2026"],
+    ["coupon", "SAVE10"],
+    ["coupon_code", "WELCOME20"],
+    ["coupon_id", "abc-123"],
+    ["discount_code", "STUDENT15"],
+    ["discount_id", "loyalty-tier-2"],
+  ])("preserves a hidden %s input alongside the rule (legitimate user discount)", (name, value) => {
+    document.body.innerHTML = `
+        <form>
+          <input type="hidden" name="utm_source" value="email">
+          <input type="hidden" name="${name}" value="${value}">
+          <button type="submit">Place order</button>
+        </form>
+      `;
+    hiddenAffiliateSanitizeRule.apply(document.body);
+
+    const utm = document.querySelector(
+      'input[name="utm_source"]',
+    ) as HTMLInputElement;
+    const promo = document.querySelector(
+      `input[name="${name}"]`,
+    ) as HTMLInputElement;
+    // Attribution still cleared.
+    expect(utm.value).toBe("");
+    // Promo / coupon / discount kept intact so the user's discount
+    // survives the agent's submit.
+    expect(promo.value).toBe(value);
+    expect(promo.getAttribute(CLEARED_ATTR)).toBe("skipped");
   });
 
   it("works for inputs associated with a form via the `form` attribute", () => {

--- a/extension/src/rules/hidden-affiliate-sanitize.ts
+++ b/extension/src/rules/hidden-affiliate-sanitize.ts
@@ -92,10 +92,10 @@ const AFFILIATE_NAME_RE = new RegExp(
 // match. Failure mode for CSRF / session / cart / order / nonce / state
 // / signature is a silently-rejected submit — worse than the original
 // dark pattern. Substring-match by design: any input whose name
-// contains `signature`, `csrf`, `token`, `nonce`, `session`, etc. is a
-// security primitive we must not touch even if it also happens to
-// match the allowlist by name overlap (e.g. a custom name like
-// `coupon_token` ought to be left alone).
+// contains `signature`, `csrf`, `nonce`, `session`, etc. is a security
+// primitive we must not touch even if a future allowlist addition
+// happens to name-overlap (e.g. a hypothetical `affiliate_nonce` would
+// be caught by the `nonce` substring).
 //
 // Token boundary uses `[^A-Za-z]` (not `\b`) because hidden-input
 // names commonly use snake/kebab/leading-underscore (`_csrf`,
@@ -116,10 +116,11 @@ const DENY_TOKENS: readonly string[] = [
   "verify",
   "requesttoken",
   "xtoken",
-  // Bare `token` and `state` are listed here as whole-name matches
-  // below — substring "token" would also catch the allowlist `aff_token`
-  // which we'd want a separate review for anyway, so keep them deny
-  // by default. `tok` is too short to substring safely.
+  // Bare `token` and `state` are listed in `DENY_WHOLE_NAMES` below
+  // rather than here — substring "token" is too noisy to substring
+  // safely (every framework's CSRF / antiforgery / session-id field
+  // ends in `_token`, but so could a benign field name that escapes
+  // our review). `tok` is too short to substring safely.
 ];
 const DENY_WHOLE_NAMES: ReadonlySet<string> = new Set([
   "state",

--- a/extension/src/rules/hidden-affiliate-sanitize.ts
+++ b/extension/src/rules/hidden-affiliate-sanitize.ts
@@ -241,6 +241,41 @@ function isFormScopedHidden(input: HTMLInputElement): boolean {
   return input.form !== null;
 }
 
+function tryClearInput(
+  input: HTMLInputElement,
+  outcome: { cleared: number; names: string[] },
+): void {
+  if (input.hasAttribute(CLEARED_ATTR)) {
+    return;
+  }
+  if (!input.isConnected) {
+    return;
+  }
+  if (!isFormScopedHidden(input)) {
+    return;
+  }
+  const name = input.name;
+  if (!shouldClearName(name)) {
+    // Stamp non-empty-name rejections so re-scans don't re-check the
+    // same node. Unnamed hidden inputs we leave unstamped since
+    // they're rare and the next scan's no-op cost is negligible.
+    if (name.length > 0) {
+      input.setAttribute(CLEARED_ATTR, "skipped");
+    }
+    return;
+  }
+  // Use the attribute value, not just live `.value`, to detect the
+  // "value never set" case where there's nothing to clear and we
+  // can short-circuit.
+  if (input.value.length === 0) {
+    input.setAttribute(CLEARED_ATTR, "already-empty");
+    return;
+  }
+  clearValue(input);
+  outcome.cleared++;
+  outcome.names.push(name);
+}
+
 function scanAndClear(root: ParentNode): void {
   if (!isCheckoutUrl(globalThis.location.href)) {
     return;
@@ -248,46 +283,28 @@ function scanAndClear(root: ParentNode): void {
   if (isKillSwitchedHost(globalThis.location.href)) {
     return;
   }
+  const outcome = { cleared: 0, names: [] as string[] };
+  // querySelectorAll only walks descendants. When the subtree watcher
+  // delivers a single `<input type="hidden">` appended directly to an
+  // existing form, the input itself is the root and would slip past
+  // the loop below. Check the root explicitly first — same pattern as
+  // `attribute-injection-sanitize` and `confirmshame-sanitize`.
+  if (root instanceof HTMLInputElement) {
+    tryClearInput(root, outcome);
+  }
   // The selector keeps the loop body tight by pre-filtering type and
-  // FLAGGED_ATTR. We still need to re-verify name/denylist/form-scope
-  // per element below — those don't translate cleanly to CSS.
+  // CLEARED_ATTR. We still need to re-verify form-scope / denylist /
+  // allowlist per element below — those don't translate cleanly to CSS.
   const candidates = root.querySelectorAll<HTMLInputElement>(
     `input[type="hidden"]:not([${CLEARED_ATTR}])`,
   );
-  let cleared = 0;
-  const names: string[] = [];
   for (const input of candidates) {
-    if (!input.isConnected) {
-      continue;
-    }
-    if (!isFormScopedHidden(input)) {
-      continue;
-    }
-    const name = input.name;
-    if (!shouldClearName(name)) {
-      // Stamp non-empty-name rejections so re-scans don't re-check the
-      // same node. Unnamed hidden inputs we leave unstamped since
-      // they're rare and the next scan's no-op cost is negligible.
-      if (name.length > 0) {
-        input.setAttribute(CLEARED_ATTR, "skipped");
-      }
-      continue;
-    }
-    // Use the attribute value, not just live `.value`, to detect the
-    // "value never set" case where there's nothing to clear and we
-    // can short-circuit.
-    if (input.value.length === 0) {
-      input.setAttribute(CLEARED_ATTR, "already-empty");
-      continue;
-    }
-    clearValue(input);
-    cleared++;
-    names.push(name);
+    tryClearInput(input, outcome);
   }
-  if (cleared > 0) {
+  if (outcome.cleared > 0) {
     log("hidden affiliate values cleared", {
-      count: cleared,
-      names,
+      count: outcome.cleared,
+      names: outcome.names,
       url: globalThis.location.href,
     });
   }

--- a/extension/src/rules/hidden-affiliate-sanitize.ts
+++ b/extension/src/rules/hidden-affiliate-sanitize.ts
@@ -1,10 +1,20 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-// Clear `value` on `<input type="hidden">` whose `name` matches a curated
-// affiliate / UTM / promo / coupon allowlist on checkout pages, so the
-// agent doesn't silently submit attribution or discount-source metadata
-// that biases pricing or routes commission to a third party.
+// Clear `value` on `<input type="hidden">` whose `name` matches a
+// curated affiliate / UTM / referral attribution allowlist on checkout
+// pages, so the agent doesn't silently submit third-party attribution
+// metadata that routes commission or biases downstream pricing.
+//
+// Scope is attribution only — `promo` / `coupon` / `discount` names
+// are intentionally NOT in the allowlist. Hidden promo-code inputs
+// commonly carry a legitimate user-acquired discount (email promo
+// link, sticky session promo, "apply coupon" UI that writes to a
+// hidden field at submit time), and clearing them would silently
+// strip the user's discount with no visible recourse. Attribution
+// (UTM, gclid, affiliate refs) has the opposite asymmetry: clearing
+// it is invisible to the user and only costs the marketing trail.
+// See PR #188 for the discussion.
 //
 // Companion to `form-prefill-annotate` (issue #121): annotation is the
 // wrong tool for hidden inputs — the value is submitted regardless of
@@ -42,21 +52,24 @@ import type { Rule } from "./types";
 
 const RULE_ID = "hidden-affiliate-sanitize" as const;
 
-// Curated affiliate / UTM / promo / coupon name patterns. Whole-name
-// regex match against `input.name` (case-insensitive). Each entry pulls
-// double duty in the property tests as both a positive example and an
-// invariant input. Additions go through PR review — keep the set tight
-// so the surface stays small enough to reason about and so we can
-// property-test exhaustively against the denylist.
+// Curated attribution name patterns. Whole-name regex match against
+// `input.name` (case-insensitive). Each entry pulls double duty in the
+// property tests as both a positive example and an invariant input.
+// Additions go through PR review — keep the set tight so the surface
+// stays small enough to reason about and so we can property-test
+// exhaustively against the denylist.
 //
-// Trailing/leading word-boundary classes (`[_-]?\d*`, `[_-]?id`)
-// capture common suffix conventions:
+// Attribution only — patterns that could carry a legitimate
+// user-acquired discount (`promo`, `coupon`, `discount`, `promotion`)
+// are intentionally absent. See the file header.
+//
+// Trailing/leading word-boundary classes (`[_-]?id`) capture common
+// suffix conventions:
 //   - `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`
 //   - `aff`, `aff_id`, `affid`, `affiliate_id`
 //   - `ref`, `referrer`, `ref_id`, `refid`, `referral_code`
-//   - `promo`, `promo_code`, `promotion_id`, `promocode`
-//   - `coupon`, `coupon_code`, `coupon_id`
-//   - `discount`, `discount_code`, `discount_id`
+//   - `source_id`, `campaign_id`, `partner_code`
+//   - `click_id`, `gclid`, `fbclid`, `msclkid`
 const AFFILIATE_NAME_RE = new RegExp(
   [
     `^utm[_-]?(?:source|medium|campaign|term|content|id)$`,
@@ -64,10 +77,6 @@ const AFFILIATE_NAME_RE = new RegExp(
     `^affiliate[_-]?(?:id|code|source)?$`,
     `^ref(?:[_-]?(?:id|code|errer|erral|erral[_-]?code))?$`,
     `^referr?al[_-]?(?:id|code|source)?$`,
-    `^promo(?:[_-]?(?:code|id|tion|tion[_-]?id))?$`,
-    `^promotion[_-]?(?:id|code|source)?$`,
-    `^coupon(?:[_-]?(?:code|id))?$`,
-    `^discount(?:[_-]?(?:code|id))?$`,
     `^source[_-]?(?:id|code)$`,
     `^campaign[_-]?(?:id|code|source)$`,
     `^partner[_-]?(?:id|code|source)$`,
@@ -325,9 +334,9 @@ function apply(root: ParentNode): void {
 
 export const hiddenAffiliateSanitizeRule = {
   id: RULE_ID,
-  label: "Scrub Hidden Affiliate / Promo Metadata",
+  label: "Scrub Hidden Affiliate Metadata",
   description:
-    "On checkout pages, clear `value` on hidden inputs whose name matches a curated affiliate / UTM / promo / coupon allowlist. CSRF, session, cart, order, nonce, signature, and state fields are preserved.",
+    "On checkout pages, clear `value` on hidden inputs whose name matches a curated affiliate / UTM / referral attribution allowlist. Promo / coupon / discount names are preserved (legitimate user discount). CSRF, session, cart, order, nonce, signature, and state fields are also preserved.",
   apply,
   teardown: () => {
     watcher.stop();

--- a/extension/src/rules/hidden-affiliate-sanitize.ts
+++ b/extension/src/rules/hidden-affiliate-sanitize.ts
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Clear `value` on `<input type="hidden">` whose `name` matches a curated
+// affiliate / UTM / promo / coupon allowlist on checkout pages, so the
+// agent doesn't silently submit attribution or discount-source metadata
+// that biases pricing or routes commission to a third party.
+//
+// Companion to `form-prefill-annotate` (issue #121): annotation is the
+// wrong tool for hidden inputs — the value is submitted regardless of
+// any chip, and the agent never reads hidden inputs into a snapshot.
+// Sanitize-and-forget is the only useful action.
+//
+// Posture is intentionally narrow:
+//   - Allowlist-only — anything outside the curated affiliate set is
+//     preserved. The set is short enough to property-test exhaustively.
+//   - Hard denylist on top — CSRF / session / cart / order / nonce /
+//     state / signature shapes are never cleared even if they slip past
+//     the allowlist by name overlap. Failure mode for those is a
+//     silently-rejected submit (worse than the original dark pattern).
+//   - URL gate via `isCheckoutUrl` — never fires off checkout-shape
+//     paths.
+//   - Form-scoped — the input must live inside an enclosing `<form>`.
+//     Hidden inputs floating outside forms are JS-only data carriers
+//     for tracking pixels; clearing them risks breaking the page's own
+//     analytics without changing what the agent submits (the agent
+//     submits via the form anyway).
+//   - Per-host kill-switch (empty at launch) for known loyalty / Apple
+//     Pay / 1-Click flows where saved attribution is the user intent.
+//
+// Set-once semantics: when we clear a value we stamp the input with
+// `CLEARED_ATTR`. We do NOT observe attribute mutations, so a page
+// script that re-writes the value after our scan keeps the new value.
+// That's intentional — getting into a re-clear fight loop with the
+// page's own JS would be worse than the original dark pattern.
+
+import { isCheckoutUrl } from "../lib/checkout-url";
+import { HIDDEN_AFFILIATE_CLEARED_ATTR as CLEARED_ATTR } from "../lib/dom-markers";
+import { log } from "../lib/log";
+import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import type { Rule } from "./types";
+
+const RULE_ID = "hidden-affiliate-sanitize" as const;
+
+// Curated affiliate / UTM / promo / coupon name patterns. Whole-name
+// regex match against `input.name` (case-insensitive). Each entry pulls
+// double duty in the property tests as both a positive example and an
+// invariant input. Additions go through PR review — keep the set tight
+// so the surface stays small enough to reason about and so we can
+// property-test exhaustively against the denylist.
+//
+// Trailing/leading word-boundary classes (`[_-]?\d*`, `[_-]?id`)
+// capture common suffix conventions:
+//   - `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`
+//   - `aff`, `aff_id`, `affid`, `affiliate_id`
+//   - `ref`, `referrer`, `ref_id`, `refid`, `referral_code`
+//   - `promo`, `promo_code`, `promotion_id`, `promocode`
+//   - `coupon`, `coupon_code`, `coupon_id`
+//   - `discount`, `discount_code`, `discount_id`
+const AFFILIATE_NAME_RE = new RegExp(
+  [
+    `^utm[_-]?(?:source|medium|campaign|term|content|id)$`,
+    `^aff(?:[_-]?(?:id|iliate|iliate[_-]?id))?$`,
+    `^affiliate[_-]?(?:id|code|source)?$`,
+    `^ref(?:[_-]?(?:id|code|errer|erral|erral[_-]?code))?$`,
+    `^referr?al[_-]?(?:id|code|source)?$`,
+    `^promo(?:[_-]?(?:code|id|tion|tion[_-]?id))?$`,
+    `^promotion[_-]?(?:id|code|source)?$`,
+    `^coupon(?:[_-]?(?:code|id))?$`,
+    `^discount(?:[_-]?(?:code|id))?$`,
+    `^source[_-]?(?:id|code)$`,
+    `^campaign[_-]?(?:id|code|source)$`,
+    `^partner[_-]?(?:id|code|source)$`,
+    `^click[_-]?id$`,
+    `^gclid$`,
+    `^fbclid$`,
+    `^msclkid$`,
+  ].join("|"),
+  "i",
+);
+
+// Hard denylist: never clear these names, even if the allowlist would
+// match. Failure mode for CSRF / session / cart / order / nonce / state
+// / signature is a silently-rejected submit — worse than the original
+// dark pattern. Substring-match by design: any input whose name
+// contains `signature`, `csrf`, `token`, `nonce`, `session`, etc. is a
+// security primitive we must not touch even if it also happens to
+// match the allowlist by name overlap (e.g. a custom name like
+// `coupon_token` ought to be left alone).
+//
+// Token boundary uses `[^A-Za-z]` (not `\b`) because hidden-input
+// names commonly use snake/kebab/leading-underscore (`_csrf`,
+// `csrf-token`, `__authenticity_token`) where `\b` doesn't fire — `_`
+// is a JS word character.
+const DENY_TOKENS: readonly string[] = [
+  "csrf",
+  "nonce",
+  "signature",
+  "hmac",
+  "secret",
+  "session",
+  "cartid",
+  "orderid",
+  "antiforgery",
+  "authenticity",
+  "verification",
+  "verify",
+  "requesttoken",
+  "xtoken",
+  // Bare `token` and `state` are listed here as whole-name matches
+  // below — substring "token" would also catch the allowlist `aff_token`
+  // which we'd want a separate review for anyway, so keep them deny
+  // by default. `tok` is too short to substring safely.
+];
+const DENY_WHOLE_NAMES: ReadonlySet<string> = new Set([
+  "state",
+  "token",
+  "_token",
+  "x_token",
+  "x-token",
+  "csrf",
+  "_csrf",
+  "csrf_token",
+  "csrf-token",
+  "authenticity_token",
+  "authenticity-token",
+  "cart_id",
+  "cart-id",
+  "order_id",
+  "order-id",
+  "session",
+  "session_id",
+  "session-id",
+  "sig",
+  "hash",
+]);
+
+// Per-host kill-switch — hostnames where saved attribution / referral
+// metadata IS the user intent (Amazon 1-Click affiliate flows, Apple
+// Pay shopper-id passthroughs, loyalty programs). Empty at launch;
+// populate via PR review when real-world activity counts surface a
+// host where the affiliate id is load-bearing for the user. Same
+// governance posture as `roach-motel-annotate`'s curated list and
+// `hidden-fee-annotate`'s host denylist.
+const HOST_KILL_SWITCH: ReadonlySet<string> = new Set<string>();
+
+export function isAffiliateName(name: string): boolean {
+  return AFFILIATE_NAME_RE.test(name);
+}
+
+export function isDenylistedName(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (DENY_WHOLE_NAMES.has(lower)) {
+    return true;
+  }
+  // Strip non-letter characters for substring search so `_csrf` and
+  // `csrf-token` both surface their `csrf` token. We keep the lowered
+  // form's separators only as boundary cues for `DENY_WHOLE_NAMES`
+  // above.
+  const stripped = lower.replaceAll(/[^a-z]/g, "");
+  for (const token of DENY_TOKENS) {
+    if (stripped.includes(token)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Exported so the property tests can confirm disjointness — no name in
+// the affiliate allowlist should also match the denylist, and vice
+// versa.
+export function shouldClearName(name: string): boolean {
+  if (name.length === 0) {
+    return false;
+  }
+  if (isDenylistedName(name)) {
+    return false;
+  }
+  return isAffiliateName(name);
+}
+
+function isKillSwitchedHost(href: string): boolean {
+  try {
+    return HOST_KILL_SWITCH.has(new URL(href).hostname);
+  } catch {
+    return false;
+  }
+}
+
+// React/Vue track `value` internally; setting `.value` directly skips
+// their value-tracker, so any subsequent re-render with the same prop
+// would not detect a change. Going through the prototype's native
+// setter lets the framework observe the change. Same pattern as
+// `checkout-checkbox-sanitize` uses for `checked`.
+//
+// Resolved lazily on first `apply` so this module is safe to import in
+// DOM-less contexts (service worker, codegen). Touching
+// `HTMLInputElement.prototype` at module top level would crash the
+// background-worker bundle — see scripts/check-background-purity.ts.
+let cachedNativeValueSetter:
+  | ((this: HTMLInputElement, value: string) => void)
+  | null
+  | undefined;
+
+function getNativeValueSetter():
+  | ((this: HTMLInputElement, value: string) => void)
+  | null {
+  if (cachedNativeValueSetter !== undefined) {
+    return cachedNativeValueSetter;
+  }
+  // `set` is unbound here by design — we invoke it via `.call(input, …)`
+  // below so `this` is the input element, not the descriptor.
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  cachedNativeValueSetter = setter ?? null;
+  return cachedNativeValueSetter;
+}
+
+function clearValue(input: HTMLInputElement): void {
+  getNativeValueSetter()?.call(input, "");
+  // No input/change event dispatch. Hidden inputs aren't observed by
+  // listeners the user would have wired up for visible-control
+  // interactions, and firing one here could trip totals-recalculation
+  // handlers that re-fetch attribution from the same source. The agent
+  // submits via the form anyway; a downstream listener that genuinely
+  // needs the field non-empty will see the cleared value at submit
+  // time and can do whatever fallback the page intended for "user
+  // didn't come from a tracked source".
+  input.setAttribute(CLEARED_ATTR, "");
+}
+
+function isFormScopedHidden(input: HTMLInputElement): boolean {
+  if (input.type.toLowerCase() !== "hidden") {
+    return false;
+  }
+  // `input.form` is the live association — works for both the
+  // enclosing-form case and the `form` attribute pointing at a form id.
+  return input.form !== null;
+}
+
+function scanAndClear(root: ParentNode): void {
+  if (!isCheckoutUrl(globalThis.location.href)) {
+    return;
+  }
+  if (isKillSwitchedHost(globalThis.location.href)) {
+    return;
+  }
+  // The selector keeps the loop body tight by pre-filtering type and
+  // FLAGGED_ATTR. We still need to re-verify name/denylist/form-scope
+  // per element below — those don't translate cleanly to CSS.
+  const candidates = root.querySelectorAll<HTMLInputElement>(
+    `input[type="hidden"]:not([${CLEARED_ATTR}])`,
+  );
+  let cleared = 0;
+  const names: string[] = [];
+  for (const input of candidates) {
+    if (!input.isConnected) {
+      continue;
+    }
+    if (!isFormScopedHidden(input)) {
+      continue;
+    }
+    const name = input.name;
+    if (!shouldClearName(name)) {
+      // Stamp non-empty-name rejections so re-scans don't re-check the
+      // same node. Unnamed hidden inputs we leave unstamped since
+      // they're rare and the next scan's no-op cost is negligible.
+      if (name.length > 0) {
+        input.setAttribute(CLEARED_ATTR, "skipped");
+      }
+      continue;
+    }
+    // Use the attribute value, not just live `.value`, to detect the
+    // "value never set" case where there's nothing to clear and we
+    // can short-circuit.
+    if (input.value.length === 0) {
+      input.setAttribute(CLEARED_ATTR, "already-empty");
+      continue;
+    }
+    clearValue(input);
+    cleared++;
+    names.push(name);
+  }
+  if (cleared > 0) {
+    log("hidden affiliate values cleared", {
+      count: cleared,
+      names,
+      url: globalThis.location.href,
+    });
+  }
+}
+
+const watcher = createSubtreeWatcher({
+  onSubtrees: (roots) => {
+    for (const root of roots) {
+      scanAndClear(root);
+    }
+  },
+});
+
+function apply(root: ParentNode): void {
+  scanAndClear(root);
+  watcher.start(root);
+}
+
+export const hiddenAffiliateSanitizeRule = {
+  id: RULE_ID,
+  label: "Scrub Hidden Affiliate / Promo Metadata",
+  description:
+    "On checkout pages, clear `value` on hidden inputs whose name matches a curated affiliate / UTM / promo / coupon allowlist. CSRF, session, cart, order, nonce, signature, and state fields are preserved.",
+  apply,
+  teardown: () => {
+    watcher.stop();
+  },
+} satisfies Rule;

--- a/extension/src/rules/index.ts
+++ b/extension/src/rules/index.ts
@@ -16,6 +16,7 @@ import { disguisedAdFlagRule } from "./disguised-ad-flag";
 import { encodedPayloadRedactRule } from "./encoded-payload-redact";
 import { footerRedactRule } from "./footer-redact";
 import { formPrefillAnnotateRule } from "./form-prefill-annotate";
+import { hiddenAffiliateSanitizeRule } from "./hidden-affiliate-sanitize";
 import { hiddenFeeAnnotateRule } from "./hidden-fee-annotate";
 import { hiddenTextStripRule } from "./hidden-text-strip";
 import { htmlCommentStripRule } from "./html-comment-strip";
@@ -94,6 +95,7 @@ const RULES_TUPLE = [
   closedShadowRootAnnotateRule,
   hiddenFeeAnnotateRule,
   formPrefillAnnotateRule,
+  hiddenAffiliateSanitizeRule,
 ] as const satisfies readonly Rule[];
 
 export type RuleId = (typeof RULES_TUPLE)[number]["id"];

--- a/extension/src/rules/rule-defaults.generated.ts
+++ b/extension/src/rules/rule-defaults.generated.ts
@@ -45,6 +45,7 @@ export const RULE_DEFAULTS = {
   "closed-shadow-root-annotate": false,
   "hidden-fee-annotate": true,
   "form-prefill-annotate": true,
+  "hidden-affiliate-sanitize": true,
 } as const satisfies Readonly<Record<string, boolean>>;
 
 export type RuleId = keyof typeof RULE_DEFAULTS;


### PR DESCRIPTION
Sibling to #187 (`form-prefill-annotate`), which has now landed on `main`.

## Summary

- Narrow sanitize companion to `form-prefill-annotate`. On checkout URLs, clears `value` on `<input type="hidden">` whose `name` matches a curated affiliate / UTM / referral attribution allowlist (`utm_*`, `aff*`, `ref*`, `source_id`, `campaign_*`, `partner_*`, `click_id`, `gclid` / `fbclid` / `msclkid`).
- **Promo / coupon / discount names are intentionally preserved.** Hidden promo-code inputs commonly carry a legitimate user-acquired discount (email promo link, sticky session promo, "apply coupon" UI that writes to a hidden field at submit time); clearing them would silently strip the user's discount with no visible recourse. Attribution has the opposite asymmetry — invisible to the user, only costs the marketing trail.
- CSRF / nonce / signature / hmac / session / state / cart_id / order_id / token / antiforgery names are preserved by a hard denylist that takes precedence.
- Form-scoped (must live inside or reference a `<form>`), URL-gated, per-host kill-switch (empty at launch), set-once via CLEARED_ATTR so a page that repopulates the value doesn't drive a re-clear fight loop.
- Cleared via the prototype's native value setter so React/Vue value trackers observe the change; no input/change event dispatch.
- Default-on. Docs section under Dark patterns → Preselection; demo Checkout page exercises both halves (utm/aff cleared, coupon_code + csrf_token preserved).

## Review rounds

- **Round 1 (`2d909a4`)** — Fixed [unblocked][1]'s catch that `querySelectorAll` skips the root element, so a single hidden input appended directly into an existing form was never cleared. Extracted per-input scrub into `tryClearInput` and call it for the root before the descendant loop, matching `attribute-injection-sanitize` / `confirmshame-sanitize`. Regression test added.
- **Round 2 (`e90533dffb3ed520150271db827ea107e898a28d`)** — Dropped promo/coupon/discount from the allowlist (see Summary). Moved those names to negative `isAffiliateName` cases, added a `shouldClearName` preservation suite, an end-to-end `it.each` that survives a hidden promo input next to a cleared utm_source, and a property test asserting hidden promo inputs at checkout keep their value. Rule label tightened to "Scrub Hidden Affiliate Metadata"; demo and rules.md updated.

[1]: https://github.com/pixiebrix/agent-browser-shield/pull/188#discussion_r3366625303

## Rebase notes

- Rebased onto `origin/main` (`4ac452e`) after #187 squash-merged. Dropped the two stacked PR1 commits — `git diff 1344f0b origin/main` (PR1 HEAD vs squash-merge result) was empty for source files, so the rebase replayed only the PR2 commit on top of the new main with no conflicts.
- Other PRs that merged in the window (#189 `actions/checkout`, #193 `setup-uv`, #195 `sticky-pull-request-comment`) are dependabot workflow bumps with no file overlap.

## Test plan

- [x] `bun run test` (1616 tests passing)
- [x] `bun run check`
- [x] `bun run typecheck`
- [x] `pre-commit run` on changed files (demo-site eslint skipped locally — no node_modules in this worktree; CI runs it)
- [x] Catalog invariants pass
- [x] Property tests assert allowlist/denylist disjointness, denylist precedence across composed names, URL-gate invariance, idempotency across a mix of allowed and preserved inputs, and that promo/coupon/discount fields survive scrubbing at checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)