### PR TITLE
Chore: switch Dependabot ecosystem from npm to bun

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /extension
     schedule:
       interval: weekly
@@ -12,7 +12,7 @@ updates:
         dependency-type: development
         update-types: [minor, patch]
 
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /demo-site
     schedule:
       interval: weekly
@@ -24,7 +24,7 @@ updates:
         dependency-type: development
         update-types: [minor, patch]
 
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /docs
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary

- Switch `package-ecosystem` from `npm` to `bun` for the `/extension`, `/demo-site`, and `/docs` entries in `.github/dependabot.yml`.

## Why

Dependabot's npm updater rewrites `package.json` but leaves `bun.lock` alone, so every dev-deps PR breaks CI on `bun install --frozen-lockfile` (currently affecting #190, #191, #192, #194). Dependabot's `bun` ecosystem went GA in Feb 2025 and supports the text-based `bun.lock` v1 format already in use across all three workspaces — no workspaces config means we avoid the known [dependabot-core#14223](https://github.com/dependabot/dependabot-core/issues/14223) edge case, and the prior bun.lock update bug ([#11602](https://github.com/dependabot/dependabot-core/issues/11602)) is closed. Caveat: bun security updates aren't supported yet — version updates (what we use) are GA.

## Test plan

- [ ] Merge and wait for the next Dependabot run.
- [ ] Confirm the next dev-deps PR updates both `package.json` and `bun.lock`, and CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)