### PR TITLE
Fix: resolve modern CSS color syntaxes in hidden-text-strip

### DIFF
--- a/extension/src/rules/__tests__/hidden-text-strip.test.ts
+++ b/extension/src/rules/__tests__/hidden-text-strip.test.ts
@@ -1,5 +1,8 @@
 import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
-import { hiddenTextStripRule } from "../hidden-text-strip";
+import {
+  __resetColorProbeForTesting,
+  hiddenTextStripRule,
+} from "../hidden-text-strip";
 import { FIXTURES } from "./injection-fixtures";
 
 beforeEach(() => {
@@ -472,5 +475,171 @@ describe("hiddenTextStripRule", () => {
 
     expect(document.querySelector("#ph")).not.toBeNull();
     expect(document.querySelector("#inner")).not.toBeNull();
+  });
+});
+
+// jsdom's HTMLCanvasElement.getContext returns null without the `canvas`
+// package, so the canvas-based color parser never runs in tests by default.
+// These cases install a deterministic stub that mimics the spec's
+// silent-ignore behavior for unparseable fillStyle assignments, then
+// exercise the rule against CSS Color Level 4 syntaxes that the regex
+// parser doesn't understand. With the stub uninstalled, the existing
+// jsdom path (regex parser only) is what runs.
+type RGBA = [number, number, number, number];
+
+function noop(): void {
+  // Stub for canvas drawing operations the rule calls but doesn't read.
+}
+
+function installMockCanvas(colorMap: Record<string, RGBA>): () => void {
+  // Sentinels used by parseColorViaCanvas must be accepted as valid colors
+  // so the two-probe round trip can converge for a parseable input.
+  const knownColors: Record<string, RGBA> = {
+    "#1a2b3c": [26, 43, 60, 255],
+    "#fedcba": [254, 220, 186, 255],
+    "#000000": [0, 0, 0, 255],
+    ...Object.fromEntries(
+      Object.entries(colorMap).map(([k, v]) => [k.toLowerCase().trim(), v]),
+    ),
+  };
+  let internal = "#000000";
+  const stubContext = {
+    clearRect: noop,
+    fillRect: noop,
+    getImageData: (): ImageData => {
+      const rgba = knownColors[internal] ?? [0, 0, 0, 0];
+      return {
+        data: new Uint8ClampedArray(rgba),
+        width: 1,
+        height: 1,
+        colorSpace: "srgb",
+      };
+    },
+  };
+  Object.defineProperty(stubContext, "fillStyle", {
+    get: () => internal,
+    set: (value: string) => {
+      if (typeof value !== "string") {
+        return;
+      }
+      const lower = value.toLowerCase().trim();
+      // Spec: an unparseable assignment is silently ignored. Mirror that
+      // by only accepting strings present in the color map.
+      if (knownColors[lower] !== undefined) {
+        internal = lower;
+      }
+    },
+  });
+
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function patched(
+    kind: string,
+  ): unknown {
+    if (kind === "2d") {
+      return stubContext;
+    }
+    return null;
+  } as typeof HTMLCanvasElement.prototype.getContext;
+  __resetColorProbeForTesting();
+
+  return () => {
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    __resetColorProbeForTesting();
+  };
+}
+
+describe("hiddenTextStripRule modern CSS color syntaxes", () => {
+  let uninstall: (() => void) | undefined;
+
+  afterEach(() => {
+    uninstall?.();
+    uninstall = undefined;
+  });
+
+  // The dominant in-the-wild bypass against the regex-only parser: text
+  // painted via `oklch()` (Tailwind v4, Open Props, modern design systems)
+  // reaches computed style unnormalized, so the regex returned null and
+  // the candidate was preserved. Canvas resolution recovers the RGB.
+  it("scrubs near-white oklch text on a white background", () => {
+    uninstall = installMockCanvas({
+      "oklch(0.99 0 0)": [252, 252, 252, 255],
+    });
+    document.body.setAttribute("style", "background-color: rgb(255, 255, 255)");
+    document.body.innerHTML = `
+      <p id="x" style="color: oklch(0.99 0 0)">${FIXTURES.HIDDEN_WHITE_ON_WHITE}</p>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expectScrubbed("#x");
+  });
+
+  // Same threat via lab(): a dark grey color on a dark background that
+  // the regex parser misses.
+  it("scrubs near-black lab text on a near-black background", () => {
+    uninstall = installMockCanvas({
+      "lab(20 0 0)": [48, 48, 48, 255],
+      "lab(22 0 0)": [52, 52, 52, 255],
+    });
+    document.body.innerHTML = `
+      <section style="background-color: lab(20 0 0)">
+        <span id="x" style="color: lab(22 0 0)">${FIXTURES.HIDDEN_SMUGGLED}</span>
+      </section>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expectScrubbed("#x");
+  });
+
+  // Color-mix() is the same threat class with even more obfuscation room
+  // — the resolved value can be any RGB, but visually it can match a
+  // sibling's background.
+  it("scrubs color-mix() text matching the ancestor background", () => {
+    uninstall = installMockCanvas({
+      "color-mix(in oklch, white, transparent)": [255, 255, 255, 255],
+    });
+    document.body.setAttribute("style", "background-color: rgb(255, 255, 255)");
+    document.body.innerHTML = `
+      <p id="x" style="color: color-mix(in oklch, white, transparent)">${FIXTURES.HIDDEN_WHITE_ON_WHITE}</p>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expectScrubbed("#x");
+  });
+
+  // Counterpart to the existing rgb-on-rgb regression: an oklch background
+  // that the canvas resolves to orange must NOT cause the white text on
+  // top to be stripped, because the perceptual distance is large. The
+  // existing test of the same shape passed in jsdom by accident (regex
+  // bailed); this confirms the fix preserves the right behavior for the
+  // right reason.
+  it("preserves white text on an oklch orange background", () => {
+    uninstall = installMockCanvas({
+      "oklch(0.705 0.213 47.604)": [251, 146, 60, 255],
+    });
+    document.body.innerHTML = `
+      <aside style="background-color: rgb(255, 255, 255)">
+        <a id="buy" href="/checkout"
+           style="background-color: oklch(0.705 0.213 47.604); color: rgb(255, 255, 255)">Buy Now</a>
+      </aside>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#buy")).not.toBeNull();
+  });
+
+  // The two-sentinel probe must reject any value the browser couldn't
+  // parse. Wired up by feeding the mock a name that isn't in its color
+  // map; the rule should leave the element alone rather than trip on the
+  // sentinel's RGB.
+  it("preserves the element when the color value is unparseable", () => {
+    uninstall = installMockCanvas({}); // no modern syntaxes registered
+    document.body.setAttribute("style", "background-color: rgb(255, 255, 255)");
+    document.body.innerHTML = `
+      <p id="x" style="color: not-a-color(0 0 0)">${FIXTURES.HIDDEN_WHITE_ON_WHITE}</p>
+    `;
+    hiddenTextStripRule.apply(document.body);
+
+    expect(document.querySelector("#x")).not.toBeNull();
+    expect(document.querySelector("#x")?.textContent ?? "").not.toBe("");
   });
 });

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -360,7 +360,7 @@ const COLOR_MATCH_DISTANCE = 24;
 type RGB = readonly [number, number, number];
 type RGBA = readonly [number, number, number, number];
 
-function parseColor(value: string): RGBA | null {
+function parseColorViaRegex(value: string): RGBA | null {
   const match =
     /^rgba?\(\s*(\d+(?:\.\d+)?)[\s,]+(\d+(?:\.\d+)?)[\s,]+(\d+(?:\.\d+)?)(?:\s*[,/]\s*([\d.]+))?\s*\)$/i.exec(
       value,
@@ -378,15 +378,82 @@ function parseColor(value: string): RGBA | null {
   return [r, g, b, a];
 }
 
+// One-time-allocated 1×1 canvas for resolving CSS Color Level 4 syntaxes
+// (`oklch()`, `lab()`, `color()`, `color-mix()`) that browsers emit
+// verbatim in computed style. `getContext` returns null in environments
+// without canvas (jsdom by default); callers fall back to the regex
+// parser. `undefined` distinguishes "not yet probed" from "probed, no
+// context".
+let colorProbeContext: CanvasRenderingContext2D | null | undefined;
+
+function getColorProbeContext(): CanvasRenderingContext2D | null {
+  if (colorProbeContext !== undefined) {
+    return colorProbeContext;
+  }
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    colorProbeContext = canvas.getContext("2d", { willReadFrequently: true });
+  } catch {
+    colorProbeContext = null;
+  }
+  return colorProbeContext;
+}
+
+// Resolve any CSS color syntax through the canvas 2D parser. Two distinct
+// sentinels guard against the silent-ignore behavior the spec mandates
+// for unparseable values: if `value` is rejected, fillStyle retains the
+// most recently-set sentinel under each probe, so the two reads disagree.
+// A valid color converges to the same resolved string under either
+// sentinel. Once the value is known to parse, we paint a single pixel
+// and read it back to recover the alpha channel (which the read-back
+// fillStyle string normalizes to opaque for the `#rrggbb` form).
+function parseColorViaCanvas(value: string): RGBA | null {
+  const context = getColorProbeContext();
+  if (!context) {
+    return null;
+  }
+  context.fillStyle = "#1a2b3c";
+  context.fillStyle = value;
+  const probe1 = context.fillStyle;
+  context.fillStyle = "#fedcba";
+  context.fillStyle = value;
+  const probe2 = context.fillStyle;
+  if (probe1 !== probe2) {
+    return null;
+  }
+  try {
+    context.clearRect(0, 0, 1, 1);
+    context.fillRect(0, 0, 1, 1);
+    const pixel = context.getImageData(0, 0, 1, 1).data;
+    return [pixel[0] ?? 0, pixel[1] ?? 0, pixel[2] ?? 0, (pixel[3] ?? 0) / 255];
+  } catch {
+    return null;
+  }
+}
+
+function parseColor(value: string): RGBA | null {
+  return parseColorViaRegex(value) ?? parseColorViaCanvas(value);
+}
+
+// Test-only: clear the cached canvas probe so a test that installs a
+// mock canvas after the module has already been imported can force a
+// fresh probe. Production code never calls this; the canvas is created
+// lazily at first parseColor() call and persists for the lifetime of
+// the realm.
+export function __resetColorProbeForTesting(): void {
+  colorProbeContext = undefined;
+}
+
 // Effective background color: walk up ancestors and composite the first
 // opaque background we find. `transparent` and `rgba(_, _, _, 0)` mean
 // "ask my parent." Falls back to white because every browser paints the
 // canvas white when nothing intervenes. Returns null when we hit a
-// background whose computed value we can't parse (CSS Color Level 4
-// syntaxes like `oklch()` / `lab()` / `color()` reach computed style
-// unnormalized) — walking past it to a distant white ancestor would
-// strip legitimate UI like a `bg-orange-500` button with white text
-// sitting inside an otherwise-white card.
+// background whose computed value neither the regex parser nor the
+// canvas can resolve — walking past an unknown background to a distant
+// white ancestor would strip legitimate UI like a colored button with
+// white text sitting inside an otherwise-white card.
 function effectiveBackgroundColor(element: Element): RGB | null {
   let current: Element | null = element;
   while (current) {


### PR DESCRIPTION
## Summary

Closes one item from the red-team audit in #203 (High, S).

`hidden-text-strip`'s `parseColor` was regex-only and accepted just `rgb()` / `rgba()`. Tailwind v4, Open Props, and any stylesheet authored against CSS Color Level 4 emit `oklch()`, `lab()`, `color()`, and `color-mix()` in computed style verbatim, so:

- An element with **`color: oklch(...)` matching its background** wasn't caught by `detectColorMatch` — `parseColor` returned null on the modern syntax and the candidate was preserved.
- An element with a **modern-syntax ancestor background** caused `effectiveBackgroundColor` to bail (the existing intentional behavior, added to avoid stripping `bg-orange-500` buttons with white text inside a white card).

The result: a white-on-white injection painted via `color: oklch(0.99 0 0)` on a plain white card was invisible to humans **and** invisible to the rule.

## Approach

Add a 1×1 canvas probe as a fallback after the regex parser fails. The browser's 2D context accepts any valid CSS color string and silently ignores anything else.

- **Two-sentinel probe** (`#1a2b3c` then `#fedcba`) reliably distinguishes a parsed value (both probes converge to the same resolved `fillStyle`) from a rejected one (each probe keeps its own sentinel).
- Once accepted, paint and `getImageData` to recover the resolved RGBA including alpha.
- Per-realm singleton canvas — lazy-init at first call, persisted for the lifetime of the realm. No alloc on hot paths.

The existing regex parser runs first, so the common `rgb()` / `rgba()` path stays a single regex match.

## Test plan

- [x] `bun run test -- hidden-text-strip` — all 41 cases green (36 existing + 5 new).
- [x] `bun run preflight` — codegen + Biome + ESLint + typecheck + knip + Jest all green.
- [x] **New tests** cover:
  - White-on-white via `color: oklch(...)` is correctly stripped.
  - Near-black-on-near-black via `lab(...)` is correctly stripped.
  - `color-mix()` matching the ancestor background is correctly stripped.
  - The existing oklch-orange-bg-with-white-text case is preserved (now for the *right* reason — perceptual distance is huge, not because we bailed).
  - An unparseable value still returns null (rule preserves the element).

## Notes for reviewers

- **jsdom test environment**: `getContext('2d')` returns null without the `canvas` package, so the canvas path silently no-ops in the existing test suite — the regex parser fully handles those cases. The new tests install a deterministic stub canvas that mimics the spec's silent-ignore behavior; the stub also wires the two sentinels through so the rule's probe round-trips correctly. `__resetColorProbeForTesting` is exported solely so the test can re-prime the cached canvas after installing the stub.
- **Why not canvas-first?** The regex parser is faster than allocating + probing canvas for the dominant `rgb()` / `rgba()` shape that browsers emit by default, and keeps all existing tests exercising the same code path they do today.
- **Reading back alpha**: the canonical `fillStyle` read-back for the `#rrggbb` form drops alpha; sampling via `getImageData` keeps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)