### PR TITLE
Fix: schema-trust Person annotation + broader disguised-ad coverage (#203)

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -350,12 +350,24 @@ claims — `Article.publisher`, `Article.sourceOrganization`,
 [registrable domain](https://publicsuffix.org/) than the page asserting it.
 Structural fields (`@type`, `logo`, `datePublished`, `price`, `ratingValue`) are
 preserved exactly, so an agent still gets the article's body data; it just loses
-the impersonating identity strings. `Person`-typed claims and name-only claims
-with no `url` to anchor against are out of scope and left alone. Off by default
-while we gather real-world signal on false positives; the rule short-circuits
-entirely on known syndicators (Google News, Yahoo News, MSN, Apple News,
-Flipboard, SmartNews, Feedly, Pocket), web archives, AMP cache, and Google
-Translate proxies, where mismatched publisher claims are expected.
+the impersonating identity strings. Name-only claims with no `url` to anchor
+against are left alone. Off by default while we gather real-world signal on
+false positives; the rule short-circuits entirely on known syndicators (Google
+News, Yahoo News, MSN, Apple News, Flipboard, SmartNews, Feedly, Pocket), web
+archives, AMP cache, and Google Translate proxies, where mismatched publisher
+claims are expected.
+
+`Person`-typed claims get a weaker treatment than `Organization`. When a
+`Person` is nested under an authority-context property (`author`, `editor`,
+`publisher`, `creator`, `contributor`, `reviewedBy`, `funder`, `sponsor`,
+similar) and its `url` is on a different registrable domain than the page, the
+rule annotates the markup with `abs:unverified-authority: true` (JSON-LD) or
+`data-abs-schema-trust-unverified="true"` (microdata) and leaves the identity
+fields intact. Sanitizing those would erase legitimate guest-author and academic
+bylines, which routinely link off-domain. The annotation surfaces the same
+domain-binding gap a blanked Organization would, without damaging real metadata.
+A standalone `@type: Person` (a personal homepage) is not borrowing anyone's
+authority and is left alone regardless of URL.
 
 Schema.org has no native provenance mechanism — every claim is self-asserted,
 which is structurally why a page can list itself as published by The New York
@@ -950,18 +962,23 @@ and tracker selector patterns.
 - **Default:** on
 
 Hide article-shaped blocks that carry a visible disclosure label — "Sponsored",
-"Promoted", "Advertorial", "Paid Post", "Partner Content", or the bracketed
-variants common in social feeds — but are rendered by the publisher's own CMS
-rather than served from an ad network. Native advertorials bypass the
-infrastructure-level selectors that power `ads-hide` because they share class
-names and DOM shape with editorial articles; the only signal that distinguishes
-them is the disclosure label itself, which the
+"Promoted", "Advertorial", "Paid Post", "Partner Content", "Featured Listing",
+"From our Advertisers", "Marketing Partner", "In partnership with `<Brand>`", or
+the bracketed variants (`[Ad]`, `(promoted)`, `(sponsored)`) common in social
+feeds — but are rendered by the publisher's own CMS rather than served from an
+ad network. Native advertorials bypass the infrastructure-level selectors that
+power `ads-hide` because they share class names and DOM shape with editorial
+articles; the only signal that distinguishes them is the disclosure label
+itself, which the
 [FTC's `.com Disclosures`](https://www.ftc.gov/business-guidance/resources/com-disclosures-how-make-effective-disclosures-digital-advertising)
 require publishers to render prominently.
 
 Detection works on the visible label — not network selectors — and only fires
 when the label sits inside an article-shaped container (heading, image or
-outbound link, body prose). Filter chips, navigation links, and editorial
+outbound link, body prose). The heading carrier is recognized as any of `<h1>`–
+`<h6>`, `[role="heading"]`, or `[class~="headline"]`, so design systems that
+emit a styled `<div class="headline">` or an ARIA-heading `<div>` instead of a
+real `<h*>` are still detected. Filter chips, navigation links, and editorial
 paragraphs that mention sponsorship in passing are excluded by that shape check,
 by an interactive-ancestor guard, and by a whole-string regex on the label
 element. Matching cards are replaced with a click-to-reveal placeholder in the

--- a/extension/src/lib/__tests__/schema-trust.test.ts
+++ b/extension/src/lib/__tests__/schema-trust.test.ts
@@ -2,6 +2,8 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 import {
+  isAnnotateOnlyAuthorityType,
+  isAuthorityContextProperty,
   isAuthorityType,
   isAuthorityUrlMismatch,
   shouldSkipPage,
@@ -45,12 +47,43 @@ describe("isAuthorityType", () => {
     );
   });
 
-  it("does not match Person (out of scope for V1)", () => {
+  it("does not match Person (Person goes through the annotate path, not the sanitize path)", () => {
     expect(isAuthorityType("Person")).toBe(false);
   });
 
   it("does not match Article", () => {
     expect(isAuthorityType("Article")).toBe(false);
+  });
+});
+
+describe("isAnnotateOnlyAuthorityType", () => {
+  it("matches Person", () => {
+    expect(isAnnotateOnlyAuthorityType("Person")).toBe(true);
+  });
+
+  it("matches Person via the long-form IRI", () => {
+    expect(isAnnotateOnlyAuthorityType("https://schema.org/Person")).toBe(true);
+  });
+
+  it("does not match Organization (sanitized, not annotated)", () => {
+    expect(isAnnotateOnlyAuthorityType("Organization")).toBe(false);
+  });
+});
+
+describe("isAuthorityContextProperty", () => {
+  it("matches author / editor / publisher", () => {
+    expect(isAuthorityContextProperty("author")).toBe(true);
+    expect(isAuthorityContextProperty("editor")).toBe(true);
+    expect(isAuthorityContextProperty("publisher")).toBe(true);
+  });
+
+  it("matches reviewedBy", () => {
+    expect(isAuthorityContextProperty("reviewedBy")).toBe(true);
+  });
+
+  it("does not match arbitrary properties", () => {
+    expect(isAuthorityContextProperty("headline")).toBe(false);
+    expect(isAuthorityContextProperty("about")).toBe(false);
   });
 });
 

--- a/extension/src/lib/dom-markers.ts
+++ b/extension/src/lib/dom-markers.ts
@@ -93,3 +93,16 @@ export const FORM_PREFILL_ANNOTATED_ATTR = "data-abs-form-prefill-annotated";
 // drive an infinite re-clear loop.
 export const HIDDEN_AFFILIATE_CLEARED_ATTR =
   "data-abs-hidden-affiliate-cleared";
+
+// `schema-trust-sanitize`: stamped on a microdata Person scope (and added as
+// the JSON-LD key `abs:unverified-authority` on the corresponding object) when
+// the Person carries borrowed organizational authority — i.e. it is the value
+// of an `author` / `editor` / `publisher` / similar property — and its `url`
+// resolves to a different registrable domain than the page. We annotate
+// rather than blank because legitimate guest-author and academic bylines
+// routinely link off-domain; sanitizing those would erase real metadata. The
+// marker is the same domain-binding warning the Organization-typed path
+// communicates by blanking, surfaced through structured data only (these
+// nodes have no visible carrier, so a chip wouldn't reach an agent reading
+// JSON-LD).
+export const SCHEMA_TRUST_UNVERIFIED_ATTR = "data-abs-schema-trust-unverified";

--- a/extension/src/lib/schema-trust.ts
+++ b/extension/src/lib/schema-trust.ts
@@ -11,12 +11,10 @@
 
 import { registrableDomain } from "./domain-trust";
 
-// Schema.org @type values we treat as carrying organizational authority.
-// `Person` is intentionally excluded: legitimate guest authors and
-// outside contributors routinely link to personal sites, so a
-// cross-domain `author.url` is too noisy to act on in V1. The
-// `Organization` subtypes we list here are the ones we see in real-world
-// publisher / sourceOrganization / ClaimReview.author markup.
+// Schema.org @type values we treat as carrying organizational authority
+// strongly enough to *blank* identity fields when the URL doesn't match.
+// `Person` is intentionally NOT in this set — see ANNOTATE_ONLY_AUTHORITY_TYPES
+// below for the weaker treatment.
 //
 // Match is by substring on the bare type name so a `@type` of
 // `"https://schema.org/NewsMediaOrganization"` (the long-form IRI form)
@@ -32,11 +30,55 @@ export const AUTHORITY_TYPES: ReadonlySet<string> = new Set([
   "MediaOrganization",
 ]);
 
+// Schema.org @type values we treat as carrying *borrowed* authority — strong
+// enough to flag a cross-RD URL as unverifiable, not strong enough to blank
+// the identity outright. Concretely: `Person`. We can't sanitize Person.url
+// mismatches because they're routinely legitimate (a guest author on
+// nytimes.com linking to their personal site at janedoe.example, an academic
+// `author` whose `url` is their university page). But the same shape is also
+// the exact carrier for byline impersonation — a scam page asserting
+// `Article.author = Person{name:"Sanjay Gupta", url:"cnn.com"}` to borrow
+// CNN's authority. The annotate path lets an agent reading structured data
+// see "this authority claim has no domain binding" without erasing genuine
+// metadata.
+export const ANNOTATE_ONLY_AUTHORITY_TYPES: ReadonlySet<string> = new Set([
+  "Person",
+]);
+
+// Schema.org property names whose values inherit organizational authority
+// from the enclosing entity (the Article, ClaimReview, Product, etc.). A
+// `Person` standing alone (e.g. a top-level bio page typed as `Person`) is
+// not making a cross-domain authority claim — only one nested under one of
+// these properties is. Restricting the annotate path to these properties is
+// what makes it safe to ship: a personal homepage typed as `@type: Person`
+// with a cross-RD `url` is not borrowing anyone's authority and is left
+// alone.
+export const AUTHORITY_CONTEXT_PROPERTIES: ReadonlySet<string> = new Set([
+  "author",
+  "editor",
+  "publisher",
+  "creator",
+  "contributor",
+  "maintainer",
+  "sourceOrganization",
+  "reviewedBy",
+  "funder",
+  "sponsor",
+  "provider",
+  "producer",
+]);
+
 // Fields to blank on an authority object whose URL doesn't match the
 // page. The agent still sees the structural shape of the claim
 // (`@type: Organization`), it just loses the impersonating identity
 // strings.
 export const SANITIZE_KEYS: readonly string[] = ["name", "url", "@id"];
+
+// JSON-LD key we add to a Person object whose borrowed-authority URL
+// doesn't match the page. The `abs:` prefix namespaces the assertion so
+// it can't collide with a real schema.org property and is recognizable
+// to any agent that's inspecting the structured data.
+export const UNVERIFIED_AUTHORITY_KEY = "abs:unverified-authority";
 
 // Page hosts where mismatched publisher claims are expected, not
 // suspicious — aggregators, AMP caches, web archives, reader-mode
@@ -91,6 +133,16 @@ export function typeNames(rawType: unknown): string[] {
 
 export function isAuthorityType(rawType: unknown): boolean {
   return typeNames(rawType).some((name) => AUTHORITY_TYPES.has(name));
+}
+
+export function isAnnotateOnlyAuthorityType(rawType: unknown): boolean {
+  return typeNames(rawType).some((name) =>
+    ANNOTATE_ONLY_AUTHORITY_TYPES.has(name),
+  );
+}
+
+export function isAuthorityContextProperty(name: string): boolean {
+  return AUTHORITY_CONTEXT_PROPERTIES.has(name);
 }
 
 // True iff `claimUrl` resolves to a different registrable domain than

--- a/extension/src/rules/__tests__/disguised-ad-flag.test.ts
+++ b/extension/src/rules/__tests__/disguised-ad-flag.test.ts
@@ -60,8 +60,57 @@ describe("disguisedAdFlagRule positive cases", () => {
     "Sponsored Content",
     "Sponsored Post",
     "Branded Content",
+    "Featured Listing",
+    "From Our Advertisers",
+    "Marketing Partner",
   ])("hides a card labeled '%s'", (label) => {
     document.body.innerHTML = articleCard({ label });
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+  });
+
+  it("hides a card labeled 'In partnership with Acme'", () => {
+    document.body.innerHTML = articleCard({
+      label: "In partnership with Acme",
+    });
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+  });
+
+  it("hides a card with lowercase '[ad]'", () => {
+    // Audit #203 item 18: lowercase form. Safe because the regex is anchored
+    // on the trimmed textContent with no internal whitespace allowed —
+    // editorial idioms `[ad hoc]` / `[ad lib]` can't match.
+    document.body.innerHTML = articleCard({ label: "[ad]" });
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+  });
+
+  it('hides a card whose heading is a `<div class="headline">` instead of an h*', () => {
+    document.body.innerHTML = `
+      <article class="post" data-fixture="card">
+        <span class="label">Sponsored</span>
+        <div class="headline"><a href="/x">Acme energy drinks are the future of hydration</a></div>
+        <img src="hero.jpg" alt="" />
+        <p>A long-form look at how Acme reformulated its flagship beverage to taste less metallic while keeping the same caffeine load and electrolyte balance.</p>
+        <a href="/x">Read more</a>
+      </article>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+    expect(document.querySelector('[data-fixture="card"]')).toBeNull();
+  });
+
+  it("hides a card whose heading is `[role=heading]` on a div", () => {
+    document.body.innerHTML = `
+      <article class="post" data-fixture="card">
+        <span class="label">Sponsored</span>
+        <div role="heading" aria-level="2"><a href="/x">Acme drinks are the future</a></div>
+        <img src="hero.jpg" alt="" />
+        <p>A long-form look at how Acme reformulated its flagship beverage to taste less metallic while keeping the same caffeine load and electrolyte balance.</p>
+        <a href="/x">Read more</a>
+      </article>
+    `;
     disguisedAdFlagRule.apply(document.body);
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
   });

--- a/extension/src/rules/__tests__/schema-trust-sanitize.test.ts
+++ b/extension/src/rules/__tests__/schema-trust-sanitize.test.ts
@@ -147,19 +147,79 @@ describe("JSON-LD path", () => {
     expect(parsed["@graph"][1]?.name).toBe("Story");
   });
 
-  it("does not touch Person.author (out of V1 scope)", () => {
+  it("annotates Person.author with a cross-RD URL but preserves identity", () => {
     const script = jsonLdScript({
       "@type": "Article",
       author: {
         "@type": "Person",
-        name: "Jane Doe",
-        url: "https://janedoe.example/bio",
+        name: "Sanjay Gupta",
+        url: "https://www.cnn.com/profiles/sanjay-gupta",
+      },
+    });
+    document.head.append(script);
+    schemaTrustSanitizeRule.apply(document);
+    const parsed = parseScript(script) as {
+      author: Record<string, unknown>;
+    };
+    expect(parsed.author["abs:unverified-authority"]).toBe(true);
+    // Identity is preserved (unlike Organization, where we blank). The
+    // annotation surfaces the domain-binding gap; the agent still sees
+    // the name/url so legitimate guest-author bylines render normally.
+    expect(parsed.author.name).toBe("Sanjay Gupta");
+    expect(parsed.author.url).toBe("https://www.cnn.com/profiles/sanjay-gupta");
+  });
+
+  it("leaves Person.author alone when the URL matches the page RD", () => {
+    const script = jsonLdScript({
+      "@type": "Article",
+      author: {
+        "@type": "Person",
+        name: "House Reporter",
+        url: "https://attacker.example/staff/house-reporter",
       },
     });
     document.head.append(script);
     const before = script.textContent;
     schemaTrustSanitizeRule.apply(document);
     expect(script.textContent).toBe(before);
+  });
+
+  it("leaves a standalone (non-author) Person block alone even when cross-RD", () => {
+    // A personal homepage typed `@type: Person` isn't borrowing anyone's
+    // authority — the cross-RD URL would just be the person's own site.
+    const script = jsonLdScript({
+      "@type": "Person",
+      name: "Jane Doe",
+      url: "https://janedoe.example/",
+    });
+    document.head.append(script);
+    const before = script.textContent;
+    schemaTrustSanitizeRule.apply(document);
+    expect(script.textContent).toBe(before);
+  });
+
+  it("annotates Person nested under editor / publisher / reviewedBy", () => {
+    const script = jsonLdScript({
+      "@type": "Article",
+      editor: {
+        "@type": "Person",
+        name: "Editor X",
+        url: "https://elsewhere.example/editor-x",
+      },
+      reviewedBy: {
+        "@type": "Person",
+        name: "Reviewer Y",
+        url: "https://other.example/reviewer-y",
+      },
+    });
+    document.head.append(script);
+    schemaTrustSanitizeRule.apply(document);
+    const parsed = parseScript(script) as {
+      editor: Record<string, unknown>;
+      reviewedBy: Record<string, unknown>;
+    };
+    expect(parsed.editor["abs:unverified-authority"]).toBe(true);
+    expect(parsed.reviewedBy["abs:unverified-authority"]).toBe(true);
   });
 
   it("does nothing when the Organization claim has no URL anchor", () => {
@@ -255,6 +315,45 @@ describe("microdata path", () => {
     expect(
       document.querySelector('[itemprop="url"]')?.getAttribute("href"),
     ).toBe("");
+  });
+
+  it("annotates a microdata Person.author with a cross-RD URL", () => {
+    document.body.innerHTML = `
+      <article itemscope itemtype="https://schema.org/Article">
+        <h1 itemprop="headline">Profile</h1>
+        <div itemprop="author" itemscope itemtype="https://schema.org/Person">
+          <span itemprop="name">Sanjay Gupta</span>
+          <link itemprop="url" href="https://www.cnn.com/profiles/sanjay-gupta">
+        </div>
+      </article>
+    `;
+    schemaTrustSanitizeRule.apply(document.body);
+    const author = document.querySelector('[itemprop="author"]');
+    expect(author).toBeInstanceOf(HTMLElement);
+    expect((author as HTMLElement).dataset.absSchemaTrustUnverified).toBe(
+      "true",
+    );
+    // Identity preserved.
+    expect(author?.querySelector('[itemprop="name"]')?.textContent).toBe(
+      "Sanjay Gupta",
+    );
+    expect(
+      author?.querySelector('[itemprop="url"]')?.getAttribute("href"),
+    ).toBe("https://www.cnn.com/profiles/sanjay-gupta");
+  });
+
+  it("leaves a standalone microdata Person scope alone", () => {
+    // No enclosing authority-context itemprop, so the cross-RD URL is
+    // the Person's own site, not a borrowed-authority claim.
+    document.body.innerHTML = `
+      <div itemscope itemtype="https://schema.org/Person">
+        <span itemprop="name">Jane Doe</span>
+        <link itemprop="url" href="https://janedoe.example/">
+      </div>
+    `;
+    const before = document.body.innerHTML;
+    schemaTrustSanitizeRule.apply(document.body);
+    expect(document.body.innerHTML).toBe(before);
   });
 
   it("does not descend into nested itemscope when reading the item's own URL", () => {

--- a/extension/src/rules/disguised-ad-flag.ts
+++ b/extension/src/rules/disguised-ad-flag.ts
@@ -68,6 +68,12 @@ const STANDALONE_PHRASES: readonly string[] = [
   "sponsored content",
   "sponsored post",
   "branded content",
+  // Added per audit #203 item 18: marketplace listings and partner-program
+  // disclosures use these as standalone labels in the same shape — small
+  // leaf-ish text in the corner of an article-shaped card.
+  "featured listing",
+  "from our advertisers",
+  "marketing partner",
 ];
 
 // Suffix-form phrases — "Sponsored by Acme", "Presented by Acme", "Paid
@@ -77,6 +83,10 @@ const SUFFIX_PHRASES: readonly string[] = [
   "sponsored by",
   "presented by",
   "paid for and presented by",
+  // Added per audit #203 item 18: "In partnership with <Brand>" is the
+  // co-branded native-advertorial label shape on retail and editorial
+  // sites alike.
+  "in partnership with",
 ];
 
 function escapeRegex(literal: string): string {
@@ -98,9 +108,13 @@ const SUFFIX_RE = new RegExp(
 );
 
 // Bracket / parenthesized labels common in social feeds and mobile apps.
-// Case-sensitive on the "A" so the English preposition "ad" in
-// "[ad hoc]" / "[ad lib]" doesn't trigger.
-const BRACKET_RE = /^(?:\[Ad\]|\[AD\]|\(promoted\)|\(sponsored\))$/;
+// The regex is anchored end-to-end against the *trimmed* textContent of a
+// leaf-ish candidate, so the editorial idioms "ad hoc" / "ad lib" cannot
+// match — their bracketed forms have internal whitespace ("[ad hoc]")
+// which the no-content `\[ad\]` literal rejects. That's why we can accept
+// the lowercase form here (audit #203 item 18) alongside the original
+// case-variants that were guarded as a defense-in-depth precaution.
+const BRACKET_RE = /^(?:\[ad\]|\[Ad\]|\[AD\]|\(promoted\)|\(sponsored\))$/;
 
 interface LabelMatch {
   // The phrase form that matched, used in the placeholder copy so a
@@ -177,12 +191,26 @@ function isPageBoundary(element: Element): boolean {
   return element.getAttribute("role") === "main";
 }
 
+// Heading-equivalent selector. Beyond the literal h1–h6 set, accept two
+// accessibility-spec-compliant carriers (audit #203 item 19):
+//   - `[role="heading"]`: the ARIA-defined heading carrier (a `<div
+//     role="heading" aria-level="…">` is semantically identical to an
+//     `<h*>` for assistive tech, and design systems that style their own
+//     headings emit it instead of a real `<h*>`).
+//   - `.headline` (exact token match via `[class~="headline"]`): the
+//     conventional class name for card headlines on news / publisher CMSs
+//     (`<div class="headline">`, `<div class="card headline">`). Narrow
+//     to this single token — `[class*="title"]` would chew through chrome
+//     like `.page-title` / `.section-title` and over-fire.
+const HEADING_SELECTOR =
+  'h1, h2, h3, h4, h5, h6, [role="heading"], [class~="headline"]';
+
 // True if `element` looks like an article card: contains a heading, plus
 // at least one of an image or an outgoing link, plus enough prose text to
 // be confusable with editorial. The label text itself and headings are
 // excluded from the prose count so a label-only row doesn't qualify.
 function isArticleShaped(element: Element, labelElement: Element): boolean {
-  const heading = element.querySelector("h1, h2, h3, h4, h5, h6");
+  const heading = element.querySelector(HEADING_SELECTOR);
   if (heading === null) {
     return false;
   }
@@ -207,7 +235,7 @@ function isArticleShaped(element: Element, labelElement: Element): boolean {
     if (child === labelElement || labelElement.contains(child)) {
       continue;
     }
-    if (child.querySelector("h1, h2, h3, h4, h5, h6") !== null) {
+    if (child.querySelector(HEADING_SELECTOR) !== null) {
       continue;
     }
     let hasNestedCandidate = false;

--- a/extension/src/rules/disguised-ad-flag.ts
+++ b/extension/src/rules/disguised-ad-flag.ts
@@ -123,8 +123,11 @@ interface LabelMatch {
 }
 
 function matchLabel(text: string): LabelMatch | null {
-  // Bracket form is case-sensitive on `Ad`, so check it before the
-  // case-insensitive regexes.
+  // Bracket form has no `i` flag (case-sensitive) and enumerates the three
+  // accepted variants explicitly (`[ad]`, `[Ad]`, `[AD]`) so the editorial
+  // idioms `[ad hoc]` / `[ad lib]` — which carry internal whitespace — can't
+  // match. Check it before the case-insensitive regexes since both could
+  // match a `[Ad]` text otherwise.
   if (BRACKET_RE.test(text)) {
     return { phrase: text };
   }

--- a/extension/src/rules/schema-trust-sanitize.ts
+++ b/extension/src/rules/schema-trust-sanitize.ts
@@ -10,26 +10,41 @@
 // Snopes, or a top-level `@type: Organization` block on a domain that
 // has no relationship to the named entity.
 //
-// V1 scope is intentionally narrow: only `Organization` and its
-// subtypes, only when the claim object exposes a `url` field, only
-// matching at eTLD+1 (registrable domain). `Person.url` mismatches and
-// name-only claims with no `url` to anchor against are out — they're
-// noisier and need a brand allowlist to handle without false positives.
+// Two treatments live in this rule, picked by `@type`:
 //
-// Sanitize semantics: when a mismatch is detected we blank the
-// identifying string fields (`name`, `url`, `@id`) on the offending
-// object and leave the surrounding structure intact, so an agent still
-// receives the article's price / rating / headline / dates but loses
-// the impersonating identity. Pages on known syndicators, AMP caches,
-// archive proxies, and reader-mode hosts short-circuit the rule
-// entirely — mismatched publishers on those hosts are expected, not
-// suspicious.
+//   * Organization-family @types are *sanitized* — `name` / `url` /
+//     `@id` are blanked on a cross-RD mismatch. The agent still sees
+//     `@type: Organization` and the surrounding metadata (headline,
+//     price, dates) but loses the impersonating identity strings.
+//   * `Person` is *annotated* — when nested under an authority context
+//     property (author / editor / publisher / etc.) and the URL is
+//     cross-RD, we stamp the JSON-LD object with
+//     `abs:unverified-authority: true` and stamp the microdata scope
+//     with `data-abs-schema-trust-unverified`. The identity is left
+//     intact. The asymmetry is on purpose: sanitizing Person.url would
+//     erase legitimate guest-author and academic bylines that
+//     routinely link off-domain, but the same shape is the carrier for
+//     byline impersonation (a scam page asserting `Article.author =
+//     Person{name:"Sanjay Gupta", url:"cnn.com"}`). The annotation
+//     gives an agent reading structured data the same domain-binding
+//     warning the Organization path conveys by blanking, without
+//     damaging real metadata. A standalone `@type: Person` (a personal
+//     homepage) is left alone — it isn't borrowing anyone's authority,
+//     so the cross-RD URL isn't a smoking gun.
+//
+// Pages on known syndicators, AMP caches, archive proxies, and
+// reader-mode hosts short-circuit the rule entirely — mismatched
+// publishers on those hosts are expected, not suspicious.
 
+import { SCHEMA_TRUST_UNVERIFIED_ATTR } from "../lib/dom-markers";
 import {
+  isAnnotateOnlyAuthorityType,
+  isAuthorityContextProperty,
   isAuthorityType,
   isAuthorityUrlMismatch,
   SANITIZE_KEYS,
   shouldSkipPage,
+  UNVERIFIED_AUTHORITY_KEY,
 } from "../lib/schema-trust";
 import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import type { Rule } from "./types";
@@ -68,14 +83,33 @@ function sanitizeAuthorityNode(
   }
 }
 
+function annotateAuthorityNode(
+  node: Record<string, unknown>,
+  mutated: { value: boolean },
+): void {
+  if (node[UNVERIFIED_AUTHORITY_KEY] === true) {
+    return;
+  }
+  node[UNVERIFIED_AUTHORITY_KEY] = true;
+  mutated.value = true;
+}
+
+// `parentKey` is the property name under which this object lives in its
+// containing object — `undefined` for the top-level node. It's used only
+// to gate the Person annotate path: a Person under `author` (or one of
+// the other authority-context properties) is borrowing organizational
+// authority and worth flagging; a top-level `@type: Person` page is
+// not. Arrays inherit the parent's key (a `Person[]` under `author` is
+// still author-context).
 function walk(
   value: unknown,
   pageHost: string,
   mutated: { value: boolean },
+  parentKey?: string,
 ): void {
   if (Array.isArray(value)) {
     for (const item of value) {
-      walk(item, pageHost, mutated);
+      walk(item, pageHost, mutated, parentKey);
     }
     return;
   }
@@ -88,9 +122,18 @@ function walk(
     if (claimUrl !== null && isAuthorityUrlMismatch(claimUrl, pageHost)) {
       sanitizeAuthorityNode(node, mutated);
     }
+  } else if (
+    parentKey !== undefined &&
+    isAuthorityContextProperty(parentKey) &&
+    isAnnotateOnlyAuthorityType(node["@type"])
+  ) {
+    const claimUrl = extractClaimUrl(node);
+    if (claimUrl !== null && isAuthorityUrlMismatch(claimUrl, pageHost)) {
+      annotateAuthorityNode(node, mutated);
+    }
   }
-  for (const child of Object.values(node)) {
-    walk(child, pageHost, mutated);
+  for (const [key, child] of Object.entries(node)) {
+    walk(child, pageHost, mutated, key);
   }
 }
 
@@ -215,32 +258,67 @@ function blankItempropValue(element: Element): boolean {
   return false;
 }
 
+// Microdata equivalent of the JSON-LD `parentKey` gate: in microdata,
+// an item that's serving as the value of a property on the enclosing
+// item carries that property name in its own `itemprop` attribute
+// (e.g. `<div itemscope itemtype=".../Person" itemprop="author">`).
+// Returns the property names this item is filling for its enclosing
+// scope, or an empty array for a top-level item that isn't acting as
+// anyone's property.
+function itemPropertyContext(item: Element): string[] {
+  const itemprop = item.getAttribute("itemprop");
+  if (itemprop === null) {
+    return [];
+  }
+  return itemprop.split(/\s+/).filter((name) => name !== "");
+}
+
+function readClaimUrl(item: Element): string | null {
+  const urlElements = scopedDescendants(item, "url");
+  for (const element of urlElements) {
+    const value = readItempropValue(element).trim();
+    if (value !== "") {
+      return value;
+    }
+  }
+  const itemid = item.getAttribute("itemid");
+  if (itemid !== null && itemid !== "") {
+    return itemid;
+  }
+  return null;
+}
+
 function processItem(item: Element, pageHost: string): void {
   const itemtype = item.getAttribute("itemtype");
   if (itemtype === null) {
     return;
   }
   const types = microdataTypeNames(itemtype);
-  if (!types.some((name) => isAuthorityType(name))) {
+  const isAuthority = types.some((name) => isAuthorityType(name));
+  const isAnnotateOnly =
+    !isAuthority && types.some((name) => isAnnotateOnlyAuthorityType(name));
+  if (!isAuthority && !isAnnotateOnly) {
     return;
   }
-  const urlElements = scopedDescendants(item, "url");
-  let claimUrl: string | null = null;
-  for (const element of urlElements) {
-    const value = readItempropValue(element).trim();
-    if (value !== "") {
-      claimUrl = value;
-      break;
+  // For annotate-only (Person) we require an authority-context itemprop on
+  // the item itself — a standalone Person scope (a personal bio page typed
+  // as Person) is not borrowing anyone's authority, so a cross-RD URL
+  // there isn't suspicious.
+  if (isAnnotateOnly) {
+    const context = itemPropertyContext(item);
+    if (!context.some((name) => isAuthorityContextProperty(name))) {
+      return;
+    }
+    if (item.hasAttribute(SCHEMA_TRUST_UNVERIFIED_ATTR)) {
+      return;
     }
   }
-  if (claimUrl === null) {
-    // Fall back to itemid (microdata's @id-equivalent) if present.
-    const itemid = item.getAttribute("itemid");
-    if (itemid !== null && itemid !== "") {
-      claimUrl = itemid;
-    }
-  }
+  const claimUrl = readClaimUrl(item);
   if (claimUrl === null || !isAuthorityUrlMismatch(claimUrl, pageHost)) {
+    return;
+  }
+  if (isAnnotateOnly) {
+    item.setAttribute(SCHEMA_TRUST_UNVERIFIED_ATTR, "true");
     return;
   }
   for (const key of SANITIZE_KEYS) {


### PR DESCRIPTION
## Summary

Bundles three audit items from #203 (`schema-trust` #15, `disguised-ad-flag` #18 + #19).

- **15 — Person annotate path** in `schema-trust-sanitize`. Sanitize-on-Person is too noisy to ship (legit guest-author and academic bylines routinely link off-domain), but the same shape is the exact carrier for byline impersonation (`Article.author = Person{name:"Sanjay Gupta", url:"cnn.com"}`). Resolution: when a `Person` is nested under an authority-context property (`author` / `editor` / `publisher` / `reviewedBy` / etc.) and its `url` is cross-RD, stamp the JSON-LD node with `abs:unverified-authority: true` and the microdata scope with `data-abs-schema-trust-unverified`. Identity (`name`/`url`/`@id`) preserved. Standalone `@type: Person` left alone — not borrowing anyone's authority.
- **18 — broader label vocabulary** in `disguised-ad-flag`. Adds standalones `Featured Listing`, `From our Advertisers`, `Marketing Partner`; suffix-form `In partnership with <Brand>`; and lowercase `[ad]`. The lowercase bracket form is safe because the regex is anchored on trimmed text with no internal whitespace — editorial idioms (`[ad hoc]`, `[ad lib]`) can't match.
- **19 — heading-equivalent allowlist**. `HEADING_SELECTOR` accepts `[role="heading"]` (ARIA spec) and `[class~="headline"]` (exact-token match) alongside `h1`–`h6`. Used in both the article-shape gate and the nested-prose-skip gate. Selector is narrow — broader `*title*` / `*heading*` matches would pull in chrome (`.page-title`, `.video-title`).

Why-comments added inline at each decision so future readers see the FP analysis (Person) and the safety argument for lowercase `[ad]` without re-deriving them.

## Test plan

- [x] `bun run check` — biome + eslint clean
- [x] `bun run typecheck` — clean
- [x] `bun run knip` — clean
- [x] 80/80 tests pass in `schema-trust` + `disguised-ad-flag` suites (lib + rule + skip + property)
- [x] `pre-commit run --files docs/src/content/docs/rules.md` — mdformat + markdownlint clean
- [ ] Manual: drop a fixture JSON-LD with `Article.author = Person{...cross-RD...}` on the demo site and confirm the rule annotates without breaking the byline; verify a standalone `@type: Person` page is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)