### PR TITLE
Fix: detect PII / encoded payloads split across sibling text nodes (#203)

### DIFF
--- a/demo-site/src/pages/Checkout.tsx
+++ b/demo-site/src/pages/Checkout.tsx
@@ -42,6 +42,49 @@ export default function Checkout() {
             </div>
           </div>
 
+          {/* Each digit group / segment rendered as its own <span> — the
+              React-style render shape that defeats per-text-node scanning
+              for pii-redact / encoded-payload-redact / secrets-redact. The
+              factory's inline-formatting-context grouping concatenates
+              sibling text nodes within one block before running the
+              detector, so each entry below should still be masked. */}
+          <div className="rounded border border-stone-200 bg-white p-6">
+            <h2 className="mb-3 text-lg font-semibold text-slate-900">
+              3a. Alternate payment (cards on file, span-split rendering)
+            </h2>
+            <div className="space-y-1 text-sm text-stone-800">
+              <div>
+                Backup Visa: <span>4111 </span>
+                <span>1111 </span>
+                <span>1111 </span>
+                <span>1111</span>
+              </div>
+              <div>
+                Tax ID: <span>123</span>
+                <span>-45</span>
+                <span>-6789</span>
+              </div>
+              <div>
+                Office line: <strong>(555) </strong>
+                <em>867-</em>
+                <code>5309</code>
+              </div>
+              <div>
+                API token: <span>eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.</span>
+                <span>SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c</span>
+              </div>
+              <div>
+                Encoded note:{" "}
+                <span>
+                  VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZyB3
+                </span>
+                <span>
+                  aGlsZSByZWNpdGluZyB0aGUgYWxwaGFiZXQgZnJvbSBBIHRocm91Z2ggWi4=
+                </span>
+              </div>
+            </div>
+          </div>
+
           <div className="rounded border border-stone-200 bg-white p-6">
             <h2 className="mb-3 text-lg font-semibold text-slate-900">
               4. Shipping & contact

--- a/extension/src/lib/__tests__/placeholder.test.ts
+++ b/extension/src/lib/__tests__/placeholder.test.ts
@@ -14,12 +14,14 @@ import {
   LABEL_ICON_CLASS,
   LABEL_TEXT_CLASS,
   PLACEHOLDER_CLASS,
+  replaceMatchAcrossTextNodes,
   replaceWithBlockPlaceholder,
   revealAll,
 } from "../placeholder";
 import type { RuleId } from "../storage";
 
 const RULE_ID = "footer-redact" as RuleId;
+const PII_RULE_ID = "pii-redact" as RuleId;
 
 beforeEach(() => {
   document.body.innerHTML = "";
@@ -201,5 +203,130 @@ describe("revealAll", () => {
     expect(() => {
       revealAll(RULE_ID);
     }).not.toThrow();
+  });
+});
+
+// `replaceMatchAcrossTextNodes` is exercised end-to-end via the
+// inline-text-redact factory tests, but the wrapper-preservation /
+// reveal-restoration invariants are easier to pin down at the helper
+// level than through a rule's MutationObserver loop.
+describe("replaceMatchAcrossTextNodes", () => {
+  // Helper: lay out a parent `<p>` containing the supplied text fragments,
+  // wrapping each in a `<span>` so the rule's typical React-style render
+  // shape is reproduced. Returns the array of text nodes in document
+  // order — the helper takes them positionally.
+  function spanify(parts: readonly string[]): {
+    container: HTMLParagraphElement;
+    textNodes: Text[];
+  } {
+    const container = document.createElement("p");
+    const textNodes: Text[] = [];
+    for (const part of parts) {
+      const span = document.createElement("span");
+      const text = document.createTextNode(part);
+      span.append(text);
+      container.append(span);
+      textNodes.push(text);
+    }
+    document.body.append(container);
+    return { container, textNodes };
+  }
+
+  it("inserts one inline placeholder spanning matched range across siblings", () => {
+    const { container, textNodes } = spanify(["4111", "1111", "1111", "1111"]);
+    replaceMatchAcrossTextNodes(
+      textNodes,
+      0,
+      0,
+      3,
+      4,
+      PII_RULE_ID,
+      "[card hidden]",
+    );
+
+    const placeholders = container.querySelectorAll(`.${PLACEHOLDER_CLASS}`);
+    expect(placeholders).toHaveLength(1);
+    expect(placeholders[0]?.textContent).toBe("[card hidden]");
+    expect(container.textContent).toBe("[card hidden]");
+  });
+
+  it("keeps wrapping spans in the DOM even when their text is fully matched", () => {
+    const { container, textNodes } = spanify(["4111", "1111", "1111", "1111"]);
+    const spansBefore = [...container.querySelectorAll("span")];
+
+    replaceMatchAcrossTextNodes(
+      textNodes,
+      0,
+      0,
+      3,
+      4,
+      PII_RULE_ID,
+      "[card hidden]",
+    );
+
+    // All four wrapper spans stay (per the "scrub, don't detach
+    // framework-owned nodes" rule). The first span now hosts the
+    // placeholder; spans 2-4 hold empty text nodes.
+    const spansAfter = [...container.querySelectorAll("span")];
+    expect(spansAfter).toEqual(spansBefore);
+  });
+
+  it("preserves prefix and suffix text when the match is partial at the boundaries", () => {
+    const { container, textNodes } = spanify(["Card: 4111", "1111 1111 1111"]);
+    // "Card: " is 6 chars; first node length 10. Match covers digits only.
+    replaceMatchAcrossTextNodes(
+      textNodes,
+      0,
+      6,
+      1,
+      14,
+      PII_RULE_ID,
+      "[card hidden]",
+    );
+
+    expect(container.textContent).toBe("Card: [card hidden]");
+    expect(container.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(1);
+  });
+
+  it("restores the original concatenated text on reveal click", () => {
+    const { container, textNodes } = spanify(["4111", "1111", "1111", "1111"]);
+    replaceMatchAcrossTextNodes(
+      textNodes,
+      0,
+      0,
+      3,
+      4,
+      PII_RULE_ID,
+      "[card hidden]",
+    );
+
+    const placeholder = container.querySelector<HTMLElement>(
+      `.${PLACEHOLDER_CLASS}`,
+    );
+    expect(placeholder).not.toBeNull();
+    placeholder?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    // Reveal collapses the original split into a single text node at the
+    // placeholder's prior position; spans 2-4 stay but contribute their
+    // (still-blanked) empty values.
+    expect(container.textContent).toBe("4111111111111111");
+    expect(container.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+
+  it("delegates to replaceMatchesInTextNode when both endpoints land in one node", () => {
+    const { container, textNodes } = spanify(["leading 4111111111111111 tail"]);
+    // Match the 16-digit run inside the single text node, exercising the
+    // same-index fast path.
+    replaceMatchAcrossTextNodes(
+      textNodes,
+      0,
+      8,
+      0,
+      24,
+      PII_RULE_ID,
+      "[card hidden]",
+    );
+
+    expect(container.textContent).toBe("leading [card hidden] tail");
   });
 });

--- a/extension/src/lib/dom-utils.ts
+++ b/extension/src/lib/dom-utils.ts
@@ -199,6 +199,75 @@ export function walkTextNodes(
   return collectTextNodesShadowPiercing(root, options);
 }
 
+// Tags that introduce a new inline-formatting context — text nodes on
+// opposite sides render on separate lines visually and do NOT logically
+// concatenate. Used by `collectTextNodesWithInlineGroups` to bucket text
+// nodes so the inline-text-redact factory can detect matches split across
+// sibling text nodes (a React `<span>`-per-digit-group card render is the
+// motivating case) without falsely concatenating across block boundaries.
+//
+// Static list rather than `getComputedStyle().display` — the lookup is
+// hot (every text node visited), the false-negative cost is only a missed
+// detection on an inline tag styled to `display:block`, and reading
+// computed style during a tree walk forces layout. Conservative: a tag
+// missing from this set is treated as inline; that can cause false
+// negatives but never false positives across true block boundaries.
+const BLOCK_LEVEL_TAGS: ReadonlySet<string> = new Set([
+  "ADDRESS",
+  "ARTICLE",
+  "ASIDE",
+  "BLOCKQUOTE",
+  "BODY",
+  "CAPTION",
+  "COLGROUP",
+  "DD",
+  "DETAILS",
+  "DIALOG",
+  "DIV",
+  "DL",
+  "DT",
+  "FIELDSET",
+  "FIGCAPTION",
+  "FIGURE",
+  "FOOTER",
+  "FORM",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+  "HEADER",
+  "HR",
+  "HTML",
+  "LI",
+  "MAIN",
+  "MENU",
+  "NAV",
+  "OL",
+  "P",
+  "PRE",
+  "SECTION",
+  "SUMMARY",
+  "TABLE",
+  "TBODY",
+  "TD",
+  "TFOOT",
+  "TH",
+  "THEAD",
+  "TR",
+  "UL",
+]);
+
+export interface TextNodeWithInlineGroup {
+  node: Text;
+  // Stable id per inline-formatting context within this collection pass.
+  // Two text nodes share a group iff they're rendered as one continuous
+  // line of inline text (no intervening block element, `<br>`, or shadow
+  // boundary). Ids are dense within a pass but otherwise opaque.
+  group: number;
+}
+
 // Shared core for `walkTextNodes` and the chunked walker in
 // `yielding-text-walk.ts`. Pre-collects every text node under `root`
 // matching the same filter both APIs expose, descending through open
@@ -212,8 +281,31 @@ export function collectTextNodesShadowPiercing(
   root: ParentNode,
   options: WalkTextNodesOptions = {},
 ): Text[] {
+  return collectTextNodesWithInlineGroups(root, options).map(
+    (entry) => entry.node,
+  );
+}
+
+// Group-aware variant. Same filter and shadow-piercing semantics as
+// `collectTextNodesShadowPiercing`, plus an inline-formatting-context id
+// per text node so callers can detect cross-node matches without
+// concatenating across block / `<br>` / shadow-root boundaries.
+//
+// Group id bumps:
+//   - on entering and leaving a `BLOCK_LEVEL_TAGS` subtree (pre+post so
+//     siblings before/inside/after the block sit in three groups);
+//   - on encountering a `<br>` element (post only; `<br>` is void);
+//   - on entering and leaving a shadow root.
+//
+// Each text node is tagged with the counter's value at the moment it's
+// visited.
+export function collectTextNodesWithInlineGroups(
+  root: ParentNode,
+  options: WalkTextNodesOptions = {},
+): TextNodeWithInlineGroup[] {
   const { minLength = 0, shouldSkipParent } = options;
-  const out: Text[] = [];
+  const out: TextNodeWithInlineGroup[] = [];
+  let currentGroup = 0;
 
   function accept(text: Text): boolean {
     const parent = text.parentElement;
@@ -240,7 +332,7 @@ export function collectTextNodesShadowPiercing(
     if (node.nodeType === Node.TEXT_NODE) {
       const text = node as Text;
       if (accept(text)) {
-        out.push(text);
+        out.push({ node: text, group: currentGroup });
       }
       return;
     }
@@ -255,13 +347,29 @@ export function collectTextNodesShadowPiercing(
     if (isNonContentTag(element.tagName)) {
       return;
     }
+    const tag = element.tagName;
+    if (tag === "BR") {
+      // Void element; bump on leave so any post-<br> sibling text starts
+      // a new group.
+      currentGroup++;
+      return;
+    }
+    const isBlock = BLOCK_LEVEL_TAGS.has(tag);
+    if (isBlock) {
+      currentGroup++;
+    }
     for (const child of element.childNodes) {
       visit(child);
     }
     if (element.shadowRoot) {
+      currentGroup++;
       for (const child of element.shadowRoot.childNodes) {
         visit(child);
       }
+      currentGroup++;
+    }
+    if (isBlock) {
+      currentGroup++;
     }
   }
 

--- a/extension/src/lib/inline-text-redact.ts
+++ b/extension/src/lib/inline-text-redact.ts
@@ -31,9 +31,9 @@
 import { ReusableAbortController } from "abort-utils";
 import type { Rule } from "../rules/types";
 import type { TextNodeWithInlineGroup } from "./dom-utils";
-import type { InlineMatch } from "./placeholder";
+import type { InlineMatch, MultiNodeMatch } from "./placeholder";
 import {
-  replaceMatchAcrossTextNodes,
+  replaceMatchesAcrossTextNodes,
   replaceMatchesInTextNode,
 } from "./placeholder";
 import { subscribeRouteChange } from "./route-change";
@@ -175,12 +175,17 @@ function buildBucketLayout(bucket: TextNodeWithInlineGroup[]): BucketLayout {
 // each match. Single-node buckets fall through `replaceMatchesInTextNode`
 // (bit-identical to the pre-grouping behavior). Multi-node buckets
 // concatenate values, run `collectMatches` on the concatenation, then
-// route each match to single-node or cross-node materializer based on
-// whether it straddles a node boundary.
+// hand the full match set to `replaceMatchesAcrossTextNodes` which
+// applies all mutations atomically per affected node.
 //
-// Multi-node matches are applied last-to-first so each application's
-// position references stay valid as later (rightward) mutations land
-// first and leave earlier offsets untouched.
+// All-at-once application is load-bearing: applying matches sequentially
+// would let each match invalidate the layout offsets the next match
+// depends on (a single-node match replaces its text node, detaching it
+// from the DOM and silently dropping any later match into the same node;
+// a cross-node match truncates a boundary node's value, shifting offsets
+// for any later match in that node). The plural helper plans every
+// affected node's new content from a single snapshot of the originals,
+// so each text node is mutated exactly once.
 function processBucket(
   bucket: TextNodeWithInlineGroup[],
   ruleId: RuleId,
@@ -213,31 +218,19 @@ function processBucket(
     return;
   }
 
-  for (const match of matches.toReversed()) {
+  const multiMatches: MultiNodeMatch[] = [];
+  for (const match of matches) {
     const start = locateStart(layout, match.start);
     const end = locateEnd(layout, match.end);
-    if (start.index === end.index) {
-      const node = layout.nodes[start.index];
-      if (!node) {
-        continue;
-      }
-      replaceMatchesInTextNode(
-        node,
-        [{ start: start.offset, end: end.offset, label: match.label }],
-        ruleId,
-      );
-      continue;
-    }
-    replaceMatchAcrossTextNodes(
-      layout.nodes,
-      start.index,
-      start.offset,
-      end.index,
-      end.offset,
-      ruleId,
-      match.label,
-    );
+    multiMatches.push({
+      startIndex: start.index,
+      startOffset: start.offset,
+      endIndex: end.index,
+      endOffset: end.offset,
+      label: match.label,
+    });
   }
+  replaceMatchesAcrossTextNodes(layout.nodes, multiMatches, ruleId);
 }
 
 // Translate a concatenated-string offset to (node index, local offset).

--- a/extension/src/lib/inline-text-redact.ts
+++ b/extension/src/lib/inline-text-redact.ts
@@ -7,6 +7,13 @@
 // duplicated the same lifecycle scaffolding around a one-line difference
 // in `collectMatches`.
 //
+// The walk groups text nodes by inline-formatting context (see
+// `collectTextNodesWithInlineGroups`) so `collectMatches` sees the
+// concatenation of sibling text nodes within one inline run — a card
+// number rendered as `<span>4111</span> <span>1111</span> ...` is
+// detected, while digits split across a `<br>` or block boundary are
+// not.
+//
 // Lifecycle the factory owns:
 //   - One `ReusableAbortController` whose signal is threaded into every
 //     chunked text walk. Route changes call `abortAndReset` to cancel
@@ -23,12 +30,16 @@
 
 import { ReusableAbortController } from "abort-utils";
 import type { Rule } from "../rules/types";
+import type { TextNodeWithInlineGroup } from "./dom-utils";
 import type { InlineMatch } from "./placeholder";
-import { replaceMatchesInTextNode } from "./placeholder";
+import {
+  replaceMatchAcrossTextNodes,
+  replaceMatchesInTextNode,
+} from "./placeholder";
 import { subscribeRouteChange } from "./route-change";
 import type { RuleId } from "./storage";
 import { createSubtreeWatcher } from "./subtree-watcher";
-import { walkTextNodesChunked } from "./yielding-text-walk";
+import { walkTextNodeGroupsChunked } from "./yielding-text-walk";
 
 export interface InlineTextRedactRuleOptions {
   id: RuleId;
@@ -56,15 +67,18 @@ export function defineInlineTextRedactRule(
   let unsubscribeRouteChange: (() => void) | null = null;
 
   function scanAndMask(root: ParentNode): void {
-    walkTextNodesChunked(root, {
+    // Per-node `minLength` is intentionally NOT passed to the walker —
+    // it would drop legitimate cross-node matches whose individual text
+    // nodes sit below the floor (the card-in-spans bypass we're fixing
+    // is exactly this shape: each `<span>` carries a 4-digit fragment,
+    // well below pii-redact's MIN_TEXT_LENGTH=9). The per-group floor
+    // applies in `processBucket` against the concatenated length, which
+    // preserves the per-rule cheap early-out for prose nodes.
+    walkTextNodeGroupsChunked(root, {
       signal: lifecycle.signal,
-      minLength,
       process: (chunk) => {
-        for (const node of chunk) {
-          const matches = collectMatches(node.nodeValue ?? "");
-          if (matches.length > 0) {
-            replaceMatchesInTextNode(node, matches, id);
-          }
+        for (const bucket of bucketByGroup(chunk)) {
+          processBucket(bucket, id, collectMatches, minLength);
         }
       },
     });
@@ -97,4 +111,168 @@ export function defineInlineTextRedactRule(
       unsubscribeRouteChange = null;
     },
   } satisfies InlineTextRedactRule;
+}
+
+// Bucket a chunk of group-tagged text nodes into runs of consecutive
+// entries that share a group id. Chunk-internal grouping only —
+// cross-chunk groups (rare: >100 text nodes in one inline-formatting
+// context, e.g. a single huge `<p>` with span-per-word rendering) are
+// processed as two separate buckets. Accepted miss: matches that span
+// the chunk boundary go undetected. The 100-node default cushion makes
+// this vanishingly rare in practice.
+function bucketByGroup(
+  chunk: readonly TextNodeWithInlineGroup[],
+): TextNodeWithInlineGroup[][] {
+  const buckets: TextNodeWithInlineGroup[][] = [];
+  let current: TextNodeWithInlineGroup[] = [];
+  let currentGroup: number | null = null;
+  for (const entry of chunk) {
+    if (currentGroup === null || entry.group !== currentGroup) {
+      if (current.length > 0) {
+        buckets.push(current);
+      }
+      current = [entry];
+      currentGroup = entry.group;
+    } else {
+      current.push(entry);
+    }
+  }
+  if (current.length > 0) {
+    buckets.push(current);
+  }
+  return buckets;
+}
+
+interface BucketLayout {
+  // Sibling text nodes whose nodeValues concatenate to form `concatenated`.
+  nodes: Text[];
+  // `lengths[i] = nodes[i].nodeValue.length`. Parallel to `nodes`.
+  lengths: number[];
+  // `offsets[i] = sum(lengths[0..i-1])`. Parallel to `nodes`.
+  offsets: number[];
+  // Joined value of every node, in document order.
+  concatenated: string;
+}
+
+function buildBucketLayout(bucket: TextNodeWithInlineGroup[]): BucketLayout {
+  const nodes: Text[] = [];
+  const lengths: number[] = [];
+  const offsets: number[] = [];
+  let total = 0;
+  const parts: string[] = [];
+  for (const entry of bucket) {
+    const value = entry.node.nodeValue ?? "";
+    nodes.push(entry.node);
+    lengths.push(value.length);
+    offsets.push(total);
+    parts.push(value);
+    total += value.length;
+  }
+  return { nodes, lengths, offsets, concatenated: parts.join("") };
+}
+
+// Run `collectMatches` over a single inline-group bucket and materialize
+// each match. Single-node buckets fall through `replaceMatchesInTextNode`
+// (bit-identical to the pre-grouping behavior). Multi-node buckets
+// concatenate values, run `collectMatches` on the concatenation, then
+// route each match to single-node or cross-node materializer based on
+// whether it straddles a node boundary.
+//
+// Multi-node matches are applied last-to-first so each application's
+// position references stay valid as later (rightward) mutations land
+// first and leave earlier offsets untouched.
+function processBucket(
+  bucket: TextNodeWithInlineGroup[],
+  ruleId: RuleId,
+  collectMatches: (text: string) => InlineMatch[],
+  minLength: number,
+): void {
+  const [firstEntry] = bucket;
+  if (!firstEntry) {
+    return;
+  }
+  if (bucket.length === 1) {
+    const node = firstEntry.node;
+    const value = node.nodeValue ?? "";
+    if (value.length < minLength) {
+      return;
+    }
+    const matches = collectMatches(value);
+    if (matches.length > 0) {
+      replaceMatchesInTextNode(node, matches, ruleId);
+    }
+    return;
+  }
+
+  const layout = buildBucketLayout(bucket);
+  if (layout.concatenated.length < minLength) {
+    return;
+  }
+  const matches = collectMatches(layout.concatenated);
+  if (matches.length === 0) {
+    return;
+  }
+
+  for (const match of matches.toReversed()) {
+    const start = locateStart(layout, match.start);
+    const end = locateEnd(layout, match.end);
+    if (start.index === end.index) {
+      const node = layout.nodes[start.index];
+      if (!node) {
+        continue;
+      }
+      replaceMatchesInTextNode(
+        node,
+        [{ start: start.offset, end: end.offset, label: match.label }],
+        ruleId,
+      );
+      continue;
+    }
+    replaceMatchAcrossTextNodes(
+      layout.nodes,
+      start.index,
+      start.offset,
+      end.index,
+      end.offset,
+      ruleId,
+      match.label,
+    );
+  }
+}
+
+// Translate a concatenated-string offset to (node index, local offset).
+// `start` semantics: at an exact node boundary, prefer the right node
+// (offset=0) so the placeholder lands inside the wrapper that holds the
+// matched content rather than at the trailing edge of a non-matching
+// sibling.
+function locateStart(
+  layout: BucketLayout,
+  position: number,
+): { index: number; offset: number } {
+  for (const [i, length] of layout.lengths.entries()) {
+    const offset = layout.offsets[i] ?? 0;
+    if (position < offset + length) {
+      return { index: i, offset: position - offset };
+    }
+  }
+  const lastIndex = layout.lengths.length - 1;
+  return { index: lastIndex, offset: layout.lengths[lastIndex] ?? 0 };
+}
+
+// `end` semantics: at an exact node boundary, prefer the left node
+// (offset=length). Otherwise the cross-node helper would be asked to
+// truncate a node from offset 0 to 0 — a no-op that leaves the trailing
+// node's text fully intact and pushes the placeholder past content the
+// match was supposed to consume.
+function locateEnd(
+  layout: BucketLayout,
+  position: number,
+): { index: number; offset: number } {
+  for (let i = layout.offsets.length - 1; i >= 0; i--) {
+    const offset = layout.offsets[i] ?? 0;
+    if (offset < position) {
+      return { index: i, offset: position - offset };
+    }
+  }
+  return { index: 0, offset: 0 };
 }

--- a/extension/src/lib/placeholder.ts
+++ b/extension/src/lib/placeholder.ts
@@ -179,23 +179,13 @@ export function replaceMatchesInTextNode(
     if (match.start > cursor) {
       fragment.append(document.createTextNode(text.slice(cursor, match.start)));
     }
-    // Inline placeholders are short and have no scrollable area, so the
-    // <button> serves as both the visual chip and the a11y-tree exposure.
-    const placeholder = document.createElement("button");
-    placeholder.type = "button";
-    placeholder.className = `${PLACEHOLDER_CLASS} ${PLACEHOLDER_CLASS}--inline`;
-    placeholder.setAttribute(RULE_ATTR, ruleId);
-    placeholder.textContent = match.label;
-    const restored = document.createTextNode(
-      text.slice(match.start, match.end),
+    fragment.append(
+      createInlinePlaceholder(
+        ruleId,
+        match.label,
+        text.slice(match.start, match.end),
+      ),
     );
-    attachReveal(placeholder, restored);
-    fragment.append(placeholder);
-    log("inline placeholder created", {
-      ruleId,
-      label: match.label,
-      hiddenLength: match.end - match.start,
-    });
     cursor = match.end;
   }
 
@@ -204,6 +194,111 @@ export function replaceMatchesInTextNode(
   }
 
   textNode.parentNode?.replaceChild(fragment, textNode);
+}
+
+function createInlinePlaceholder(
+  ruleId: RuleId,
+  label: string,
+  originalText: string,
+): HTMLButtonElement {
+  // Inline placeholders are short and have no scrollable area, so the
+  // <button> serves as both the visual chip and the a11y-tree exposure.
+  const placeholder = document.createElement("button");
+  placeholder.type = "button";
+  placeholder.className = `${PLACEHOLDER_CLASS} ${PLACEHOLDER_CLASS}--inline`;
+  placeholder.setAttribute(RULE_ATTR, ruleId);
+  placeholder.textContent = label;
+  attachReveal(placeholder, document.createTextNode(originalText));
+  log("inline placeholder created", {
+    ruleId,
+    label,
+    hiddenLength: originalText.length,
+  });
+  return placeholder;
+}
+
+// Cross-node analog of `replaceMatchesInTextNode`. `nodes` is an ordered
+// run of sibling text nodes in one inline-formatting context (per
+// `collectTextNodesWithInlineGroups`). `match.start` / `match.end` are
+// offsets into the concatenation of those nodes' `nodeValue`s; the helper
+// slices the first and last nodes, blanks any nodes in between, and
+// inserts a single inline placeholder where the matched range begins.
+//
+// Wrapping inline elements (the `<span>`s a framework rendered around
+// per-digit groups) are NOT detached — the carrier text node's value is
+// reduced to its non-matched prefix/suffix, and interior nodes get their
+// value blanked to `""`. This follows the "scrub the carrier, don't
+// detach framework-owned nodes" pattern that already covers the rest of
+// the codebase.
+//
+// Reveal restores the matched substring as a single new text node at the
+// placeholder's position — the original per-node split is not
+// reconstructed. The user sees the same characters; the surrounding
+// wrapper elements remain in place around them.
+export function replaceMatchAcrossTextNodes(
+  nodes: readonly Text[],
+  startIndex: number,
+  startOffset: number,
+  endIndex: number,
+  endOffset: number,
+  ruleId: RuleId,
+  label: string,
+): void {
+  const firstNode = nodes[startIndex];
+  const lastNode = nodes[endIndex];
+  if (!firstNode || !lastNode) {
+    return;
+  }
+
+  if (startIndex === endIndex) {
+    // Caller bug — single-node case belongs in replaceMatchesInTextNode.
+    // Tolerate it for robustness rather than throw mid-walk.
+    replaceMatchesInTextNode(
+      firstNode,
+      [{ start: startOffset, end: endOffset, label }],
+      ruleId,
+    );
+    return;
+  }
+
+  const firstText = firstNode.nodeValue ?? "";
+  const lastText = lastNode.nodeValue ?? "";
+
+  // Capture the original matched span before mutating anything — used as
+  // the reveal target. Interior nodes' full values are included so reveal
+  // shows the exact characters that were hidden.
+  const interiorText = nodes
+    .slice(startIndex + 1, endIndex)
+    .map((node) => node.nodeValue ?? "")
+    .join("");
+  const originalText =
+    firstText.slice(startOffset) + interiorText + lastText.slice(0, endOffset);
+
+  const placeholder = createInlinePlaceholder(ruleId, label, originalText);
+
+  // First node: keep prefix (if any), insert placeholder right after it.
+  // When the match starts at offset 0, swap the node out entirely so the
+  // placeholder takes its sibling slot — keeps the parent's child list
+  // tidy on the common "whole span is the digit group" case.
+  const firstParent = firstNode.parentNode;
+  if (!firstParent) {
+    return;
+  }
+  if (startOffset === 0) {
+    firstNode.replaceWith(placeholder);
+  } else {
+    firstNode.nodeValue = firstText.slice(0, startOffset);
+    firstParent.insertBefore(placeholder, firstNode.nextSibling);
+  }
+
+  // Interior nodes: blank value, keep node in place so any framework
+  // tracking the element / its parent span doesn't see a detach.
+  for (const interior of nodes.slice(startIndex + 1, endIndex)) {
+    interior.nodeValue = "";
+  }
+
+  // Last node: keep suffix (if any), drop the matched prefix.
+  lastNode.nodeValue = lastText.slice(endOffset);
 }
 
 export function revealAll(ruleId: RuleId): void {

--- a/extension/src/lib/placeholder.ts
+++ b/extension/src/lib/placeholder.ts
@@ -217,24 +217,182 @@ function createInlinePlaceholder(
   return placeholder;
 }
 
-// Cross-node analog of `replaceMatchesInTextNode`. `nodes` is an ordered
-// run of sibling text nodes in one inline-formatting context (per
-// `collectTextNodesWithInlineGroups`). `match.start` / `match.end` are
-// offsets into the concatenation of those nodes' `nodeValue`s; the helper
-// slices the first and last nodes, blanks any nodes in between, and
-// inserts a single inline placeholder where the matched range begins.
+// One match in a bucket-level operation. Offsets are in each text node's
+// local nodeValue space; `startIndex` / `endIndex` index into the `nodes`
+// array passed to `replaceMatchesAcrossTextNodes`. Single-node matches
+// have `startIndex === endIndex`.
+export interface MultiNodeMatch {
+  startIndex: number;
+  startOffset: number;
+  endIndex: number;
+  endOffset: number;
+  label: string;
+}
+
+// Atomic-by-node materializer for a bucket of sibling text nodes in one
+// inline-formatting context. `nodes` is the ordered text-node run; each
+// match's offsets are interpreted against the *original* nodeValues, so
+// the caller passes pre-mutation positions for all matches at once. The
+// helper plans every affected node's new content before touching the DOM,
+// then performs at most one replaceChild per affected node.
+//
+// Why batch: applying matches one at a time invalidates the offset map.
+// Calling `parentNode.replaceChild(fragment, textNode)` for the first
+// match detaches that text node; a second match into the same node finds
+// `parentNode === null` and silently drops. Cross-node matches that
+// truncate a boundary node shift every later offset in that node by the
+// truncation amount, so a single-node match that lands in the truncated
+// region masks the wrong characters. Batching sidesteps both: each
+// affected text node is mutated exactly once, against its original
+// content.
 //
 // Wrapping inline elements (the `<span>`s a framework rendered around
-// per-digit groups) are NOT detached — the carrier text node's value is
-// reduced to its non-matched prefix/suffix, and interior nodes get their
-// value blanked to `""`. This follows the "scrub the carrier, don't
-// detach framework-owned nodes" pattern that already covers the rest of
-// the codebase.
+// per-digit groups) are NOT detached. Interior text nodes consumed
+// entirely have their `nodeValue` blanked instead of being removed, so
+// any framework tracking the parent span's child list still sees a
+// (now-empty) text node child. This matches the "scrub the carrier,
+// don't detach framework-owned nodes" pattern used by the rest of the
+// codebase.
 //
 // Reveal restores the matched substring as a single new text node at the
 // placeholder's position — the original per-node split is not
 // reconstructed. The user sees the same characters; the surrounding
 // wrapper elements remain in place around them.
+export function replaceMatchesAcrossTextNodes(
+  nodes: readonly Text[],
+  matches: readonly MultiNodeMatch[],
+  ruleId: RuleId,
+): void {
+  if (matches.length === 0) {
+    return;
+  }
+
+  // Snapshot original values up front — every offset in `matches` is
+  // interpreted against these, regardless of order. nodeValue can change
+  // out from under us as we mutate, but the snapshot stays canonical.
+  const originalValues = nodes.map((node) => node.nodeValue ?? "");
+
+  // For each match, build its reveal-text from the matched span (which
+  // can cross node boundaries) and create one placeholder element. The
+  // placeholder is anchored to the first node the match touches.
+  interface NodeSegment {
+    localStart: number;
+    localEnd: number;
+    // Present only on the node that anchors this match's placeholder.
+    placeholder?: HTMLButtonElement;
+  }
+  const perNode = new Map<number, NodeSegment[]>();
+
+  function pushSegment(index: number, segment: NodeSegment): void {
+    let list = perNode.get(index);
+    if (!list) {
+      list = [];
+      perNode.set(index, list);
+    }
+    list.push(segment);
+  }
+
+  for (const match of matches) {
+    if (
+      match.startIndex < 0 ||
+      match.startIndex >= nodes.length ||
+      match.endIndex < 0 ||
+      match.endIndex >= nodes.length ||
+      match.startIndex > match.endIndex
+    ) {
+      continue;
+    }
+    const matchedText = collectMatchedText(originalValues, match);
+    const placeholder = createInlinePlaceholder(
+      ruleId,
+      match.label,
+      matchedText,
+    );
+    if (match.startIndex === match.endIndex) {
+      pushSegment(match.startIndex, {
+        localStart: match.startOffset,
+        localEnd: match.endOffset,
+        placeholder,
+      });
+      continue;
+    }
+    pushSegment(match.startIndex, {
+      localStart: match.startOffset,
+      localEnd: originalValues[match.startIndex]?.length ?? 0,
+      placeholder,
+    });
+    for (let i = match.startIndex + 1; i < match.endIndex; i++) {
+      pushSegment(i, {
+        localStart: 0,
+        localEnd: originalValues[i]?.length ?? 0,
+      });
+    }
+    pushSegment(match.endIndex, {
+      localStart: 0,
+      localEnd: match.endOffset,
+    });
+  }
+
+  // Materialize each affected node from its original value. Segments
+  // come in concat order already (matches are sorted ascending in the
+  // caller); per-node segments inherit that ordering.
+  for (const [index, segments] of perNode) {
+    const node = nodes[index];
+    const originalValue = originalValues[index];
+    if (!node || originalValue === undefined) {
+      continue;
+    }
+    const fragment = document.createDocumentFragment();
+    let cursor = 0;
+    for (const segment of segments) {
+      if (segment.localStart > cursor) {
+        fragment.append(
+          document.createTextNode(
+            originalValue.slice(cursor, segment.localStart),
+          ),
+        );
+      }
+      if (segment.placeholder) {
+        fragment.append(segment.placeholder);
+      }
+      cursor = segment.localEnd;
+    }
+    if (cursor < originalValue.length) {
+      fragment.append(document.createTextNode(originalValue.slice(cursor)));
+    }
+    if (fragment.childNodes.length === 0) {
+      // Interior text node fully consumed by a cross-node match with no
+      // placeholder anchor here — blank rather than detach so the parent
+      // element still sees a child text node in its layout-time position.
+      node.nodeValue = "";
+    } else {
+      node.parentNode?.replaceChild(fragment, node);
+    }
+  }
+}
+
+function collectMatchedText(
+  originalValues: readonly string[],
+  match: MultiNodeMatch,
+): string {
+  const firstValue = originalValues[match.startIndex] ?? "";
+  if (match.startIndex === match.endIndex) {
+    return firstValue.slice(match.startOffset, match.endOffset);
+  }
+  const interior = originalValues
+    .slice(match.startIndex + 1, match.endIndex)
+    .join("");
+  const lastValue = originalValues[match.endIndex] ?? "";
+  return (
+    firstValue.slice(match.startOffset) +
+    interior +
+    lastValue.slice(0, match.endOffset)
+  );
+}
+
+// Single-match convenience wrapper. Most callers (and the placeholder.ts
+// tests) operate on one match at a time; the bucket factory uses the
+// plural form directly so its planning step can see every match at once.
 export function replaceMatchAcrossTextNodes(
   nodes: readonly Text[],
   startIndex: number,
@@ -244,61 +402,11 @@ export function replaceMatchAcrossTextNodes(
   ruleId: RuleId,
   label: string,
 ): void {
-  const firstNode = nodes[startIndex];
-  const lastNode = nodes[endIndex];
-  if (!firstNode || !lastNode) {
-    return;
-  }
-
-  if (startIndex === endIndex) {
-    // Caller bug — single-node case belongs in replaceMatchesInTextNode.
-    // Tolerate it for robustness rather than throw mid-walk.
-    replaceMatchesInTextNode(
-      firstNode,
-      [{ start: startOffset, end: endOffset, label }],
-      ruleId,
-    );
-    return;
-  }
-
-  const firstText = firstNode.nodeValue ?? "";
-  const lastText = lastNode.nodeValue ?? "";
-
-  // Capture the original matched span before mutating anything — used as
-  // the reveal target. Interior nodes' full values are included so reveal
-  // shows the exact characters that were hidden.
-  const interiorText = nodes
-    .slice(startIndex + 1, endIndex)
-    .map((node) => node.nodeValue ?? "")
-    .join("");
-  const originalText =
-    firstText.slice(startOffset) + interiorText + lastText.slice(0, endOffset);
-
-  const placeholder = createInlinePlaceholder(ruleId, label, originalText);
-
-  // First node: keep prefix (if any), insert placeholder right after it.
-  // When the match starts at offset 0, swap the node out entirely so the
-  // placeholder takes its sibling slot — keeps the parent's child list
-  // tidy on the common "whole span is the digit group" case.
-  const firstParent = firstNode.parentNode;
-  if (!firstParent) {
-    return;
-  }
-  if (startOffset === 0) {
-    firstNode.replaceWith(placeholder);
-  } else {
-    firstNode.nodeValue = firstText.slice(0, startOffset);
-    firstParent.insertBefore(placeholder, firstNode.nextSibling);
-  }
-
-  // Interior nodes: blank value, keep node in place so any framework
-  // tracking the element / its parent span doesn't see a detach.
-  for (const interior of nodes.slice(startIndex + 1, endIndex)) {
-    interior.nodeValue = "";
-  }
-
-  // Last node: keep suffix (if any), drop the matched prefix.
-  lastNode.nodeValue = lastText.slice(endOffset);
+  replaceMatchesAcrossTextNodes(
+    nodes,
+    [{ startIndex, startOffset, endIndex, endOffset, label }],
+    ruleId,
+  );
 }
 
 export function revealAll(ruleId: RuleId): void {

--- a/extension/src/lib/yielding-text-walk.ts
+++ b/extension/src/lib/yielding-text-walk.ts
@@ -26,7 +26,11 @@
 // catch payloads rendered inside web-component shadow trees. Closed
 // shadow roots are opaque by design and not visited.
 
-import { collectTextNodesShadowPiercing } from "./dom-utils";
+import type { TextNodeWithInlineGroup } from "./dom-utils";
+import {
+  collectTextNodesShadowPiercing,
+  collectTextNodesWithInlineGroups,
+} from "./dom-utils";
 
 export interface WalkTextNodesChunkedOptions {
   // Aborts the walk at the next chunk boundary. Already-processed
@@ -127,6 +131,92 @@ export function walkTextNodesChunked(
       index = end;
     }
     return index < texts.length ? "yield" : "done";
+  }
+
+  function continueAsync(): void {
+    void yieldStrategy().then(() => {
+      if (signal?.aborted) {
+        return;
+      }
+      if (runChunkSync() === "done") {
+        runFinalize();
+      } else {
+        continueAsync();
+      }
+    });
+  }
+
+  if (runChunkSync() === "done") {
+    runFinalize();
+  } else {
+    continueAsync();
+  }
+}
+
+export interface WalkTextNodeGroupsChunkedOptions {
+  signal?: AbortSignal;
+  minLength?: number;
+  shouldSkipParent?: (parent: Element) => boolean;
+  chunkSize?: number;
+  // Same chunking contract as `walkTextNodesChunked`, but each entry
+  // carries its inline-formatting-context id so the consumer can detect
+  // matches that span sibling text nodes within one inline context.
+  // Chunk boundaries can fall mid-group — group id is stable across
+  // chunks, so a consumer that batches by group can detect that on its
+  // own.
+  process: (chunk: TextNodeWithInlineGroup[]) => void;
+  onComplete?: () => void;
+  yieldStrategy?: () => Promise<void>;
+}
+
+// Group-aware variant of `walkTextNodesChunked`. Same chunked-yield
+// semantics; the only difference is the item type. Existing callers
+// (prompt-injection-redact) keep using the non-group walker; the
+// `inline-text-redact` factory uses this one to enable cross-node
+// detection.
+export function walkTextNodeGroupsChunked(
+  root: ParentNode,
+  options: WalkTextNodeGroupsChunkedOptions,
+): void {
+  const {
+    signal,
+    minLength = 0,
+    shouldSkipParent,
+    chunkSize = 100,
+    process,
+    onComplete,
+    yieldStrategy = defaultYieldStrategy,
+  } = options;
+
+  if (signal?.aborted) {
+    return;
+  }
+
+  const entries = collectTextNodesWithInlineGroups(
+    root,
+    shouldSkipParent ? { minLength, shouldSkipParent } : { minLength },
+  );
+
+  if (signal?.aborted) {
+    return;
+  }
+
+  let index = 0;
+
+  function runFinalize(): void {
+    if (signal?.aborted) {
+      return;
+    }
+    onComplete?.();
+  }
+
+  function runChunkSync(): "yield" | "done" {
+    const end = Math.min(index + chunkSize, entries.length);
+    if (end > index) {
+      process(entries.slice(index, end));
+      index = end;
+    }
+    return index < entries.length ? "yield" : "done";
   }
 
   function continueAsync(): void {

--- a/extension/src/rules/__tests__/encoded-payload-redact.property.test.ts
+++ b/extension/src/rules/__tests__/encoded-payload-redact.property.test.ts
@@ -165,3 +165,91 @@ describe("encoded-payload-redact (property)", () => {
     );
   });
 });
+
+// Render `encoded` inside `<p>`, split across N sibling `<span>` text
+// nodes — the markdown-highlight / syntax-color shape that defeated the
+// per-node length floors.
+function applyToSpanSplitText(
+  encoded: string,
+  splits: readonly number[],
+): HTMLElement {
+  document.body.innerHTML = "";
+  const p = document.createElement("p");
+  let cursor = 0;
+  for (const split of splits) {
+    const span = document.createElement("span");
+    span.textContent = encoded.slice(cursor, split);
+    p.append(span);
+    cursor = split;
+  }
+  const tail = document.createElement("span");
+  tail.textContent = encoded.slice(cursor);
+  p.append(tail);
+  document.body.append(p);
+  encodedPayloadRedactRule.apply(document.body);
+  return document.body;
+}
+
+function sortedSplitsArb(length: number) {
+  return fc
+    .uniqueArray(fc.integer({ min: 1, max: length - 1 }), {
+      minLength: 1,
+      maxLength: 4,
+    })
+    .map((indices) => indices.toSorted((a, b) => a - b));
+}
+
+describe("encoded-payload-redact cross-node detection (property)", () => {
+  it("redacts base64 payloads regardless of how they're split across sibling spans", () => {
+    fc.assert(
+      fc.property(
+        printableTextArb.chain((text) => {
+          const encoded = base64Encode(text);
+          return fc.tuple(
+            fc.constant(encoded),
+            sortedSplitsArb(encoded.length),
+          );
+        }),
+        ([encoded, splits]) => {
+          const body = applyToSpanSplitText(encoded, splits);
+          expect(body.querySelector(`.${PLACEHOLDER_CLASS}`)?.textContent).toBe(
+            "[encoded payload hidden]",
+          );
+          expect(body.textContent).not.toContain(encoded);
+        },
+      ),
+    );
+  });
+
+  // Payloads whose ENCODED length is just over the base64 floor; splitting
+  // such a payload in half puts each half below the floor, so the only way
+  // the rule could redact would be by concatenating across the block
+  // boundary (which it must not do).
+  const justOverFloorTextArb = fc
+    .stringMatching(/^[ -~]{91,130}$/)
+    .filter((s) => s.length >= MIN_DECODED_LENGTH);
+
+  it("never redacts a payload whose halves fall below the floor when split across two paragraphs", () => {
+    fc.assert(
+      fc.property(justOverFloorTextArb, (text) => {
+        const encoded = base64Encode(text);
+        // Sanity: the full thing IS detectable when not split.
+        expect(encoded.length).toBeGreaterThanOrEqual(MIN_BASE64_LENGTH);
+        const mid = Math.floor(encoded.length / 2);
+        // Each half must sit below the floor, otherwise the rule could
+        // legitimately fire on one half alone — not a cross-block leak.
+        expect(mid).toBeLessThan(MIN_BASE64_LENGTH);
+
+        document.body.innerHTML = "";
+        const a = document.createElement("p");
+        const b = document.createElement("p");
+        a.textContent = encoded.slice(0, mid);
+        b.textContent = encoded.slice(mid);
+        document.body.append(a, b);
+        encodedPayloadRedactRule.apply(document.body);
+
+        expect(document.body.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+      }),
+    );
+  });
+});

--- a/extension/src/rules/__tests__/encoded-payload-redact.test.ts
+++ b/extension/src/rules/__tests__/encoded-payload-redact.test.ts
@@ -214,6 +214,70 @@ describe("encoded-payload-redact false-positive guards", () => {
   });
 });
 
+describe("encoded-payload-redact cross-node detection", () => {
+  // Splitting an encoded payload across sibling text nodes (e.g. wrapped
+  // in highlight `<span>`s after a markdown render) used to defeat the
+  // per-node length floors — each fragment fell below MIN_BASE64_LENGTH
+  // even when the full concatenation cleared it. Audit gap #203/#7.
+  it("redacts a long base64 run split across two sibling spans", () => {
+    const payload = base64Encode(LONG_PROSE);
+    const half = Math.floor(payload.length / 2);
+    const first = payload.slice(0, half);
+    const second = payload.slice(half);
+    document.body.innerHTML = `<p><span>${first}</span><span>${second}</span></p>`;
+    encodedPayloadRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)?.textContent).toBe(
+      "[encoded payload hidden]",
+    );
+    expect(document.body.textContent).not.toContain(payload);
+  });
+
+  it("redacts a long hex run split across sibling spans", () => {
+    const payload = hexEncode(LONG_HEX_PROSE);
+    const a = payload.slice(0, 80);
+    const b = payload.slice(80);
+    document.body.innerHTML = `<p><span>${a}</span><span>${b}</span></p>`;
+    encodedPayloadRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)?.textContent).toBe(
+      "[encoded payload hidden]",
+    );
+  });
+
+  it("redacts a long percent-encoded run split across sibling spans", () => {
+    const payload = percentEncode(LONG_PERCENT_PROSE);
+    const mid = Math.floor(payload.length / 2);
+    // Slice on a triplet boundary so each half is still well-formed.
+    const a = payload.slice(0, mid - (mid % 3));
+    const b = payload.slice(mid - (mid % 3));
+    document.body.innerHTML = `<p><span>${a}</span><span>${b}</span></p>`;
+    encodedPayloadRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)?.textContent).toBe(
+      "[encoded payload hidden]",
+    );
+  });
+
+  it("does not redact a payload split across a <br>", () => {
+    const payload = base64Encode(LONG_PROSE);
+    const half = Math.floor(payload.length / 2);
+    document.body.innerHTML = `<p>${payload.slice(0, half)}<br>${payload.slice(half)}</p>`;
+    encodedPayloadRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+
+  it("does not redact a payload split across two block elements", () => {
+    const payload = base64Encode(LONG_PROSE);
+    const half = Math.floor(payload.length / 2);
+    document.body.innerHTML = `<div>${payload.slice(0, half)}</div><div>${payload.slice(half)}</div>`;
+    encodedPayloadRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+});
+
 describe("encoded-payload-redact teardown", () => {
   it("stops re-scanning after teardown", async () => {
     encodedPayloadRedactRule.apply(document.body);

--- a/extension/src/rules/__tests__/pii-redact.property.test.ts
+++ b/extension/src/rules/__tests__/pii-redact.property.test.ts
@@ -87,3 +87,87 @@ describe("pii-redact Luhn detection (property)", () => {
     );
   });
 });
+
+// Render `text` inside `<p>`, splitting it into `splits.length + 1` sibling
+// `<span>` text fragments at the indices in `splits` (already sorted +
+// in-range). Whitespace inside the source string stays where it was — the
+// sibling-span shape is a pure DOM rearrangement.
+function applyPiiToSpanSplitText(
+  text: string,
+  splits: readonly number[],
+): HTMLElement {
+  document.body.innerHTML = "";
+  const p = document.createElement("p");
+  let cursor = 0;
+  for (const split of splits) {
+    const span = document.createElement("span");
+    span.textContent = text.slice(cursor, split);
+    p.append(span);
+    cursor = split;
+  }
+  const tail = document.createElement("span");
+  tail.textContent = text.slice(cursor);
+  p.append(tail);
+  document.body.append(p);
+  piiRedactRule.apply(document.body);
+  return document.body;
+}
+
+// Generate 1-4 sorted split indices in `[1, len)` so the resulting wrapper
+// `<span>`s each carry at least one character.
+function sortedSplitsArb(length: number) {
+  return fc
+    .uniqueArray(fc.integer({ min: 1, max: length - 1 }), {
+      minLength: 1,
+      maxLength: 4,
+    })
+    .map((indices) => indices.toSorted((a, b) => a - b));
+}
+
+describe("pii-redact cross-node detection (property)", () => {
+  // Splittability invariant: rendering a Luhn-valid card across N sibling
+  // span text nodes inside a single `<p>` must still mask it, for any
+  // split point inside the digit run.
+  it("masks card digits split across any number of sibling spans", () => {
+    fc.assert(
+      fc.property(
+        cardDigitsArb.chain((card) => {
+          const wrapped = `card ${card} end`;
+          return fc.tuple(
+            fc.constant(wrapped),
+            fc.constant(card),
+            sortedSplitsArb(wrapped.length),
+          );
+        }),
+        ([wrapped, card, splits]) => {
+          const body = applyPiiToSpanSplitText(wrapped, splits);
+          const placeholder = body.querySelector(`.${PLACEHOLDER_CLASS}`);
+          expect(placeholder?.textContent).toBe("[card hidden]");
+          expect(body.textContent).not.toContain(card);
+        },
+      ),
+    );
+  });
+
+  // No-cross-block invariant: when a Luhn-valid card is rendered across
+  // two paragraphs, the rule must NOT mask it (the digits visually appear
+  // on separate lines, and concatenating across the block would be a
+  // false positive against any page that happens to put consecutive
+  // numeric labels in adjacent blocks).
+  it("never masks card digits split across two block elements", () => {
+    fc.assert(
+      fc.property(cardDigitsArb, (card) => {
+        document.body.innerHTML = "";
+        const a = document.createElement("p");
+        const b = document.createElement("p");
+        const mid = Math.floor(card.length / 2);
+        a.textContent = card.slice(0, mid);
+        b.textContent = card.slice(mid);
+        document.body.append(a, b);
+        piiRedactRule.apply(document.body);
+
+        expect(document.body.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+      }),
+    );
+  });
+});

--- a/extension/src/rules/__tests__/pii-redact.test.ts
+++ b/extension/src/rules/__tests__/pii-redact.test.ts
@@ -188,6 +188,37 @@ describe("pii-redact cross-node detection", () => {
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 
+  // Regression: when two single-node matches both live in the same text
+  // node of a multi-node bucket, applying matches sequentially used to
+  // detach the text node on the first replace, so the second match
+  // silently dropped. Reported by unblocked review bot on PR #210.
+  it("masks two matches that share a text node in a multi-node bucket", () => {
+    document.body.innerHTML =
+      "<p><span>SSN: 123-45-6789 Card: 4111 1111 1111 1111</span><span> end</span></p>";
+    piiRedactRule.apply(document.body);
+
+    expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(2);
+    expect(document.body.textContent).not.toContain("123-45-6789");
+    expect(document.body.textContent).not.toContain("4111 1111 1111 1111");
+  });
+
+  // Same root cause as above, different shape: a cross-node phone match
+  // shares its lastNode with a single-node card match. Sequential
+  // application either dropped one match or shifted its offsets so the
+  // wrong characters were redacted.
+  it("masks a cross-node phone and a single-node card sharing a text node", () => {
+    document.body.innerHTML =
+      "<p>Contact <span>(555) 123-</span><span>4567 then card 4111 1111 1111 1111 end</span></p>";
+    piiRedactRule.apply(document.body);
+
+    expect(document.querySelectorAll(`.${PLACEHOLDER_CLASS}`)).toHaveLength(2);
+    expect(document.body.textContent).not.toContain("(555) 123-4567");
+    expect(document.body.textContent).not.toContain("4111 1111 1111 1111");
+    // The "4567" digits used to leak when the cross-node's lastNode
+    // truncation didn't apply because card had already detached N2.
+    expect(document.body.textContent).not.toMatch(/4567/);
+  });
+
   it("reveals the original split text on click of a cross-node placeholder", () => {
     document.body.innerHTML =
       "<p>Card: <span>4111 </span><span>1111 </span><span>1111 </span><span>1111</span></p>";

--- a/extension/src/rules/__tests__/pii-redact.test.ts
+++ b/extension/src/rules/__tests__/pii-redact.test.ts
@@ -103,6 +103,108 @@ describe("pii-redact", () => {
   });
 });
 
+describe("pii-redact cross-node detection", () => {
+  // Each digit-group rendered as its own `<span>`, the canonical React /
+  // Vue / Svelte shape that defeated per-text-node scanning (the bypass
+  // tracked in #203 as Critical-3). The card regex wants whitespace OR
+  // hyphens between four-digit groups; sibling text nodes have no
+  // implicit separator, so the spans need to carry the whitespace
+  // themselves to render a visually-correct card.
+  it("masks a card number split across sibling spans", () => {
+    document.body.innerHTML =
+      "<p>Card: <span>4111 </span><span>1111 </span><span>1111 </span><span>1111</span></p>";
+    piiRedactRule.apply(document.body);
+
+    const placeholder = document.querySelector(`.${PLACEHOLDER_CLASS}`);
+    expect(placeholder?.textContent).toBe("[card hidden]");
+    expect(document.body.textContent).not.toContain("4111 1111 1111 1111");
+    expect(document.body.textContent).toContain("Card:");
+  });
+
+  it("masks a card split across two spans with no inner whitespace", () => {
+    // Sibling text nodes concatenate with no separator. 16 contiguous
+    // digits is still a Luhn-valid card under the regex.
+    document.body.innerHTML =
+      "<p>Card: <span>41111111</span><span>11111111</span></p>";
+    piiRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)?.textContent).toBe(
+      "[card hidden]",
+    );
+    expect(document.body.textContent).not.toContain("4111111111111111");
+  });
+
+  it("masks an SSN split across sibling spans", () => {
+    document.body.innerHTML =
+      "<p>SSN: <span>123</span><span>-45</span><span>-6789</span></p>";
+    piiRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)?.textContent).toBe(
+      "[ssn hidden]",
+    );
+    expect(document.body.textContent).not.toContain("123-45-6789");
+  });
+
+  it("masks a phone number split across inline wrappers", () => {
+    // Wrappers can be any inline tag — strong, em, code, etc. The
+    // grouping pass cares about the nearest block ancestor (a `<p>`),
+    // not the specific inline wrappers between text and block.
+    document.body.innerHTML =
+      "<p>Call <strong>(555) </strong><em>123-</em><code>4567</code></p>";
+    piiRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)?.textContent).toBe(
+      "[phone hidden]",
+    );
+  });
+
+  it("does not mask digits split across a <br>", () => {
+    // <br> is a line break inside an inline-formatting context but
+    // introduces a visual newline; the rule's regex would never match
+    // across it on a single text node. Treat as a group boundary.
+    document.body.innerHTML =
+      "<p><span>4111 1111</span><br><span>1111 1111</span></p>";
+    piiRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+    expect(document.body.textContent).toContain("4111 11111111 1111");
+  });
+
+  it("does not mask digits split across a block element", () => {
+    // Two `<div>`s render on separate lines. The rule must not
+    // concatenate across the block boundary.
+    document.body.innerHTML =
+      "<div><span>4111 1111</span></div><div><span>1111 1111</span></div>";
+    piiRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+
+  it("does not mask digits split across two paragraphs", () => {
+    document.body.innerHTML =
+      "<p><span>4111 1111</span></p><p><span>1111 1111</span></p>";
+    piiRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+
+  it("reveals the original split text on click of a cross-node placeholder", () => {
+    document.body.innerHTML =
+      "<p>Card: <span>4111 </span><span>1111 </span><span>1111 </span><span>1111</span></p>";
+    piiRedactRule.apply(document.body);
+
+    const placeholder = document.querySelector<HTMLElement>(
+      `.${PLACEHOLDER_CLASS}`,
+    );
+    placeholder?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+    // Wrappers stay in place; matched characters collapse into one text
+    // node at the first wrapper's position. Visible text is the same.
+    expect(document.body.textContent).toContain("4111 1111 1111 1111");
+  });
+});
+
 describe("pii-redact lazy-loaded subtrees", () => {
   it("masks PII appearing after a client-side route change", async () => {
     piiRedactRule.apply(document.body);

--- a/extension/src/rules/__tests__/secrets-redact.test.ts
+++ b/extension/src/rules/__tests__/secrets-redact.test.ts
@@ -194,6 +194,40 @@ describe("secrets-redact", () => {
   });
 });
 
+describe("secrets-redact cross-node detection", () => {
+  // Falls out of the shared inline-text-redact factory work — verifies
+  // splitting a token across sibling text nodes no longer hides it from
+  // the regex.
+  it("masks a JWT split across sibling spans", () => {
+    const half = Math.floor(JWT.length / 2);
+    document.body.innerHTML = `<p>token: <span>${JWT.slice(0, half)}</span><span>${JWT.slice(half)}</span></p>`;
+    secretsRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)?.textContent).toBe(
+      "[jwt hidden]",
+    );
+    expect(document.body.textContent).not.toContain(JWT);
+  });
+
+  it("masks an AWS key split across sibling inline wrappers", () => {
+    const half = Math.floor(AWS_KEY.length / 2);
+    document.body.innerHTML = `<p>k=<code>${AWS_KEY.slice(0, half)}</code><code>${AWS_KEY.slice(half)}</code></p>`;
+    secretsRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)?.textContent).toBe(
+      "[aws key hidden]",
+    );
+  });
+
+  it("does not mask a token split across two paragraphs", () => {
+    const half = Math.floor(AWS_KEY.length / 2);
+    document.body.innerHTML = `<p>${AWS_KEY.slice(0, half)}</p><p>${AWS_KEY.slice(half)}</p>`;
+    secretsRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+  });
+});
+
 describe("secrets-redact lazy-loaded subtrees", () => {
   it("masks secrets appearing after a client-side route change", async () => {
     secretsRedactRule.apply(document.body);


### PR DESCRIPTION
## Summary

- Closes the last Critical bypass tracked in #203: PII / encoded payloads / secrets rendered with one wrapper element per fragment (e.g. React `<span>`-per-digit-group cards) used to slip past the per-text-node regex.
- Same change also closes #203 / item 7 (encoded-payload split-across-whitespace) because both rules share the inline-text-redact factory.

## Approach

- `collectTextNodesWithInlineGroups` (new) tags each text node with an inline-formatting-context id. Group id bumps on entering/leaving a block-level element, on `<br>`, and on shadow-root boundaries. The existing `collectTextNodesShadowPiercing` becomes a thin wrapper that drops the group tag — no callers of the non-group walker change.
- `walkTextNodeGroupsChunked` (new sibling of `walkTextNodesChunked`) threads the group ids through the same chunked-yield driver.
- `defineInlineTextRedactRule` switches to the new walker. Each chunk is bucketed by group; single-node buckets keep the existing single-node fast path; multi-node buckets concatenate values, run `collectMatches` against the concatenation, and route each match to either `replaceMatchesInTextNode` (within-node) or `replaceMatchAcrossTextNodes` (new).
- `replaceMatchAcrossTextNodes` scrubs the carrier — first node keeps its prefix, last node keeps its suffix, interior nodes have their `nodeValue` blanked. Wrapping inline elements stay in the DOM (per the "scrub, don't detach framework-owned nodes" rule). Reveal restores the matched characters as a single text node at the placeholder's position.
- Per-node `minLength` no longer filters at the walker level (it would drop legitimate cross-node candidates whose individual nodes sit below the floor); the group's concatenated length is checked instead, preserving the cheap early-out for prose nodes.

## Demo site

- New "3a. Alternate payment" block on `Checkout.tsx` exercises five span-split shapes (card, SSN, phone, JWT, base64 payload) so the before/after diff visualizes the closed gap.

## Test plan

- [x] `bun run check` (extension)
- [x] `bun run typecheck` (extension)
- [x] `bun run test` (extension — 1716 tests, all green; 16 new cross-node tests across pii / secrets / encoded-payload / placeholder helper + 4 new property tests)
- [x] `bun run check` (demo-site)
- [x] `pre-commit run --all-files`
- [ ] Spot-check demo site in browser: card / SSN / phone / JWT / encoded payload on the new section 3a should each render as `[…hidden]` chips, and reveal-on-click should restore the original characters.

## Notes / accepted trade-offs

- Reveal collapses the matched-text split into one text node — the original per-span breakdown isn't reconstructed. Visual characters are the same; wrapper elements stay.
- Cross-chunk-boundary cross-node matches are not detected (>100 text nodes in a single inline-formatting context). Vanishingly rare with the default `chunkSize=100`.
- Late-inserted siblings that complete an existing cross-node match aren't picked up by the incremental watcher (its scan root is the new subtree, not the joined context). Same limitation as the pre-existing per-node case missing late additions to existing text nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)