### PR TITLE
Fix: defend cleared checkout checkboxes against programmatic re-checks (#203)

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -685,6 +685,11 @@ The agent is then expected to re-check anything it actually wants to opt into,
 including required agreements. `role="checkbox"` widgets and radio groups are
 out of scope.
 
+The cleared state is held against framework re-renders that would otherwise
+silently restore pre-selected values from component state. A genuine user (or
+WebDriver-driven) click on the box releases that lock and the toggle sticks
+normally; only programmatic re-checks issued by the page itself are reverted.
+
 Pre-checked opt-ins are *Preselection* in Mathur et al.
 [[9]](#ref-mathur-dark-patterns) and Brignull's deceptive.design catalog
 [[10]](#ref-brignull).

--- a/extension/build.ts
+++ b/extension/build.ts
@@ -131,6 +131,15 @@ async function build(): Promise<void> {
       // registration call. See `lib/webdriver-probe-source.ts` and
       // `lib/webdriver-probe-registration.ts`.
       join(SRC, "webdriver-probe.ts"),
+      // Standalone main-world bundle registered by the background worker
+      // whenever `checkout-checkbox-sanitize` is enabled. The patched
+      // `HTMLInputElement.prototype.checked` setter MUST live in the page
+      // world — page scripts (React/Vue reconciles) hit the page's own
+      // copy of the prototype, which is distinct from the one the
+      // isolated-world content script sees. See
+      // `lib/checkout-checkbox-defense-source.ts` and
+      // `lib/checkout-checkbox-defense-registration.ts`.
+      join(SRC, "checkout-checkbox-defense.ts"),
     ],
     outdir: DIST,
     target: "browser",

--- a/extension/knip.json
+++ b/extension/knip.json
@@ -7,6 +7,7 @@
     "src/popup.tsx",
     "src/options.tsx",
     "src/webdriver-probe.ts",
+    "src/checkout-checkbox-defense.ts",
     "eslint-rules/index.js"
   ],
   "project": ["src/**/*.{ts,tsx}", "scripts/**/*.ts", "eslint-rules/**/*.js"],

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
+import { startCheckoutCheckboxDefenseRegistration } from "./lib/checkout-checkbox-defense-registration";
+import { installCheckoutCheckboxDefense } from "./lib/checkout-checkbox-defense-source";
 import type {
   DetectionKind,
   DetectionPayload,
@@ -281,6 +283,35 @@ chrome.runtime.onMessage.addListener(
       return undefined;
     }
 
+    if (message.type === "inject-checkout-checkbox-defense") {
+      const tabId = sender.tab?.id;
+      if (typeof tabId !== "number") {
+        return undefined;
+      }
+      const frameId = sender.frameId;
+      // Same shape as inject-webdriver-probe: the registered content
+      // script covers future navigations; this fallback runs the defense
+      // on the tab the user was already viewing when they toggled the
+      // rule on. installCheckoutCheckboxDefense's
+      // `__abs_checkout_checkbox_defense_installed` guard makes a
+      // redundant call a no-op in the page world.
+      chrome.scripting
+        .executeScript({
+          target: {
+            tabId,
+            frameIds: typeof frameId === "number" ? [frameId] : undefined,
+          },
+          world: "MAIN",
+          func: installCheckoutCheckboxDefense,
+        })
+        .catch((error: unknown) => {
+          log("inject-checkout-checkbox-defense executeScript failed", {
+            error,
+          });
+        });
+      return undefined;
+    }
+
     if (message.type === "rule-count") {
       const tabId = sender.tab?.id;
       const frameId = sender.frameId;
@@ -384,3 +415,10 @@ startClassifyPortListener();
 // content-script-side inline fallback can't reach. See
 // `lib/webdriver-probe-registration.ts`.
 startWebdriverProbeRegistration();
+
+// Same lifecycle for `checkout-checkbox-sanitize`'s page-world
+// `HTMLInputElement.prototype.checked` defense. The patch must live in
+// the page world to intercept React/Vue reconciles that drive
+// `node.checked = true` through the page's own prototype copy. See
+// `lib/checkout-checkbox-defense-registration.ts`.
+startCheckoutCheckboxDefenseRegistration();

--- a/extension/src/checkout-checkbox-defense.ts
+++ b/extension/src/checkout-checkbox-defense.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Build entrypoint for the page-world (main-world) checkout-checkbox
+// defense. Registered dynamically by the background worker via
+// `chrome.scripting.registerContentScripts` with `world: "MAIN"` and
+// `runAt: "document_start"` whenever `checkout-checkbox-sanitize` is
+// enabled. Runs before the page's first script so the patched
+// `HTMLInputElement.prototype.checked` setter is in place before any
+// React/Vue bundle caches the descriptor.
+//
+// Kept tiny on purpose — the bundled output ships into every page-world
+// at document_start, so anything imported here lands in the page's JS
+// heap. Pull only from `lib/checkout-checkbox-defense-source.ts`, which
+// is dependency-free for the same reason.
+
+import { installCheckoutCheckboxDefense } from "./lib/checkout-checkbox-defense-source";
+
+installCheckoutCheckboxDefense.call(globalThis as unknown as Window);

--- a/extension/src/lib/__tests__/checkout-checkbox-defense-registration.test.ts
+++ b/extension/src/lib/__tests__/checkout-checkbox-defense-registration.test.ts
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Exercises the dynamic main-world content-script registration that
+// `lib/checkout-checkbox-defense-registration.ts` wires up. Mirrors
+// `webdriver-probe-registration.test.ts` — same shape, different script
+// id and filename. The module syncs chrome.scripting state against
+// (rule-enabled AND enforcement-enabled).
+
+jest.mock("nanoid", () => ({ nanoid: () => "test-ref" }));
+jest.mock("abort-utils", () => ({
+  ReusableAbortController: class {
+    abort(): void {
+      // noop
+    }
+    get signal(): AbortSignal {
+      return new AbortController().signal;
+    }
+  },
+  onAbort: (): (() => void) => () => {
+    // noop
+  },
+}));
+
+const defenseRegister = chrome.scripting
+  .registerContentScripts as unknown as jest.Mock;
+const defenseUnregister = chrome.scripting
+  .unregisterContentScripts as unknown as jest.Mock;
+const defenseGetRegistered = chrome.scripting
+  .getRegisteredContentScripts as unknown as jest.Mock;
+
+interface DefenseModule {
+  startCheckoutCheckboxDefenseRegistration: () => void;
+}
+
+interface DefenseScript {
+  id: string;
+  matches: string[];
+  js: string[];
+  runAt: string;
+  world: string;
+  allFrames: boolean;
+}
+
+function flushDefense(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+async function loadDefenseModule(
+  overrides: Record<string, boolean>,
+  enforcementEnabled = true,
+  initiallyRegistered = false,
+): Promise<{ module: DefenseModule }> {
+  let module!: DefenseModule;
+
+  await jest.isolateModulesAsync(async () => {
+    process.env.EXTENSION_DEFAULT_OVERRIDES = JSON.stringify(overrides);
+
+    const registered: DefenseScript[] = initiallyRegistered
+      ? [
+          {
+            id: "checkout-checkbox-sanitize-main-world",
+            matches: ["<all_urls>"],
+            js: ["checkout-checkbox-defense.js"],
+            runAt: "document_start",
+            world: "MAIN",
+            allFrames: true,
+          },
+        ]
+      : [];
+
+    defenseRegister.mockImplementation(
+      (scripts: DefenseScript[]): Promise<void> => {
+        registered.push(...scripts);
+        return Promise.resolve();
+      },
+    );
+    defenseUnregister.mockImplementation(
+      (filter: { ids: string[] }): Promise<void> => {
+        for (const id of filter.ids) {
+          const index = registered.findIndex((script) => script.id === id);
+          if (index !== -1) {
+            registered.splice(index, 1);
+          }
+        }
+        return Promise.resolve();
+      },
+    );
+    defenseGetRegistered.mockImplementation(
+      (filter?: { ids?: string[] }): Promise<DefenseScript[]> => {
+        if (!filter?.ids) {
+          return Promise.resolve([...registered]);
+        }
+        return Promise.resolve(
+          registered.filter((script) => filter.ids?.includes(script.id)),
+        );
+      },
+    );
+
+    const enforcement = await import("../enforcement");
+    await enforcement.enforcementStorage.set(enforcementEnabled);
+
+    module = await import("../checkout-checkbox-defense-registration");
+  });
+
+  return { module };
+}
+
+beforeEach(() => {
+  defenseRegister.mockReset();
+  defenseUnregister.mockReset();
+  defenseGetRegistered.mockReset();
+});
+
+afterEach(() => {
+  delete process.env.EXTENSION_DEFAULT_OVERRIDES;
+});
+
+describe("startCheckoutCheckboxDefenseRegistration", () => {
+  it("registers the main-world script on startup when the rule is enabled", async () => {
+    const { module } = await loadDefenseModule({
+      "checkout-checkbox-sanitize": true,
+    });
+
+    module.startCheckoutCheckboxDefenseRegistration();
+    await flushDefense();
+
+    expect(defenseRegister).toHaveBeenCalledTimes(1);
+    const [scripts] = defenseRegister.mock.calls[0] as [DefenseScript[]];
+    expect(scripts[0]).toMatchObject({
+      id: "checkout-checkbox-sanitize-main-world",
+      matches: ["<all_urls>"],
+      js: ["checkout-checkbox-defense.js"],
+      runAt: "document_start",
+      world: "MAIN",
+      // Cart/checkout flows often render payment widgets in same-origin
+      // iframes; the wrap has to run per-frame because each frame has its
+      // own HTMLInputElement.prototype.
+      allFrames: true,
+    });
+  });
+
+  it("does not register when the rule is disabled", async () => {
+    const { module } = await loadDefenseModule({
+      "checkout-checkbox-sanitize": false,
+    });
+
+    module.startCheckoutCheckboxDefenseRegistration();
+    await flushDefense();
+
+    expect(defenseRegister).not.toHaveBeenCalled();
+    expect(defenseUnregister).not.toHaveBeenCalled();
+  });
+
+  it("unregisters when an already-registered script becomes ineligible", async () => {
+    const { module } = await loadDefenseModule(
+      { "checkout-checkbox-sanitize": false },
+      true,
+      /* initiallyRegistered */ true,
+    );
+
+    module.startCheckoutCheckboxDefenseRegistration();
+    await flushDefense();
+
+    expect(defenseUnregister).toHaveBeenCalledWith({
+      ids: ["checkout-checkbox-sanitize-main-world"],
+    });
+  });
+
+  it("does not re-register if the desired state already matches", async () => {
+    const { module } = await loadDefenseModule(
+      { "checkout-checkbox-sanitize": true },
+      true,
+      /* initiallyRegistered */ true,
+    );
+
+    module.startCheckoutCheckboxDefenseRegistration();
+    await flushDefense();
+
+    expect(defenseRegister).not.toHaveBeenCalled();
+    expect(defenseUnregister).not.toHaveBeenCalled();
+  });
+
+  it("treats enforcement-off as if the rule were disabled", async () => {
+    const { module } = await loadDefenseModule(
+      { "checkout-checkbox-sanitize": true },
+      /* enforcementEnabled */ false,
+    );
+
+    module.startCheckoutCheckboxDefenseRegistration();
+    await flushDefense();
+
+    expect(defenseRegister).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/lib/__tests__/checkout-checkbox-defense-source.test.ts
+++ b/extension/src/lib/__tests__/checkout-checkbox-defense-source.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://shop.example.com/checkout"}
+ */
+// Tests for the page-world checkout-checkbox defense — the prototype
+// wrap on HTMLInputElement.prototype.checked plus the capture-phase
+// `change` listener that releases the lock on trusted user gestures.
+// Mirrors how webdriver-probe-source is shipped: the function runs
+// inside the page world in production; jsdom's single-world model means
+// installing it in the test world exercises the same code path.
+
+import { installCheckoutCheckboxDefense } from "../checkout-checkbox-defense-source";
+import { isCheckoutUrl } from "../checkout-url";
+import { CHECKOUT_CHECKBOX_CLEARED_ATTR as CLEARED_ATTR } from "../dom-markers";
+
+beforeAll(() => {
+  installCheckoutCheckboxDefense.call(globalThis as unknown as Window);
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("installCheckoutCheckboxDefense — prototype wrap", () => {
+  it("reverts a programmatic .checked = true on a marked box", () => {
+    document.body.innerHTML = `<input id="upsell" type="checkbox" />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+    checkbox.setAttribute(CLEARED_ATTR, "");
+
+    // Simulate the page's hydration / controlled-input reconcile loop
+    // writing the pre-selected state back onto the input.
+    checkbox.checked = true;
+
+    expect(checkbox.checked).toBe(false);
+    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
+  });
+
+  it("reverts repeated re-check attempts on a marked box", () => {
+    document.body.innerHTML = `<input id="upsell" type="checkbox" />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+    checkbox.setAttribute(CLEARED_ATTR, "");
+
+    for (let index = 0; index < 5; index++) {
+      checkbox.checked = true;
+      expect(checkbox.checked).toBe(false);
+    }
+  });
+
+  it("allows .click() to legitimately re-check a marked box", () => {
+    document.body.innerHTML = `<input id="terms" type="checkbox" />`;
+    const checkbox = document.querySelector("#terms") as HTMLInputElement;
+    checkbox.setAttribute(CLEARED_ATTR, "");
+
+    // .click() routes through the native activation behavior, not the
+    // patched JS setter.
+    checkbox.click();
+
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it("allows re-check after the marker is removed", () => {
+    document.body.innerHTML = `<input id="terms" type="checkbox" />`;
+    const checkbox = document.querySelector("#terms") as HTMLInputElement;
+    checkbox.setAttribute(CLEARED_ATTR, "");
+
+    checkbox.removeAttribute(CLEARED_ATTR);
+    checkbox.checked = true;
+
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it("does not interfere with unmarked checkboxes", () => {
+    document.body.innerHTML = `<input id="fresh" type="checkbox" />`;
+    const checkbox = document.querySelector("#fresh") as HTMLInputElement;
+
+    checkbox.checked = true;
+
+    expect(checkbox.checked).toBe(true);
+    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(false);
+  });
+
+  it("allows .checked = false on a marked box (no-op pass-through)", () => {
+    document.body.innerHTML = `<input id="upsell" type="checkbox" />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+    checkbox.setAttribute(CLEARED_ATTR, "");
+
+    checkbox.checked = false;
+
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it("does not gate writes to .value on a marked non-checkbox input", () => {
+    // The marker is only ever stamped on checkboxes by the rule, but the
+    // patch's selectivity must hold even if a hostile page somehow gets
+    // the marker onto a text input.
+    document.body.innerHTML = `<input id="oddball" type="text" />`;
+    const input = document.querySelector("#oddball") as HTMLInputElement;
+    input.setAttribute(CLEARED_ATTR, "");
+
+    input.value = "hello";
+
+    expect(input.value).toBe("hello");
+  });
+});
+
+describe("installCheckoutCheckboxDefense — URL gate", () => {
+  it("does not defend marked boxes once the SPA route leaves checkout", () => {
+    document.body.innerHTML = `<input id="upsell" type="checkbox" />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+    checkbox.setAttribute(CLEARED_ATTR, "");
+
+    globalThis.history.replaceState({}, "", "/account");
+    try {
+      checkbox.checked = true;
+      expect(checkbox.checked).toBe(true);
+    } finally {
+      globalThis.history.replaceState({}, "", "/checkout");
+    }
+  });
+});
+
+describe("installCheckoutCheckboxDefense — change listener", () => {
+  // jsdom installs `Event.isTrusted` as a per-instance unforgeable
+  // property, so a forged-trusted event can't be dispatched through the
+  // document listener. The negative path (untrusted dispatch keeps the
+  // marker) is verified here; the positive trusted-gesture path is
+  // covered in the isolated-world rule's tests by calling the handler
+  // shape directly.
+
+  it("ignores untrusted change events from page-script dispatch", () => {
+    document.body.innerHTML = `<input id="upsell" type="checkbox" />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+    checkbox.setAttribute(CLEARED_ATTR, "");
+
+    checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
+    checkbox.checked = true;
+    expect(checkbox.checked).toBe(false);
+  });
+});
+
+describe("installCheckoutCheckboxDefense — idempotency", () => {
+  it("is a no-op when called a second time", () => {
+    // Already installed in beforeAll. A second invocation must not
+    // double-wrap (which would capture the prior wrap as "native" and
+    // lead to layered setter logic). The FLAG on globalThis
+    // short-circuits the body — verify behavior remains correct.
+    installCheckoutCheckboxDefense.call(globalThis as unknown as Window);
+
+    document.body.innerHTML = `<input id="upsell" type="checkbox" />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+    checkbox.setAttribute(CLEARED_ATTR, "");
+    checkbox.checked = true;
+    expect(checkbox.checked).toBe(false);
+  });
+});
+
+describe("parity with the isolated-world rule", () => {
+  it("CLEARED_ATTR matches the dom-markers registry constant", () => {
+    // The page-world source hard-codes the literal because it has no
+    // module imports at runtime; assert here that the registry constant
+    // still agrees so a future rename doesn't silently break the
+    // defense.
+    // eslint-disable-next-line no-restricted-syntax
+    expect(CLEARED_ATTR).toBe("data-abs-cleared");
+  });
+
+  it.each([
+    "https://shop.example.com/cart",
+    "https://shop.example.com/cart/",
+    "https://shop.example.com/checkout",
+    "https://shop.example.com/checkout/shipping",
+    "https://shop.example.com/basket",
+    "https://shop.example.com/bag",
+    "https://shop.example.com/payment",
+    "https://shop.example.com/order",
+    "https://shop.example.com/order/confirmation",
+  ])("the page-world URL gate accepts the same checkout shapes: %s", (url) => {
+    expect(isCheckoutUrl(url)).toBe(true);
+    document.body.innerHTML = `<input id="t" type="checkbox" />`;
+    const checkbox = document.querySelector("#t") as HTMLInputElement;
+    checkbox.setAttribute(CLEARED_ATTR, "");
+    const originalHref = globalThis.location.href;
+    globalThis.history.replaceState({}, "", new URL(url).pathname);
+    try {
+      checkbox.checked = true;
+      expect(checkbox.checked).toBe(false);
+    } finally {
+      globalThis.history.replaceState({}, "", originalHref);
+    }
+  });
+
+  it.each([
+    "https://shop.example.com/",
+    "https://shop.example.com/product/123",
+    "https://shop.example.com/products/cart-bag",
+    "https://shop.example.com/orders",
+    "https://shop.example.com/orders/123",
+    "https://shop.example.com/account",
+  ])("the page-world URL gate rejects non-checkout shapes: %s", (url) => {
+    expect(isCheckoutUrl(url)).toBe(false);
+    document.body.innerHTML = `<input id="t" type="checkbox" />`;
+    const checkbox = document.querySelector("#t") as HTMLInputElement;
+    checkbox.setAttribute(CLEARED_ATTR, "");
+    const originalHref = globalThis.location.href;
+    globalThis.history.replaceState({}, "", new URL(url).pathname);
+    try {
+      checkbox.checked = true;
+      expect(checkbox.checked).toBe(true);
+    } finally {
+      globalThis.history.replaceState({}, "", originalHref);
+    }
+  });
+});

--- a/extension/src/lib/checkout-checkbox-defense-registration.ts
+++ b/extension/src/lib/checkout-checkbox-defense-registration.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Background-side registration for the `checkout-checkbox-sanitize`
+// rule's main-world defense. When the rule is enabled,
+// `checkout-checkbox-defense.js` is registered via
+// `chrome.scripting.registerContentScripts` with `world: "MAIN"` and
+// `runAt: "document_start"` so the patched
+// `HTMLInputElement.prototype.checked` setter is in place before any
+// React/Vue bundle on the page caches the descriptor.
+//
+// When the rule is disabled (or enforcement is off), the registration is
+// removed so future navigations get a clean prototype. Already-loaded
+// tabs retain whatever wrap they had until the user reloads — same
+// constraint as static content_scripts and as webdriver-probe.
+//
+// The rule's own `apply` covers the currently-open tab by asking the
+// background worker (via an `inject-checkout-checkbox-defense` message)
+// to run the defense through `chrome.scripting.executeScript` — dynamic
+// registrations only take effect on subsequent navigations, so without
+// that round-trip the user would have to reload the active tab. This
+// module is purely the registration life-cycle for the standalone
+// bundle.
+
+import {
+  getEnforcementEnabled,
+  subscribeEnforcementEnabled,
+} from "./enforcement";
+import { log } from "./log";
+import { getRuleStates, subscribe } from "./storage";
+
+const SCRIPT_ID = "checkout-checkbox-sanitize-main-world";
+const SCRIPT_FILE = "checkout-checkbox-defense.js";
+
+async function shouldBeRegistered(): Promise<boolean> {
+  const [states, enforcementEnabled] = await Promise.all([
+    getRuleStates(),
+    getEnforcementEnabled(),
+  ]);
+  return enforcementEnabled && Boolean(states["checkout-checkbox-sanitize"]);
+}
+
+async function isRegistered(): Promise<boolean> {
+  try {
+    const registered = await chrome.scripting.getRegisteredContentScripts({
+      ids: [SCRIPT_ID],
+    });
+    return registered.length > 0;
+  } catch (error) {
+    // getRegisteredContentScripts throws if no script with the id exists
+    // in some Chrome versions; treat that as "not registered" rather than
+    // a failure mode that prevents registration.
+    log("checkout-checkbox-defense registration: getRegistered threw", {
+      error,
+    });
+    return false;
+  }
+}
+
+async function register(): Promise<void> {
+  try {
+    await chrome.scripting.registerContentScripts([
+      {
+        id: SCRIPT_ID,
+        matches: ["<all_urls>"],
+        js: [SCRIPT_FILE],
+        runAt: "document_start",
+        world: "MAIN",
+        // allFrames: cart/checkout flows often render the payment widget
+        // in a same-origin iframe (Stripe Checkout's embedded mode,
+        // shop-hosted express-pay drawers). Same-origin iframes have
+        // their own HTMLInputElement.prototype, so the wrap has to run
+        // per-frame. Cross-origin iframes get the patch too but their
+        // own document.location gates it via isCheckoutHref.
+        allFrames: true,
+        persistAcrossSessions: true,
+      },
+    ]);
+    log("checkout-checkbox-defense registered at document_start (main world)");
+  } catch (error) {
+    log("checkout-checkbox-defense registration failed", { error });
+  }
+}
+
+async function unregister(): Promise<void> {
+  try {
+    await chrome.scripting.unregisterContentScripts({ ids: [SCRIPT_ID] });
+    log("checkout-checkbox-defense unregistered");
+  } catch (error) {
+    // Unregister fails if the script wasn't registered to begin with;
+    // that's a benign state, not a problem.
+    log("checkout-checkbox-defense unregister no-op", { error });
+  }
+}
+
+async function sync(): Promise<void> {
+  const [target, current] = await Promise.all([
+    shouldBeRegistered(),
+    isRegistered(),
+  ]);
+  if (target === current) {
+    return;
+  }
+  await (target ? register() : unregister());
+}
+
+// Wire up the registration life-cycle. Called once from background.ts.
+export function startCheckoutCheckboxDefenseRegistration(): void {
+  // Initial reconciliation when the service worker spins up — covers both
+  // first install and SW restarts on Chrome's idle timer.
+  void sync();
+  subscribe(() => {
+    void sync();
+  });
+  subscribeEnforcementEnabled(() => {
+    void sync();
+  });
+}

--- a/extension/src/lib/checkout-checkbox-defense-source.ts
+++ b/extension/src/lib/checkout-checkbox-defense-source.ts
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Page-world (main-world) implementation of the checkout-checkbox-sanitize
+// defense. The rule itself runs in the isolated world and stamps
+// `[data-abs-cleared]` onto every checkbox it unchecks; this source
+// holds that state against page-script re-checks by wrapping
+// `HTMLInputElement.prototype.checked`. The wrap MUST live in the page
+// world — React/Vue reconciles drive `node.checked = true` through the
+// page world's own copy of the prototype, which is a distinct object
+// from the one a content script sees in its isolated world. Patching
+// the isolated-world copy is a no-op for the threat model.
+//
+// Shared between two delivery paths, mirroring the webdriver-probe
+// pattern:
+//
+//   1. Dynamic content-script registration in the background worker
+//      (`chrome.scripting.registerContentScripts` with `world: "MAIN"`
+//      and `runAt: "document_start"`). The primary path for any
+//      navigation that happens *after* the user enables the rule —
+//      the patch lands before the page's own scripts cache the
+//      `.checked` setter.
+//
+//   2. On-demand `chrome.scripting.executeScript` with `world: "MAIN"`,
+//      driven by the rule's `apply` sending an
+//      `inject-checkout-checkbox-defense` message at `document_idle`.
+//      Covers the tab the user was already viewing when they toggled
+//      the rule on (dynamic registrations only take effect on subsequent
+//      navigations). `executeScript` with `world: "MAIN"` is exempt
+//      from page CSP the same way the registered content script is, so
+//      strict `script-src` origins still get the patch.
+//
+// The function must not reference any module-scope identifiers — only
+// the function body's source crosses into the page world (either via
+// `executeScript({ func })` from the background worker or via the
+// bundled `checkout-checkbox-defense.js` entry point). The marker
+// string is hard-coded as a literal here and re-declared as
+// `CHECKOUT_CHECKBOX_CLEARED_ATTR` in `lib/dom-markers.ts` for the
+// isolated-world rule; a test asserts the two agree.
+
+export function installCheckoutCheckboxDefense(this: Window): void {
+  const FLAG = "__abs_checkout_checkbox_defense_installed";
+  const defenseWindow = this as Window & Record<string, unknown>;
+  if (defenseWindow[FLAG]) {
+    return;
+  }
+  defenseWindow[FLAG] = true;
+
+  // Mirror of CHECKOUT_CHECKBOX_CLEARED_ATTR from lib/dom-markers.ts.
+  // Hard-coded because this function runs in the page world with no
+  // module imports; the isolated-world rule and the markers registry
+  // share the same literal, asserted by a unit test. The lint rule that
+  // bans inline `data-abs-*` literals exists to keep the registry the
+  // single source of truth — this is the one principled exception.
+  // eslint-disable-next-line no-restricted-syntax
+  const CLEARED_ATTR = "data-abs-cleared";
+
+  // Mirror of the URLPattern set in lib/checkout-url.ts as a single
+  // anchored regex. `/cart`, `/cart/`, `/cart/sub` match; `/cartx`,
+  // `/products/cart-bag`, `/orders` do not. Asserted against the rule's
+  // `isCheckoutUrl` in a parity test.
+  const CHECKOUT_PATH_RE =
+    /^\/(?:cart|checkout|basket|bag|payment|order)(?:\/.*)?$/;
+
+  function isCheckoutHref(href: string): boolean {
+    try {
+      return CHECKOUT_PATH_RE.test(new URL(href).pathname);
+    } catch {
+      return false;
+    }
+  }
+
+  interface CheckedDescriptor {
+    enumerable?: boolean;
+    configurable?: boolean;
+    get?: (this: HTMLInputElement) => boolean;
+    set?: (this: HTMLInputElement, value: boolean) => void;
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "checked",
+  ) as CheckedDescriptor | undefined;
+  if (!descriptor?.configurable || !descriptor.set || !descriptor.get) {
+    // Non-configurable or partial descriptor — give up silently. A
+    // future Chrome locking down HTMLInputElement.prototype would
+    // disable the defense rather than block the page.
+    return;
+  }
+  const nativeSetter = descriptor.set;
+  const nativeGetter = descriptor.get;
+
+  try {
+    Object.defineProperty(HTMLInputElement.prototype, "checked", {
+      configurable: true,
+      enumerable: descriptor.enumerable ?? true,
+      get: nativeGetter,
+      set(this: HTMLInputElement, value: boolean) {
+        if (
+          value &&
+          this.getAttribute(CLEARED_ATTR) !== null &&
+          isCheckoutHref(globalThis.location.href)
+        ) {
+          nativeSetter.call(this, false);
+          return;
+        }
+        nativeSetter.call(this, value);
+      },
+    });
+  } catch {
+    // defineProperty can throw if another script has already locked
+    // the descriptor non-configurable since we read it; treat as the
+    // same opt-out path as the descriptor guard above.
+    return;
+  }
+
+  // Release the defense on genuine user interaction. Without this, a
+  // controlled React/Vue checkbox would visually flicker on a real-user
+  // click — native activation toggles `.checked` to true (bypassing our
+  // setter), the framework's bubble-phase onChange schedules
+  // `setState(true)` → reconcile → `node.checked = true`, and the patch
+  // would revert that reconcile because the marker is still present.
+  // Capture-phase placement guarantees the marker is gone before any
+  // framework handler runs. Gated on `isTrusted` so page-script
+  // dispatches (including the rule's own isolated-world `change` event)
+  // do not release the lock.
+  document.addEventListener(
+    "change",
+    (event) => {
+      if (!event.isTrusted) {
+        return;
+      }
+      const target = event.target;
+      if (!(target instanceof HTMLInputElement) || target.type !== "checkbox") {
+        return;
+      }
+      if (target.getAttribute(CLEARED_ATTR) !== null) {
+        target.removeAttribute(CLEARED_ATTR);
+      }
+    },
+    { capture: true },
+  );
+}

--- a/extension/src/rules/__tests__/checkout-checkbox-sanitize.property.test.ts
+++ b/extension/src/rules/__tests__/checkout-checkbox-sanitize.property.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://shop.example.com/checkout"}
+ */
+// Property-based tests for checkout-checkbox-sanitize. The rule guarantees
+// two invariants we want fast-check to hammer against arbitrary sequences
+// of programmatic state writes:
+//
+//   1. While the URL is checkout-shaped and the box wears `CLEARED_ATTR`,
+//      no sequence of `.checked = boolean` writes can leave the box in
+//      a checked state. (`.click()` is the escape hatch — it routes
+//      through the activation behavior, not the patched setter.)
+//   2. The patch is selective: a fresh checkbox that the rule never
+//      touched accepts arbitrary `.checked` writes verbatim.
+//   3. URL gating is symmetric: once the SPA navigates away from a
+//      checkout URL, a re-check on the (still-marked) box sticks again.
+
+import fc from "fast-check";
+
+import { CHECKOUT_CHECKBOX_CLEARED_ATTR as CLEARED_ATTR } from "../../lib/dom-markers";
+import { checkoutCheckboxSanitizeRule } from "../checkout-checkbox-sanitize";
+
+afterEach(() => {
+  checkoutCheckboxSanitizeRule.teardown();
+  document.body.innerHTML = "";
+});
+
+describe("cleared checkbox stays cleared under arbitrary .checked writes", () => {
+  it("any sequence of programmatic writes resolves to unchecked", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.boolean(), { minLength: 1, maxLength: 20 }),
+        (writes) => {
+          document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
+          const checkbox = document.querySelector(
+            "#upsell",
+          ) as HTMLInputElement;
+          checkoutCheckboxSanitizeRule.apply(document.body);
+          expect(checkbox.checked).toBe(false);
+
+          for (const value of writes) {
+            checkbox.checked = value;
+            // The invariant: at no point may a programmatic write leave
+            // the box checked. `value === true` is blocked outright;
+            // `value === false` is a no-op pass-through.
+            expect(checkbox.checked).toBe(false);
+          }
+          checkoutCheckboxSanitizeRule.teardown();
+          document.body.innerHTML = "";
+        },
+      ),
+    );
+  });
+});
+
+describe("non-cleared checkbox is unaffected by the prototype patch", () => {
+  it("accepts arbitrary .checked writes verbatim", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.boolean(), { minLength: 1, maxLength: 20 }),
+        (writes) => {
+          document.body.innerHTML = `<input id="fresh" type="checkbox" />`;
+          const checkbox = document.querySelector("#fresh") as HTMLInputElement;
+          // Install the patch by applying the rule on an unrelated subtree.
+          checkoutCheckboxSanitizeRule.apply(document.body);
+
+          for (const value of writes) {
+            checkbox.checked = value;
+            expect(checkbox.checked).toBe(value);
+          }
+          // Marker was never stamped on a box that started unchecked.
+          expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(false);
+          checkoutCheckboxSanitizeRule.teardown();
+          document.body.innerHTML = "";
+        },
+      ),
+    );
+  });
+});
+
+describe("URL gate releases the defense off checkout", () => {
+  it("re-checks on a marked box stick once the route is non-checkout", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("/account", "/", "/product/123", "/orders/42"),
+        (nonCheckoutPath) => {
+          globalThis.history.replaceState({}, "", "/checkout");
+          document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
+          const checkbox = document.querySelector(
+            "#upsell",
+          ) as HTMLInputElement;
+          checkoutCheckboxSanitizeRule.apply(document.body);
+          expect(checkbox.checked).toBe(false);
+          expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
+
+          globalThis.history.replaceState({}, "", nonCheckoutPath);
+          try {
+            checkbox.checked = true;
+            expect(checkbox.checked).toBe(true);
+          } finally {
+            globalThis.history.replaceState({}, "", "/checkout");
+            checkoutCheckboxSanitizeRule.teardown();
+            document.body.innerHTML = "";
+          }
+        },
+      ),
+    );
+  });
+});

--- a/extension/src/rules/__tests__/checkout-checkbox-sanitize.property.test.ts
+++ b/extension/src/rules/__tests__/checkout-checkbox-sanitize.property.test.ts
@@ -2,23 +2,28 @@
  * @jest-environment jsdom
  * @jest-environment-options {"url": "https://shop.example.com/checkout"}
  */
-// Property-based tests for checkout-checkbox-sanitize. The rule guarantees
-// two invariants we want fast-check to hammer against arbitrary sequences
-// of programmatic state writes:
+// Property-based tests for checkout-checkbox-sanitize. The rule + the
+// page-world defense together guarantee invariants we want fast-check
+// to hammer against arbitrary sequences of programmatic state writes:
 //
 //   1. While the URL is checkout-shaped and the box wears `CLEARED_ATTR`,
 //      no sequence of `.checked = boolean` writes can leave the box in
 //      a checked state. (`.click()` is the escape hatch — it routes
 //      through the activation behavior, not the patched setter.)
-//   2. The patch is selective: a fresh checkbox that the rule never
+//   2. The defense is selective: a fresh checkbox that the rule never
 //      touched accepts arbitrary `.checked` writes verbatim.
 //   3. URL gating is symmetric: once the SPA navigates away from a
 //      checkout URL, a re-check on the (still-marked) box sticks again.
 
 import fc from "fast-check";
 
+import { installCheckoutCheckboxDefense } from "../../lib/checkout-checkbox-defense-source";
 import { CHECKOUT_CHECKBOX_CLEARED_ATTR as CLEARED_ATTR } from "../../lib/dom-markers";
 import { checkoutCheckboxSanitizeRule } from "../checkout-checkbox-sanitize";
+
+beforeAll(() => {
+  installCheckoutCheckboxDefense.call(globalThis as unknown as Window);
+});
 
 afterEach(() => {
   checkoutCheckboxSanitizeRule.teardown();
@@ -61,7 +66,8 @@ describe("non-cleared checkbox is unaffected by the prototype patch", () => {
         (writes) => {
           document.body.innerHTML = `<input id="fresh" type="checkbox" />`;
           const checkbox = document.querySelector("#fresh") as HTMLInputElement;
-          // Install the patch by applying the rule on an unrelated subtree.
+          // The rule runs on an unrelated subtree; the patch is already
+          // installed via beforeAll.
           checkoutCheckboxSanitizeRule.apply(document.body);
 
           for (const value of writes) {

--- a/extension/src/rules/__tests__/checkout-checkbox-sanitize.test.ts
+++ b/extension/src/rules/__tests__/checkout-checkbox-sanitize.test.ts
@@ -123,24 +123,6 @@ describe("checkoutCheckboxSanitizeRule lazy-loaded sections", () => {
     expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
   });
 
-  it("does not re-uncheck a cleared box that the agent re-checks", async () => {
-    document.body.innerHTML = `<input id="terms" type="checkbox" checked />`;
-    checkoutCheckboxSanitizeRule.apply(document.body);
-
-    const checkbox = document.querySelector("#terms") as HTMLInputElement;
-    expect(checkbox.checked).toBe(false);
-
-    // Agent re-checks the box (e.g., after deciding to accept T&C).
-    checkbox.checked = true;
-
-    // Trigger a scan: append an unrelated element so the mutation observer fires.
-    document.body.append(document.createElement("span"));
-    await flushMutations();
-    jest.advanceTimersByTime(MUTATION_THROTTLE_MS);
-
-    expect(checkbox.checked).toBe(true);
-  });
-
   it("teardown stops the observer so later additions are ignored", async () => {
     checkoutCheckboxSanitizeRule.apply(document.body);
     checkoutCheckboxSanitizeRule.teardown();
@@ -155,5 +137,121 @@ describe("checkoutCheckboxSanitizeRule lazy-loaded sections", () => {
     const checkbox = document.querySelector("#late") as HTMLInputElement;
     expect(checkbox.checked).toBe(true);
     expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(false);
+  });
+});
+
+describe("checkoutCheckboxSanitizeRule prototype defense patch", () => {
+  it("reverts a programmatic .checked = true on a cleared box", () => {
+    document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+    expect(checkbox.checked).toBe(false);
+
+    // Simulate the page's hydration / controlled-input reconcile loop
+    // writing the pre-selected state back onto the input.
+    checkbox.checked = true;
+
+    expect(checkbox.checked).toBe(false);
+    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
+  });
+
+  it("reverts repeated re-check attempts on a cleared box", () => {
+    document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+
+    for (let index = 0; index < 5; index++) {
+      checkbox.checked = true;
+      expect(checkbox.checked).toBe(false);
+    }
+  });
+
+  it("allows .click() to legitimately re-check a cleared box", () => {
+    document.body.innerHTML = `<input id="terms" type="checkbox" checked />`;
+    const checkbox = document.querySelector("#terms") as HTMLInputElement;
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+    expect(checkbox.checked).toBe(false);
+
+    // .click() routes through the native activation behavior, not the
+    // patched JS setter — this is the documented agent escape hatch.
+    checkbox.click();
+
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it("allows re-check after the cleared marker is removed", () => {
+    document.body.innerHTML = `<input id="terms" type="checkbox" checked />`;
+    const checkbox = document.querySelector("#terms") as HTMLInputElement;
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+
+    checkbox.removeAttribute(CLEARED_ATTR);
+    checkbox.checked = true;
+
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it("does not interfere with non-cleared checkboxes", () => {
+    document.body.innerHTML = `<input id="fresh" type="checkbox" />`;
+    const checkbox = document.querySelector("#fresh") as HTMLInputElement;
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+
+    checkbox.checked = true;
+
+    expect(checkbox.checked).toBe(true);
+    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(false);
+  });
+
+  it("allows setting .checked = false on a cleared box (no-op pass-through)", () => {
+    document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+
+    checkbox.checked = false;
+
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it("does not interfere with non-checkbox inputs that happen to gain the marker", () => {
+    // CLEARED_ATTR is only ever stamped on checkboxes by the rule, but
+    // the prototype patch's selectivity rests on the marker — verify a
+    // text input wearing the marker still accepts arbitrary value writes
+    // (the patch gates by `.checked` writes only, never `.value`).
+    document.body.innerHTML = `<input id="oddball" type="text" />`;
+    const input = document.querySelector("#oddball") as HTMLInputElement;
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+
+    input.setAttribute(CLEARED_ATTR, "");
+    input.value = "hello";
+
+    expect(input.value).toBe("hello");
+  });
+});
+
+describe("checkoutCheckboxSanitizeRule URL gate on the patch", () => {
+  it("does not defend cleared boxes once the SPA route leaves checkout", () => {
+    // Sanitize a checkout box, then SPA-navigate away. The patch's URL
+    // gate releases the lock so the page's own state can drive the box
+    // again on a non-checkout route.
+    globalThis.history.replaceState({}, "", "/checkout");
+    document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+    expect(checkbox.checked).toBe(false);
+
+    globalThis.history.replaceState({}, "", "/account");
+    try {
+      checkbox.checked = true;
+      expect(checkbox.checked).toBe(true);
+    } finally {
+      globalThis.history.replaceState({}, "", "/checkout");
+    }
   });
 });

--- a/extension/src/rules/__tests__/checkout-checkbox-sanitize.test.ts
+++ b/extension/src/rules/__tests__/checkout-checkbox-sanitize.test.ts
@@ -4,7 +4,21 @@
  */
 import { isCheckoutUrl } from "../../lib/checkout-url";
 import { CHECKOUT_CHECKBOX_CLEARED_ATTR as CLEARED_ATTR } from "../../lib/dom-markers";
-import { checkoutCheckboxSanitizeRule } from "../checkout-checkbox-sanitize";
+import {
+  checkoutCheckboxSanitizeRule,
+  __handleUserChangeEventForTesting as handleUserChangeEvent,
+} from "../checkout-checkbox-sanitize";
+
+// jsdom installs `Event.isTrusted` as an unforgeable per-instance
+// property, so we can't construct a "trusted" event through the public
+// constructor — emulate the surface the production listener inspects.
+function fakeTrustedChange(target: EventTarget): Event {
+  return {
+    isTrusted: true,
+    target,
+    type: "change",
+  } as unknown as Event;
+}
 
 const MUTATION_THROTTLE_MS = 250;
 
@@ -215,6 +229,57 @@ describe("checkoutCheckboxSanitizeRule prototype defense patch", () => {
     checkbox.checked = false;
 
     expect(checkbox.checked).toBe(false);
+  });
+
+  it("releases the marker on a trusted change event so a controlled framework reconcile sticks", () => {
+    document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+    expect(checkbox.checked).toBe(false);
+    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
+
+    handleUserChangeEvent(fakeTrustedChange(checkbox));
+
+    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(false);
+    // A subsequent framework reconcile now passes through the setter
+    // patch unmodified — no flicker on a real-user click.
+    checkbox.checked = true;
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it("ignores untrusted change events so page-script dispatches do not release the lock", () => {
+    document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
+    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
+
+    // A page script firing `dispatchEvent(new Event("change"))` produces
+    // an untrusted event — must not release the defense. (jsdom's
+    // `Event` is untrusted by default, so this also covers the live
+    // listener path.)
+    checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
+    checkbox.checked = true;
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it("ignores trusted change events on non-checkbox inputs", () => {
+    document.body.innerHTML = `
+      <input id="other" type="checkbox" />
+      <input id="text" type="text" />
+    `;
+    const text = document.querySelector("#text") as HTMLInputElement;
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+    // Marker is normally rule-managed, but a hostile page could
+    // theoretically stamp it onto an arbitrary input. The handler must
+    // only release for checkboxes.
+    text.setAttribute(CLEARED_ATTR, "");
+    handleUserChangeEvent(fakeTrustedChange(text));
+    expect(text.hasAttribute(CLEARED_ATTR)).toBe(true);
   });
 
   it("does not interfere with non-checkbox inputs that happen to gain the marker", () => {

--- a/extension/src/rules/__tests__/checkout-checkbox-sanitize.test.ts
+++ b/extension/src/rules/__tests__/checkout-checkbox-sanitize.test.ts
@@ -2,29 +2,25 @@
  * @jest-environment jsdom
  * @jest-environment-options {"url": "https://shop.example.com/checkout"}
  */
+import { installCheckoutCheckboxDefense } from "../../lib/checkout-checkbox-defense-source";
 import { isCheckoutUrl } from "../../lib/checkout-url";
 import { CHECKOUT_CHECKBOX_CLEARED_ATTR as CLEARED_ATTR } from "../../lib/dom-markers";
-import {
-  checkoutCheckboxSanitizeRule,
-  __handleUserChangeEventForTesting as handleUserChangeEvent,
-} from "../checkout-checkbox-sanitize";
-
-// jsdom installs `Event.isTrusted` as an unforgeable per-instance
-// property, so we can't construct a "trusted" event through the public
-// constructor — emulate the surface the production listener inspects.
-function fakeTrustedChange(target: EventTarget): Event {
-  return {
-    isTrusted: true,
-    target,
-    type: "change",
-  } as unknown as Event;
-}
+import { checkoutCheckboxSanitizeRule } from "../checkout-checkbox-sanitize";
 
 const MUTATION_THROTTLE_MS = 250;
 
 async function flushMutations(): Promise<void> {
   await Promise.resolve();
 }
+
+beforeAll(() => {
+  // In production the defense is shipped into the page world via a
+  // separate bundle registered by the background worker; jsdom has a
+  // single world, so installing the source here gives the rule's
+  // unchecked boxes the same prototype-wrap defense they'd see at
+  // runtime. Idempotent — safe to call once per file.
+  installCheckoutCheckboxDefense.call(globalThis as unknown as Window);
+});
 
 beforeEach(() => {
   document.body.innerHTML = "";
@@ -119,6 +115,33 @@ describe("checkoutCheckboxSanitizeRule.apply", () => {
     expect(radio.checked).toBe(true);
     expect(text.value).toBe("hello");
   });
+
+  it("requests page-world defense injection via chrome.runtime.sendMessage", () => {
+    document.body.innerHTML = `<input type="checkbox" checked />`;
+    const sendMessage = chrome.runtime.sendMessage as unknown as jest.Mock;
+    sendMessage.mockReset();
+    sendMessage.mockResolvedValue(undefined);
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: "inject-checkout-checkbox-defense",
+    });
+  });
+
+  it("swallows sendMessage rejections so the rule still scans", async () => {
+    document.body.innerHTML = `<input id="x" type="checkbox" checked />`;
+    const sendMessage = chrome.runtime.sendMessage as unknown as jest.Mock;
+    sendMessage.mockReset();
+    sendMessage.mockRejectedValue(new Error("no receiver"));
+
+    checkoutCheckboxSanitizeRule.apply(document.body);
+    await flushMutations();
+
+    const checkbox = document.querySelector("#x") as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
+  });
 });
 
 describe("checkoutCheckboxSanitizeRule lazy-loaded sections", () => {
@@ -154,169 +177,43 @@ describe("checkoutCheckboxSanitizeRule lazy-loaded sections", () => {
   });
 });
 
-describe("checkoutCheckboxSanitizeRule prototype defense patch", () => {
-  it("reverts a programmatic .checked = true on a cleared box", () => {
+describe("end-to-end with the page-world defense installed", () => {
+  // The rule clears the box and stamps the marker; the source-side
+  // prototype wrap then defends that marker against programmatic
+  // re-checks. These tests exercise the integration in jsdom's
+  // single-world environment, which mirrors how the two pieces interact
+  // at runtime once the defense bundle has been injected.
+
+  it("a page-script .checked = true after sanitize is reverted", () => {
     document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
     const checkbox = document.querySelector("#upsell") as HTMLInputElement;
 
     checkoutCheckboxSanitizeRule.apply(document.body);
     expect(checkbox.checked).toBe(false);
 
-    // Simulate the page's hydration / controlled-input reconcile loop
-    // writing the pre-selected state back onto the input.
     checkbox.checked = true;
 
     expect(checkbox.checked).toBe(false);
-    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
   });
 
-  it("reverts repeated re-check attempts on a cleared box", () => {
-    document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
-    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
-
-    checkoutCheckboxSanitizeRule.apply(document.body);
-
-    for (let index = 0; index < 5; index++) {
-      checkbox.checked = true;
-      expect(checkbox.checked).toBe(false);
-    }
-  });
-
-  it("allows .click() to legitimately re-check a cleared box", () => {
+  it("an agent .click() on a cleared box re-checks (escape hatch)", () => {
     document.body.innerHTML = `<input id="terms" type="checkbox" checked />`;
     const checkbox = document.querySelector("#terms") as HTMLInputElement;
 
     checkoutCheckboxSanitizeRule.apply(document.body);
-    expect(checkbox.checked).toBe(false);
-
-    // .click() routes through the native activation behavior, not the
-    // patched JS setter — this is the documented agent escape hatch.
     checkbox.click();
 
     expect(checkbox.checked).toBe(true);
   });
 
-  it("allows re-check after the cleared marker is removed", () => {
+  it("removing the marker manually releases the lock", () => {
     document.body.innerHTML = `<input id="terms" type="checkbox" checked />`;
     const checkbox = document.querySelector("#terms") as HTMLInputElement;
 
     checkoutCheckboxSanitizeRule.apply(document.body);
-
     checkbox.removeAttribute(CLEARED_ATTR);
     checkbox.checked = true;
 
     expect(checkbox.checked).toBe(true);
-  });
-
-  it("does not interfere with non-cleared checkboxes", () => {
-    document.body.innerHTML = `<input id="fresh" type="checkbox" />`;
-    const checkbox = document.querySelector("#fresh") as HTMLInputElement;
-
-    checkoutCheckboxSanitizeRule.apply(document.body);
-
-    checkbox.checked = true;
-
-    expect(checkbox.checked).toBe(true);
-    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(false);
-  });
-
-  it("allows setting .checked = false on a cleared box (no-op pass-through)", () => {
-    document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
-    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
-
-    checkoutCheckboxSanitizeRule.apply(document.body);
-
-    checkbox.checked = false;
-
-    expect(checkbox.checked).toBe(false);
-  });
-
-  it("releases the marker on a trusted change event so a controlled framework reconcile sticks", () => {
-    document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
-    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
-
-    checkoutCheckboxSanitizeRule.apply(document.body);
-    expect(checkbox.checked).toBe(false);
-    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
-
-    handleUserChangeEvent(fakeTrustedChange(checkbox));
-
-    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(false);
-    // A subsequent framework reconcile now passes through the setter
-    // patch unmodified — no flicker on a real-user click.
-    checkbox.checked = true;
-    expect(checkbox.checked).toBe(true);
-  });
-
-  it("ignores untrusted change events so page-script dispatches do not release the lock", () => {
-    document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
-    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
-
-    checkoutCheckboxSanitizeRule.apply(document.body);
-    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
-
-    // A page script firing `dispatchEvent(new Event("change"))` produces
-    // an untrusted event — must not release the defense. (jsdom's
-    // `Event` is untrusted by default, so this also covers the live
-    // listener path.)
-    checkbox.dispatchEvent(new Event("change", { bubbles: true }));
-
-    expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(true);
-    checkbox.checked = true;
-    expect(checkbox.checked).toBe(false);
-  });
-
-  it("ignores trusted change events on non-checkbox inputs", () => {
-    document.body.innerHTML = `
-      <input id="other" type="checkbox" />
-      <input id="text" type="text" />
-    `;
-    const text = document.querySelector("#text") as HTMLInputElement;
-
-    checkoutCheckboxSanitizeRule.apply(document.body);
-    // Marker is normally rule-managed, but a hostile page could
-    // theoretically stamp it onto an arbitrary input. The handler must
-    // only release for checkboxes.
-    text.setAttribute(CLEARED_ATTR, "");
-    handleUserChangeEvent(fakeTrustedChange(text));
-    expect(text.hasAttribute(CLEARED_ATTR)).toBe(true);
-  });
-
-  it("does not interfere with non-checkbox inputs that happen to gain the marker", () => {
-    // CLEARED_ATTR is only ever stamped on checkboxes by the rule, but
-    // the prototype patch's selectivity rests on the marker — verify a
-    // text input wearing the marker still accepts arbitrary value writes
-    // (the patch gates by `.checked` writes only, never `.value`).
-    document.body.innerHTML = `<input id="oddball" type="text" />`;
-    const input = document.querySelector("#oddball") as HTMLInputElement;
-
-    checkoutCheckboxSanitizeRule.apply(document.body);
-
-    input.setAttribute(CLEARED_ATTR, "");
-    input.value = "hello";
-
-    expect(input.value).toBe("hello");
-  });
-});
-
-describe("checkoutCheckboxSanitizeRule URL gate on the patch", () => {
-  it("does not defend cleared boxes once the SPA route leaves checkout", () => {
-    // Sanitize a checkout box, then SPA-navigate away. The patch's URL
-    // gate releases the lock so the page's own state can drive the box
-    // again on a non-checkout route.
-    globalThis.history.replaceState({}, "", "/checkout");
-    document.body.innerHTML = `<input id="upsell" type="checkbox" checked />`;
-    const checkbox = document.querySelector("#upsell") as HTMLInputElement;
-
-    checkoutCheckboxSanitizeRule.apply(document.body);
-    expect(checkbox.checked).toBe(false);
-
-    globalThis.history.replaceState({}, "", "/account");
-    try {
-      checkbox.checked = true;
-      expect(checkbox.checked).toBe(true);
-    } finally {
-      globalThis.history.replaceState({}, "", "/checkout");
-    }
   });
 });

--- a/extension/src/rules/checkout-checkbox-sanitize.ts
+++ b/extension/src/rules/checkout-checkbox-sanitize.ts
@@ -9,8 +9,11 @@
 //
 // We re-scan added subtrees via a throttled MutationObserver so checkboxes
 // in lazily-loaded checkout steps are caught. We deliberately do NOT observe
-// attribute mutations: once we've cleared a checkbox, re-checks by the
-// agent/user must stick, or we'd be in a fight loop.
+// attribute mutations on existing checkboxes via the watcher — the
+// MutationObserver path would burn cycles on every class/style toggle.
+// Defense against post-sanitize re-checks lives in the prototype setter
+// patch below, which intercepts programmatic `.checked = true` writes on
+// cleared boxes synchronously.
 
 import { isCheckoutUrl } from "../lib/checkout-url";
 import { CHECKOUT_CHECKBOX_CLEARED_ATTR as CLEARED_ATTR } from "../lib/dom-markers";
@@ -19,6 +22,11 @@ import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import type { Rule } from "./types";
 
 const RULE_ID = "checkout-checkbox-sanitize" as const;
+
+// One patch per realm. Idempotent so a subframe re-import or test re-run
+// doesn't stack patches on top of each other. Matches the convention used
+// by `lib/shadow-roots.ts`.
+const PATCH_INSTALLED = Symbol.for("abs.checkoutCheckedSetterPatched");
 
 // React/Vue track checked state internally; setting `.checked` directly skips
 // their value-tracker, so onChange handlers never fire and totals don't
@@ -29,6 +37,10 @@ const RULE_ID = "checkout-checkbox-sanitize" as const;
 // DOM-less contexts (service worker, codegen). Touching
 // `HTMLInputElement.prototype` at module top level used to crash the
 // background worker bundle — see scripts/check-background-purity.ts.
+//
+// Captured before `installCheckedDefensePatch` overwrites the descriptor,
+// so the rule's own `uncheck` always invokes the native setter directly
+// rather than re-entering our wrapper.
 let cachedNativeCheckedSetter:
   | ((this: HTMLInputElement, value: boolean) => void)
   | null
@@ -49,6 +61,65 @@ function getNativeCheckedSetter():
   )?.set;
   cachedNativeCheckedSetter = setter ?? null;
   return cachedNativeCheckedSetter;
+}
+
+// Defend a cleared checkbox against programmatic re-checks driven by the
+// page itself — the dark-pattern threat model the rule was built for.
+// React/Vue controlled inputs reconcile `.checked` from component state on
+// every re-render; without this patch a single `setState({ optIn: true })`
+// after our sanitize pass silently re-checks every pre-selected add-on.
+//
+// Activation gate:
+//   - the target value is truthy (we never block unchecks),
+//   - the input bears `CLEARED_ATTR` (so non-sanitized inputs — including
+//     every text/radio/file input on the page — behave normally), and
+//   - the current URL is still checkout-shaped (SPA navigation away from
+//     checkout releases the lock).
+//
+// The marker is the source of truth: an agent that genuinely wants to
+// re-check a sanitized box must either remove `[data-abs-cleared]` first
+// or invoke `checkbox.click()`, which routes through the native activation
+// behavior and bypasses the JS setter.
+function installCheckedDefensePatch(): void {
+  const flagHolder = globalThis as unknown as Record<symbol, unknown>;
+  if (flagHolder[PATCH_INSTALLED]) {
+    return;
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "checked",
+  );
+  if (!descriptor?.configurable) {
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const nativeSetter = descriptor.set;
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const nativeGetter = descriptor.get;
+  if (!nativeSetter || !nativeGetter) {
+    return;
+  }
+  // Seed the cache so `uncheck` calls the captured native setter directly
+  // rather than discovering the now-patched descriptor on first read.
+  cachedNativeCheckedSetter = nativeSetter;
+  flagHolder[PATCH_INSTALLED] = true;
+
+  Object.defineProperty(HTMLInputElement.prototype, "checked", {
+    configurable: true,
+    enumerable: descriptor.enumerable ?? true,
+    get: nativeGetter,
+    set(this: HTMLInputElement, value: boolean) {
+      if (
+        value &&
+        this.getAttribute(CLEARED_ATTR) !== null &&
+        isCheckoutUrl(globalThis.location.href)
+      ) {
+        nativeSetter.call(this, false);
+        return;
+      }
+      nativeSetter.call(this, value);
+    },
+  });
 }
 
 function uncheck(checkbox: HTMLInputElement): void {
@@ -97,6 +168,7 @@ const watcher = createSubtreeWatcher({
 });
 
 function apply(root: ParentNode): void {
+  installCheckedDefensePatch();
   scanAndClear(root);
   watcher.start(root);
 }

--- a/extension/src/rules/checkout-checkbox-sanitize.ts
+++ b/extension/src/rules/checkout-checkbox-sanitize.ts
@@ -11,9 +11,18 @@
 // in lazily-loaded checkout steps are caught. We deliberately do NOT observe
 // attribute mutations on existing checkboxes via the watcher — the
 // MutationObserver path would burn cycles on every class/style toggle.
-// Defense against post-sanitize re-checks lives in the prototype setter
-// patch below, which intercepts programmatic `.checked = true` writes on
-// cleared boxes synchronously.
+//
+// Defense against post-sanitize re-checks (the dark-pattern threat model
+// the rule was built for) lives in a separate page-world bundle:
+// `lib/checkout-checkbox-defense-source.ts`, registered by the background
+// worker at `document_start` whenever this rule is enabled. The
+// isolated-world prototype that a content script can reach is a distinct
+// object from the page world's copy that React/Vue reconciles drive
+// `node.checked = true` through, so the wrap MUST live in the page
+// world. This rule's `apply` sends an `inject-checkout-checkbox-defense`
+// message at `document_idle` so the tab the user was already viewing
+// when they toggled the rule on also gets the patch — dynamic
+// registrations only apply to future navigations.
 
 import { isCheckoutUrl } from "../lib/checkout-url";
 import { CHECKOUT_CHECKBOX_CLEARED_ATTR as CLEARED_ATTR } from "../lib/dom-markers";
@@ -23,10 +32,9 @@ import type { Rule } from "./types";
 
 const RULE_ID = "checkout-checkbox-sanitize" as const;
 
-// One patch per realm. Idempotent so a subframe re-import or test re-run
-// doesn't stack patches on top of each other. Matches the convention used
-// by `lib/shadow-roots.ts`.
-const PATCH_INSTALLED = Symbol.for("abs.checkoutCheckedSetterPatched");
+const INJECT_DEFENSE_MESSAGE = {
+  type: "inject-checkout-checkbox-defense",
+} as const;
 
 // React/Vue track checked state internally; setting `.checked` directly skips
 // their value-tracker, so onChange handlers never fire and totals don't
@@ -37,10 +45,6 @@ const PATCH_INSTALLED = Symbol.for("abs.checkoutCheckedSetterPatched");
 // DOM-less contexts (service worker, codegen). Touching
 // `HTMLInputElement.prototype` at module top level used to crash the
 // background worker bundle — see scripts/check-background-purity.ts.
-//
-// Captured before `installCheckedDefensePatch` overwrites the descriptor,
-// so the rule's own `uncheck` always invokes the native setter directly
-// rather than re-entering our wrapper.
 let cachedNativeCheckedSetter:
   | ((this: HTMLInputElement, value: boolean) => void)
   | null
@@ -62,100 +66,6 @@ function getNativeCheckedSetter():
   cachedNativeCheckedSetter = setter ?? null;
   return cachedNativeCheckedSetter;
 }
-
-// Defend a cleared checkbox against programmatic re-checks driven by the
-// page itself — the dark-pattern threat model the rule was built for.
-// React/Vue controlled inputs reconcile `.checked` from component state on
-// every re-render; without this patch a single `setState({ optIn: true })`
-// after our sanitize pass silently re-checks every pre-selected add-on.
-//
-// Activation gate:
-//   - the target value is truthy (we never block unchecks),
-//   - the input bears `CLEARED_ATTR` (so non-sanitized inputs — including
-//     every text/radio/file input on the page — behave normally), and
-//   - the current URL is still checkout-shaped (SPA navigation away from
-//     checkout releases the lock).
-//
-// The marker is the source of truth: an agent that genuinely wants to
-// re-check a sanitized box must either remove `[data-abs-cleared]` first
-// or invoke `checkbox.click()`, which routes through the native activation
-// behavior and bypasses the JS setter.
-function installCheckedDefensePatch(): void {
-  const flagHolder = globalThis as unknown as Record<symbol, unknown>;
-  if (flagHolder[PATCH_INSTALLED]) {
-    return;
-  }
-  const descriptor = Object.getOwnPropertyDescriptor(
-    HTMLInputElement.prototype,
-    "checked",
-  );
-  if (!descriptor?.configurable) {
-    return;
-  }
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const nativeSetter = descriptor.set;
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const nativeGetter = descriptor.get;
-  if (!nativeSetter || !nativeGetter) {
-    return;
-  }
-  // Seed the cache so `uncheck` calls the captured native setter directly
-  // rather than discovering the now-patched descriptor on first read.
-  cachedNativeCheckedSetter = nativeSetter;
-  flagHolder[PATCH_INSTALLED] = true;
-
-  Object.defineProperty(HTMLInputElement.prototype, "checked", {
-    configurable: true,
-    enumerable: descriptor.enumerable ?? true,
-    get: nativeGetter,
-    set(this: HTMLInputElement, value: boolean) {
-      if (
-        value &&
-        this.getAttribute(CLEARED_ATTR) !== null &&
-        isCheckoutUrl(globalThis.location.href)
-      ) {
-        nativeSetter.call(this, false);
-        return;
-      }
-      nativeSetter.call(this, value);
-    },
-  });
-
-  // Release the defense on genuine user interaction. Without this, a
-  // controlled React/Vue checkbox would visibly flicker on a real click:
-  // native activation toggles `.checked` to true (bypassing our setter),
-  // the framework's onChange schedules `setState(true)` → reconcile →
-  // `node.checked = true`, and the patch would revert to false because
-  // the marker is still present. Running in capture phase guarantees
-  // the marker is gone before any framework handler runs, so the
-  // framework's reconcile sticks.
-  document.addEventListener("change", handleUserChangeEvent, {
-    capture: true,
-  });
-}
-
-// Gated on `isTrusted` so synthetic dispatches from page scripts
-// (including our own `uncheck` change event and any `element.click()`
-// call from page JS) do not release the lock — only real user gestures
-// and WebDriver/CDP-driven clicks do. Exported under a test-only name
-// because jsdom installs `isTrusted` as an unforgeable per-instance
-// property, so the integration listener is not reachable from a unit
-// test that constructs a synthetic "trusted" event — we call the
-// handler directly instead.
-function handleUserChangeEvent(event: Event): void {
-  if (!event.isTrusted) {
-    return;
-  }
-  const target = event.target;
-  if (!(target instanceof HTMLInputElement) || target.type !== "checkbox") {
-    return;
-  }
-  if (target.getAttribute(CLEARED_ATTR) !== null) {
-    target.removeAttribute(CLEARED_ATTR);
-  }
-}
-
-export const __handleUserChangeEventForTesting = handleUserChangeEvent;
 
 function uncheck(checkbox: HTMLInputElement): void {
   getNativeCheckedSetter()?.call(checkbox, false);
@@ -202,8 +112,18 @@ const watcher = createSubtreeWatcher({
   },
 });
 
+function requestDefenseInjection(): void {
+  // Service worker may be asleep / receiver not yet ready; swallow rejection
+  // so unhandled-promise warnings don't surface on every page load. The
+  // defense itself short-circuits on `__abs_checkout_checkbox_defense_installed`,
+  // so re-requests on the same document are no-ops in the page world.
+  chrome.runtime.sendMessage(INJECT_DEFENSE_MESSAGE).catch(() => {
+    // noop
+  });
+}
+
 function apply(root: ParentNode): void {
-  installCheckedDefensePatch();
+  requestDefenseInjection();
   scanAndClear(root);
   watcher.start(root);
 }
@@ -218,3 +138,5 @@ export const checkoutCheckboxSanitizeRule = {
     watcher.stop();
   },
 } satisfies Rule;
+
+export { INJECT_DEFENSE_MESSAGE };

--- a/extension/src/rules/checkout-checkbox-sanitize.ts
+++ b/extension/src/rules/checkout-checkbox-sanitize.ts
@@ -120,7 +120,42 @@ function installCheckedDefensePatch(): void {
       nativeSetter.call(this, value);
     },
   });
+
+  // Release the defense on genuine user interaction. Without this, a
+  // controlled React/Vue checkbox would visibly flicker on a real click:
+  // native activation toggles `.checked` to true (bypassing our setter),
+  // the framework's onChange schedules `setState(true)` → reconcile →
+  // `node.checked = true`, and the patch would revert to false because
+  // the marker is still present. Running in capture phase guarantees
+  // the marker is gone before any framework handler runs, so the
+  // framework's reconcile sticks.
+  document.addEventListener("change", handleUserChangeEvent, {
+    capture: true,
+  });
 }
+
+// Gated on `isTrusted` so synthetic dispatches from page scripts
+// (including our own `uncheck` change event and any `element.click()`
+// call from page JS) do not release the lock — only real user gestures
+// and WebDriver/CDP-driven clicks do. Exported under a test-only name
+// because jsdom installs `isTrusted` as an unforgeable per-instance
+// property, so the integration listener is not reachable from a unit
+// test that constructs a synthetic "trusted" event — we call the
+// handler directly instead.
+function handleUserChangeEvent(event: Event): void {
+  if (!event.isTrusted) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement) || target.type !== "checkbox") {
+    return;
+  }
+  if (target.getAttribute(CLEARED_ATTR) !== null) {
+    target.removeAttribute(CLEARED_ATTR);
+  }
+}
+
+export const __handleUserChangeEventForTesting = handleUserChangeEvent;
 
 function uncheck(checkbox: HTMLInputElement): void {
   getNativeCheckedSetter()?.call(checkbox, false);

--- a/skills/agent-browser-shield/SKILL.md
+++ b/skills/agent-browser-shield/SKILL.md
@@ -55,7 +55,11 @@ surfaces **before you see the page**.
 3. **Re-check required checkboxes on `/cart`, `/checkout`, `/basket`, `/bag`,
    `/payment`, `/order` (and sub-paths).** Every pre-checked box was cleared.
    Before submitting, explicitly re-check terms-of-service, ship-to-billing, age
-   confirmation, and any other genuinely-required agreements.
+   confirmation, and any other genuinely-required agreements. Drive the toggle
+   through a click (the standard Playwright / CDP / `element.click()` path) —
+   the extension actively defends the cleared state against direct
+   `input.checked = true` writes so framework re-renders don't silently restore
+   pre-selected add-ons.
 
 4. **Text revealed from `reviews-redact`, `comments-redact`,
    `prompt-injection-redact`, or `encoded-payload-redact` placeholders is


### PR DESCRIPTION
## Summary

Closes audit item #13 from #203. `checkout-checkbox-sanitize` previously
cleared pre-checked boxes once at scan time but never defended against
the page re-checking them: a React controlled input re-renders
`node.checked = true` from component state on every reconcile, and a
single `setState({ optIn: true })` after our pass would silently re-check
every pre-selected add-on.

## Architecture

The defense is a wrap on `HTMLInputElement.prototype.checked` plus a
capture-phase `change` listener that releases the lock on trusted user
gestures. Both pieces MUST live in the page world: page scripts
(React/Vue reconciles) hit the page world's own copy of the prototype,
which is a distinct object from the isolated-world copy a content script
sees. An isolated-world wrap is a no-op for the threat model.

The page-world bundle follows the established `webdriver-probe`
pattern — dynamic `chrome.scripting.registerContentScripts({ world:
"MAIN", runAt: "document_start", allFrames: true })` for navigations
after the rule is toggled on, plus a `chrome.scripting.executeScript`
fallback driven by the rule's `apply` to cover the tab the user was
already viewing.

### Page-world wrap

When `value === true` is written to a `checked` setter whose target
bears `[data-abs-cleared]` while the URL matches the checkout regex,
the wrap forwards `false` to the native setter instead. The marker is
the source of truth; the rule (in the isolated world) stamps it on
every box it unchecks, the wrap defends it, and the capture-phase
`change` listener removes it on the first trusted user gesture so a
controlled framework reconcile of `.checked = true` doesn't visibly
flicker a real-user click off the screen. Synthetic dispatches from
page scripts (`isTrusted === false`, including the rule's own `change`
event) do not release the lock.

### Escape hatches for legitimate re-checks

- A real user click, keyboard `Space`, or `<label>` click — dispatches
  a trusted `change` and releases the marker.
- `checkbox.click()` from a Playwright / CDP / WebDriver session — same
  trusted-event path.
- `checkbox.removeAttribute("data-abs-cleared")` then `.checked = true`
  as an explicit out-of-band escape.

## Files

- `extension/src/lib/checkout-checkbox-defense-source.ts` —
  dependency-free `installCheckoutCheckboxDefense(this: Window)`.
  Hard-codes the `data-abs-cleared` literal (the one principled
  exception to the `no-restricted-syntax` rule, since page-world code
  has no module imports) with a parity test asserting it tracks the
  registry constant. The URL gate is a regex parallel to
  `isCheckoutUrl`, also parity-tested.
- `extension/src/checkout-checkbox-defense.ts` — tiny build entry that
  calls `installCheckoutCheckboxDefense.call(globalThis)`.
- `extension/build.ts` — bundles the new entry alongside
  `webdriver-probe.ts`.
- `extension/src/lib/checkout-checkbox-defense-registration.ts` —
  registration/unregistration lifecycle, mirroring
  `webdriver-probe-registration.ts`.
- `extension/src/background.ts` — wires the registration into SW
  startup and handles `inject-checkout-checkbox-defense` for the
  current-tab fallback via `executeScript`.
- `extension/src/rules/checkout-checkbox-sanitize.ts` — `apply` now
  sends the inject message and keeps only the scan/uncheck/marker
  logic; the page-world wrap is no longer inline.
- `extension/knip.json` — declares the new build entry.
- `docs/src/content/docs/rules.md` — notes that the cleared state is
  held against framework re-renders but yields to real user / WebDriver
  clicks.
- `skills/agent-browser-shield/SKILL.md` item #3 — tells agents to
  drive the toggle through a click (the standard Playwright / CDP /
  `.click()` path) rather than `input.checked = true`.

## Test plan

- [x] `bun jest src/rules/__tests__/checkout-checkbox-sanitize
      src/lib/__tests__/checkout-checkbox-defense` — 60 tests pass
      across the four files, covering: scan/uncheck/marker logic, lazy
      subtree insertion, teardown, sendMessage fallback (including
      rejection handling), prototype-wrap revert/escape/marker-removal/
      URL-gate paths, listener untrusted-ignore, idempotency, parity
      assertions (CLEARED_ATTR literal + URL gate), and chrome.scripting
      registration lifecycle.
- [x] `bun jest` full suite — 1792 / 1792 pass (no regression in any
      other rule that touches `HTMLInputElement`).
- [x] `bun run check` (Biome + ESLint) clean.
- [x] `bun run typecheck` clean.
- [x] `bun run knip` clean.
- [x] `bun run build` — background-purity guard reports `ok (39
      canaries, no leaks)`. The page-world bundle ships as
      `checkout-checkbox-defense.js` and is invoked only via
      `chrome.scripting.executeScript` / `registerContentScripts`.
- [x] `bun run test:coverage` — statements 87.5%, branches 79.3%,
      functions 91.3%, lines 87.5% (above thresholds).
- [x] `pre-commit run --files …` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)