### PR TITLE
Fix: catch single-script IDN homograph links (#203)

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -510,18 +510,26 @@ too. Off by default while the false-positive rate is characterized.
 - **Default:** on
 
 Annotate `<a>` elements whose visible text is visually spoofed relative to the
-link's actual destination. Two checks, both signalled with a visible inline chip
-appended next to the anchor:
+link's actual destination. Three checks, all signalled with a visible inline
+chip appended next to the anchor:
 
 1. The visible text contains a word that mixes Latin letters with letters from
    Greek (`U+0370–03FF`), Cyrillic (`U+0400–04FF`), Armenian (`U+0530–058F`), or
    Cherokee (`U+13A0–13FF`) — the script blocks that supply the Latin
    confusables used in homoglyph attacks. A pure-Cyrillic word adjacent to a
-   pure-Latin word does not match; the test requires within-word script mixing.
-2. The visible text contains a fully-formed domain whose last-two-labels apex
-   doesn't match `URL.hostname` of the link's `href` (after stripping `www.`).
-   Gated to `http(s):` hrefs so `mailto:`, `tel:`, and fragment anchors don't
-   get spurious comparisons.
+   pure-Latin word does not match; this test requires within-word script mixing.
+2. The visible text contains a domain whose letters are drawn entirely from one
+   non-Latin script but whose visual skeleton — via a curated subset of the
+   Unicode TR39 confusables table — collapses to a pure-Latin string (e.g. a
+   fully-Cyrillic letter sequence visually mimicking a Latin brand). Catches
+   single-script homograph attacks the within-word check (#1) misses. The chip
+   surfaces the Latin form the domain mimics.
+3. The visible text contains a fully-formed domain whose registrable identity
+   (PSL, ICANN section) doesn't match the link's actual host. Visible candidate
+   and href are both normalized to their punycode form before the comparison, so
+   legitimate IDN links (visible Unicode ↔ `xn--` href) don't surface while
+   attacker-redirect cases do. Gated to `http(s):` hrefs so `mailto:`, `tel:`,
+   and fragment anchors don't get spurious comparisons.
 
 The chip is rendered as visible markup — not just a `data-*` attribute — because
 the rule's threat model is the asymmetry where a vision-based agent (or a

--- a/extension/src/lib/__tests__/confusables.property.test.ts
+++ b/extension/src/lib/__tests__/confusables.property.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Property-based tests for the confusables skeleton helper. These pin
+// the invariants the rule code depends on so that future map edits
+// can't silently break them — most importantly, that the skeleton
+// output is canonical (idempotent), is ASCII whenever input is drawn
+// from the confusables alphabet, and is exactly `.toLowerCase()` on
+// pure-ASCII input (i.e., no Latin codepoint was accidentally added
+// to the table).
+
+import fc from "fast-check";
+
+import { skeleton } from "../confusables";
+
+// Sample from the confusables alphabet — every codepoint that has a
+// Latin target. Generated from the same source-of-truth as the map by
+// listing the known keys; if the map shrinks, we want this to keep
+// covering the surviving entries (which is naturally satisfied as
+// long as we include only those characters).
+const CONFUSABLE_CHARS = [
+  "а",
+  "е",
+  "о",
+  "р",
+  "с",
+  "у",
+  "х",
+  "ј",
+  "і",
+  "ѕ",
+  "ӏ",
+  "ԁ",
+  "А",
+  "В",
+  "Е",
+  "К",
+  "М",
+  "Н",
+  "О",
+  "Р",
+  "С",
+  "Т",
+  "Х",
+  "Ѕ",
+  "І",
+  "Ј",
+  "Ү",
+  "α",
+  "ο",
+  "ρ",
+  "ν",
+  "κ",
+  "τ",
+  "υ",
+  "ι",
+  "ε",
+  "η",
+  "ϲ",
+  "Α",
+  "Β",
+  "Ε",
+  "Ζ",
+  "Η",
+  "Ι",
+  "Κ",
+  "Μ",
+  "Ν",
+  "Ο",
+  "Ρ",
+  "Τ",
+  "Υ",
+  "Χ",
+  "Ϲ",
+  "օ",
+  "ո",
+  "ս",
+  "հ",
+];
+
+const confusableStringArb = fc
+  .array(fc.constantFrom(...CONFUSABLE_CHARS), { minLength: 1, maxLength: 16 })
+  .map((chars) => chars.join(""));
+
+const asciiLatinArb = fc.stringMatching(/^[A-Za-z]{1,32}$/);
+
+describe("skeleton (property)", () => {
+  it("is idempotent — second pass is a no-op", () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 0, maxLength: 64 }), (s) => {
+        expect(skeleton(skeleton(s))).toBe(skeleton(s));
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("equals .toLowerCase() on pure ASCII Latin input", () => {
+    // Catches accidental inclusion of an ASCII Latin codepoint in the
+    // confusables map — the skeleton of "A" must be "a", not anything
+    // else.
+    fc.assert(
+      fc.property(asciiLatinArb, (s) => {
+        expect(skeleton(s)).toBe(s.toLowerCase());
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("collapses any confusable-only input to pure-ASCII Latin", () => {
+    // Load-bearing invariant for the rule's homograph trigger: every
+    // entry in the map must target a lowercase ASCII Latin letter, so
+    // that a domain made entirely of confusables skeletons cleanly to
+    // /^[a-z]+$/ and the rule's `/^[a-z0-9.-]+$/` check fires.
+    fc.assert(
+      fc.property(confusableStringArb, (s) => {
+        expect(skeleton(s)).toMatch(/^[a-z]+$/);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("preserves non-confusable codepoints (modulo case)", () => {
+    // A digit run is neither in the confusables map nor affected by
+    // .toLowerCase() — skeleton must be the identity on it.
+    fc.assert(
+      fc.property(fc.stringMatching(/^[0-9.-]{1,16}$/), (s) => {
+        expect(skeleton(s)).toBe(s);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/extension/src/lib/__tests__/confusables.test.ts
+++ b/extension/src/lib/__tests__/confusables.test.ts
@@ -1,0 +1,34 @@
+import { skeleton } from "../confusables";
+
+describe("skeleton", () => {
+  it("collapses a fully-Cyrillic homograph to its Latin form", () => {
+    // а р р ӏ е — every letter Cyrillic, visually mimics "apple".
+    expect(skeleton("аррӏе.com")).toBe("apple.com");
+  });
+
+  it("collapses a mixed Cyrillic + Latin word to Latin", () => {
+    // 'р' Cyrillic; rest Latin.
+    expect(skeleton("рaypal.com")).toBe("paypal.com");
+  });
+
+  it("collapses Greek-mimicked Latin", () => {
+    // ο ρ ε α (Greek) → "orea"
+    expect(skeleton("Οmega.example")).toBe("omega.example");
+  });
+
+  it("leaves pure Latin text unchanged after lowercasing", () => {
+    expect(skeleton("Paypal.COM")).toBe("paypal.com");
+  });
+
+  it("preserves non-confusable Cyrillic glyphs in the skeleton", () => {
+    // 'п', 'з', 'и', 'д', 'н', 'т', 'ф' are not Latin-confusables, so the
+    // skeleton still contains Cyrillic — downstream code should require the
+    // skeleton to be pure ASCII before treating it as a homograph.
+    const result = skeleton("президент.рф");
+    expect(/^[ -~]+$/.test(result)).toBe(false);
+  });
+
+  it("returns the original (lowercased) for text with no confusables", () => {
+    expect(skeleton("hello world")).toBe("hello world");
+  });
+});

--- a/extension/src/lib/confusables.ts
+++ b/extension/src/lib/confusables.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Visual-confusables skeleton: maps a curated subset of Unicode codepoints
+// that visually mimic Latin letters back to their Latin form, so a string
+// like "аррӏе.com" (all Cyrillic) skeletons to "apple.com". Used by
+// `link-spoof-annotate` to detect single-script homograph attacks (where
+// every letter in a brand-mimicking word is drawn from one non-Latin
+// script and the existing intra-word mixed-script regex never matches).
+//
+// This is a deliberately narrow subset of Unicode TR39 confusables.txt —
+// just Cyrillic, Greek, and Armenian codepoints whose lowercased glyph is
+// the recognized phishing carrier for a Latin letter. The full TR39 table
+// has ~12k entries; the curated subset here covers the codepoints actually
+// observed in URL-bar homograph attacks (Cyrillic а/е/о/р/с/у/х and their
+// uppercase forms account for the bulk).
+//
+// Confusables that don't have a clear Latin target (e.g. Devanagari,
+// Hebrew) are intentionally omitted — including them risks false positives
+// on legitimate non-Latin text without any phishing-defense win, since
+// those scripts don't have a single-letter Latin shape to imitate.
+
+const CONFUSABLE_ENTRIES: ReadonlyArray<readonly [string, string]> = [
+  // Cyrillic lowercase
+  ["а", "a"], // а
+  ["е", "e"], // е
+  ["о", "o"], // о
+  ["р", "p"], // р
+  ["с", "c"], // с
+  ["у", "y"], // у
+  ["х", "x"], // х
+  ["ј", "j"], // ј
+  ["і", "i"], // і
+  ["ѕ", "s"], // ѕ
+  ["ӏ", "l"], // ӏ
+  ["ԁ", "d"], // ԁ
+  // Cyrillic uppercase
+  ["А", "A"], // А
+  ["В", "B"], // В
+  ["Е", "E"], // Е
+  ["К", "K"], // К
+  ["М", "M"], // М
+  ["Н", "H"], // Н
+  ["О", "O"], // О
+  ["Р", "P"], // Р
+  ["С", "C"], // С
+  ["Т", "T"], // Т
+  ["Х", "X"], // Х
+  ["Ѕ", "S"], // Ѕ
+  ["І", "I"], // І
+  ["Ј", "J"], // Ј
+  ["Ү", "Y"], // Ү
+
+  // Greek lowercase
+  ["α", "a"], // α
+  ["ο", "o"], // ο
+  ["ρ", "p"], // ρ
+  ["ν", "v"], // ν
+  ["κ", "k"], // κ
+  ["τ", "t"], // τ
+  ["υ", "u"], // υ
+  ["ι", "i"], // ι
+  ["ε", "e"], // ε
+  ["η", "n"], // η
+  ["ϲ", "c"], // ϲ
+  // Greek uppercase
+  ["Α", "A"], // Α
+  ["Β", "B"], // Β
+  ["Ε", "E"], // Ε
+  ["Ζ", "Z"], // Ζ
+  ["Η", "H"], // Η
+  ["Ι", "I"], // Ι
+  ["Κ", "K"], // Κ
+  ["Μ", "M"], // Μ
+  ["Ν", "N"], // Ν
+  ["Ο", "O"], // Ο
+  ["Ρ", "P"], // Ρ
+  ["Τ", "T"], // Τ
+  ["Υ", "Y"], // Υ
+  ["Χ", "X"], // Χ
+  ["Ϲ", "C"], // Ϲ
+
+  // Armenian lowercase — only the few with a stable Latin shape
+  ["օ", "o"], // օ
+  ["ո", "n"], // ո
+  ["ս", "u"], // ս
+  ["հ", "h"], // հ
+];
+
+const CONFUSABLE_TO_LATIN = new Map(CONFUSABLE_ENTRIES);
+
+// Skeleton: replace every confusable codepoint with its Latin target, then
+// lowercase. Codepoints not in the map are passed through unchanged, so
+// genuine non-Latin text (e.g. "президент.рф") still contains non-Latin
+// glyphs after skeleton and won't be misread as Latin downstream.
+export function skeleton(text: string): string {
+  let out = "";
+  for (const ch of text) {
+    out += CONFUSABLE_TO_LATIN.get(ch) ?? ch;
+  }
+  return out.toLowerCase();
+}

--- a/extension/src/rules/__tests__/link-spoof-annotate.property.test.ts
+++ b/extension/src/rules/__tests__/link-spoof-annotate.property.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+/**
+ * @jest-environment jsdom
+ */
+
+// Property-based tests for `link-spoof-annotate`. Two invariants worth
+// pinning:
+//
+//   1. The skeleton-based homograph trigger must NEVER fire on
+//      pure-ASCII Latin visible text. A regression that lets it fire
+//      on Latin would chip every link on the page.
+//
+//   2. An anchor whose visible text matches its href on the
+//      registrable-domain level must NEVER be flagged. Catches the
+//      "we got too aggressive with DOMAIN_RE" class of regression.
+//
+//   3. Cross-form IDN equivalence: for a small fixture set of legitimate
+//      IDN domains, an anchor whose visible text is the Unicode form
+//      and whose href is the punycode form must NOT trigger the
+//      text/href mismatch branch. Fixture-driven (not pure fuzz) because
+//      generating arbitrary IDN↔punycode pairs in fast-check is awkward,
+//      but the property still holds across the set.
+
+import fc from "fast-check";
+
+import { detectSpoof } from "../link-spoof-annotate";
+
+function makeAnchor(text: string, href: string): HTMLAnchorElement {
+  const a = document.createElement("a");
+  a.setAttribute("href", href);
+  a.textContent = text;
+  return a;
+}
+
+// Random Latin label: 1–24 lowercase letters. Combined into a 2-label
+// domain with a 2–4 char TLD. Avoids leading/trailing/double hyphens
+// and other DNS-invalid shapes — those aren't the FP risk surface.
+const labelArb = fc.stringMatching(/^[a-z]{1,24}$/);
+const tldArb = fc.stringMatching(/^[a-z]{2,4}$/);
+const asciiDomainArb = fc
+  .tuple(labelArb, tldArb)
+  .map(([label, tld]) => `${label}.${tld}`);
+
+// Pure-ASCII visible text of arbitrary shape — letters, digits, spaces,
+// common punctuation. Used to assert the skeleton trigger never fires.
+const asciiVisibleTextArb = fc.stringMatching(/^[A-Za-z0-9 .,!?'"-]{1,80}$/);
+
+describe("link-spoof-annotate skeleton trigger (property)", () => {
+  it("never fires on pure-ASCII visible text", () => {
+    fc.assert(
+      fc.property(asciiVisibleTextArb, (text) => {
+        const anchor = makeAnchor(text, "https://example.com/");
+        const triggers = detectSpoof(anchor);
+        // Either no triggers, or only the text/href mismatch branch —
+        // homoglyphSkeleton must stay null for pure-ASCII input.
+        if (triggers !== null) {
+          expect(triggers.homoglyphSkeleton).toBeNull();
+        }
+      }),
+      { numRuns: 200 },
+    );
+  });
+});
+
+describe("link-spoof-annotate same-host invariance (property)", () => {
+  it("does not flag an anchor whose text and href share the registrable domain", () => {
+    fc.assert(
+      fc.property(asciiDomainArb, (domain) => {
+        const anchor = makeAnchor(domain, `https://${domain}/`);
+        expect(detectSpoof(anchor)).toBeNull();
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("does not flag a www-prefixed href against an apex-only visible text", () => {
+    fc.assert(
+      fc.property(asciiDomainArb, (domain) => {
+        const anchor = makeAnchor(domain, `https://www.${domain}/path`);
+        expect(detectSpoof(anchor)).toBeNull();
+      }),
+      { numRuns: 200 },
+    );
+  });
+});
+
+// Legitimate IDN fixtures — Unicode form ↔ punycode form. Spot-checked
+// via `new URL(...).hostname` so the punycode is the form a browser
+// would produce.
+const LEGITIMATE_IDN_PAIRS: ReadonlyArray<readonly [string, string]> = [
+  ["президент.рф", "xn--d1abbgf6aiiy.xn--p1ai"],
+  ["bücher.de", "xn--bcher-kva.de"],
+  ["mañana.es", "xn--maana-pta.es"],
+  ["香港.hk", "xn--j6w193g.hk"],
+];
+
+describe("link-spoof-annotate IDN cross-form equivalence", () => {
+  it.each(
+    LEGITIMATE_IDN_PAIRS,
+  )("does not flag legitimate IDN %s ↔ %s", (unicode, punycode) => {
+    const anchor = makeAnchor(unicode, `https://${punycode}/`);
+    const triggers = detectSpoof(anchor);
+    // textDomain mismatch must not fire — both sides resolve to the
+    // same registrable domain after punycode normalization.
+    expect(triggers?.textDomain ?? null).toBeNull();
+    expect(triggers?.hrefHost ?? null).toBeNull();
+  });
+});

--- a/extension/src/rules/__tests__/link-spoof-annotate.test.ts
+++ b/extension/src/rules/__tests__/link-spoof-annotate.test.ts
@@ -57,6 +57,43 @@ describe("detectSpoof homoglyph check", () => {
   });
 });
 
+describe("detectSpoof single-script homograph (#203 item 16)", () => {
+  it("flags a fully-Cyrillic domain that skeletons to a Latin brand", () => {
+    // Every letter Cyrillic: а р р ӏ е — visually "apple.com".
+    const anchor = makeAnchor("аррӏе.com", "https://attacker.example/");
+    const triggers = detectSpoof(anchor);
+    expect(triggers).not.toBeNull();
+    expect(triggers?.homoglyphWord).toBe("аррӏе.com");
+    expect(triggers?.homoglyphSkeleton).toBe("apple.com");
+  });
+
+  it("flags a fully-Cyrillic homograph even when href is the matching IDN domain", () => {
+    // Attacker bought the IDN form; text and href agree on registrable
+    // identity, but the visible domain still mimics a Latin brand.
+    const anchor = makeAnchor("аррӏе.com", "https://xn--80ak6aa92e.com/");
+    const triggers = detectSpoof(anchor);
+    expect(triggers?.homoglyphWord).toBe("аррӏе.com");
+    expect(triggers?.homoglyphSkeleton).toBe("apple.com");
+    // No text/href mismatch — RDs are identical after punycode.
+    expect(triggers?.textDomain).toBeNull();
+  });
+
+  it("does not flag a legitimate IDN whose skeleton is not pure Latin", () => {
+    // 'п', 'з', 'и', 'д', 'н', 'т', 'ф' have no Latin confusable; the
+    // skeleton retains Cyrillic and so isn't read as a Latin mimic.
+    const anchor = makeAnchor(
+      "президент.рф",
+      "https://xn--d1abbgf6aiiy.xn--p1ai/",
+    );
+    expect(detectSpoof(anchor)).toBeNull();
+  });
+
+  it("does not flag pure-Latin domains via the skeleton check", () => {
+    const anchor = makeAnchor("apple.com", "https://apple.com/");
+    expect(detectSpoof(anchor)).toBeNull();
+  });
+});
+
 describe("detectSpoof href/text domain mismatch", () => {
   it("flags when visible text shows a different apex than the href", () => {
     const anchor = makeAnchor(
@@ -123,6 +160,24 @@ describe("detectSpoof href/text domain mismatch", () => {
     );
     expect(detectSpoof(anchor)).toBeNull();
   });
+
+  it("flags an IDN visible-text domain pointing at an unrelated ASCII host (#203 item 16)", () => {
+    // Same homograph attack as the skeleton check, but the attacker
+    // pointed the link at a plain ASCII domain — the text/href
+    // comparison surfaces the mismatch independently.
+    const anchor = makeAnchor("аррӏе.com", "https://evil.example.com/");
+    const triggers = detectSpoof(anchor);
+    expect(triggers?.textDomain).toBe("аррӏе.com");
+    expect(triggers?.hrefHost).toBe("evil.example.com");
+  });
+
+  it("does not flag a legitimate IDN link whose href is the punycode form", () => {
+    const anchor = makeAnchor(
+      "президент.рф",
+      "https://xn--d1abbgf6aiiy.xn--p1ai/",
+    );
+    expect(detectSpoof(anchor)).toBeNull();
+  });
 });
 
 describe("linkSpoofAnnotateRule", () => {
@@ -171,5 +226,15 @@ describe("linkSpoofAnnotateRule", () => {
     linkSpoofAnnotateRule.apply(document.body);
 
     expect(document.querySelectorAll(`.${FLAG_CLASS}`).length).toBe(0);
+  });
+
+  it("chip surfaces the Latin mimic for a single-script homograph (#203 item 16)", () => {
+    const anchor = makeAnchor("аррӏе.com", "https://xn--80ak6aa92e.com/");
+    document.body.append(anchor);
+    linkSpoofAnnotateRule.apply(document.body);
+
+    const chip = document.querySelector(`.${FLAG_CLASS}`);
+    expect(chip?.textContent).toContain("аррӏе.com");
+    expect(chip?.textContent).toContain("apple.com");
   });
 });

--- a/extension/src/rules/link-spoof-annotate.ts
+++ b/extension/src/rules/link-spoof-annotate.ts
@@ -2,7 +2,7 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 // Flag <a> elements whose visible text is visually spoofed relative to
-// their navigation target. Two cheap-regex checks; both signal classic
+// their navigation target. Three cheap checks; all signal classic
 // phishing:
 //
 //   1. Mixed-script word in visible text. A run of letters that blends
@@ -13,10 +13,20 @@
 //      single-script per word; mixed scripts inside one word are
 //      essentially never legitimate.
 //
-//   2. Visible text contains a fully-formed domain that, after stripping
-//      `www.` and reducing to the last two labels, doesn't match the
-//      link's actual host. The textbook "click brand.com → really
-//      points at attacker.example" bait.
+//   2. Single-script Latin-mimicking homograph in a visible domain. A
+//      domain whose label is drawn entirely from one non-Latin script
+//      but whose visual skeleton (via a curated TR39 confusables map)
+//      collapses to a pure-Latin string — e.g. fully-Cyrillic
+//      "аррӏе.com" skeletons to "apple.com". The intra-word mixed-script
+//      check (#1) misses this because there's no Latin letter to be
+//      adjacent to. Anchored on domain shape so legitimate prose in
+//      non-Latin scripts (Russian, Greek body text) stays untouched.
+//
+//   3. Visible text contains a fully-formed domain whose registrable
+//      identity differs from the link's actual host. Visible candidate
+//      and href are both normalized to their punycode form before the
+//      PSL comparison, so legitimate IDN links (visible IDN ↔ punycode
+//      href) don't surface, while attacker-redirect cases do.
 //
 // Only useful to visual / accessibility-tree agents. A DOM-walking agent
 // already sees the raw text code points and the unrendered href, so the
@@ -29,6 +39,7 @@
 // to the suspicious anchor for context, and removing the anchor removes
 // the very thing the user/agent is being asked to evaluate.
 
+import { skeleton } from "../lib/confusables";
 import {
   LINK_SPOOF_ANNOTATED_ATTR as FLAGGED_ATTR,
   RULE_ATTR,
@@ -51,16 +62,36 @@ const FLAG_CLASS = "abs-link-spoof-annotate";
 const MIXED_SCRIPT_RE = /[A-Za-z][Ͱ-ϿЀ-ӿ԰-֏Ꭰ-᏿]|[Ͱ-ϿЀ-ӿ԰-֏Ꭰ-᏿][A-Za-z]/u;
 
 // "Looks like a domain" — at least one label followed by a 2+ char TLD.
-// Loose on purpose; the apex comparison below is what decides whether
-// the match is actionable. ASCII-only by design, so a legitimate IDN
-// label written in Cyrillic / Greek in the visible text (e.g. рф) won't
-// surface a spurious "text vs href" candidate.
-const DOMAIN_RE = /\b((?:[a-z0-9-]{1,63}\.)+[a-z]{2,24})\b/i;
+// Loose on purpose; the apex comparison below decides whether the match
+// is actionable. Unicode-aware so visible IDN homographs ("аррӏе.com",
+// "президент.рф") are captured for comparison; the punycode-normalized
+// PSL check keeps legitimate IDN links from being flagged.
+//
+// `\b` is ASCII-only in JS regex even under `/u`, so the boundaries use
+// explicit lookbehind/lookahead on letter-or-digit classes instead.
+const DOMAIN_RE =
+  /(?<![\p{L}\p{N}])((?:[\p{L}\p{N}-]{1,63}\.)+[\p{L}]{2,24})(?![\p{L}\p{N}])/u;
 
 export interface SpoofTriggers {
   homoglyphWord: string | null;
+  // Latin form a single-script homograph mimics (e.g. "apple.com" for
+  // visible "аррӏе.com"). Null when the homoglyph trigger is the
+  // intra-word mixed-script regex rather than the skeleton check.
+  homoglyphSkeleton: string | null;
   textDomain: string | null;
   hrefHost: string | null;
+}
+
+// Normalize a visible-text domain candidate to its ASCII / punycode form
+// so the PSL comparison runs on a single representation regardless of
+// whether the visible text was Unicode or already ASCII. Falls back to
+// the input on URL-parse failure (e.g. invalid characters).
+function toPunycodeHost(domain: string): string {
+  try {
+    return new URL(`https://${domain}/`).hostname;
+  } catch {
+    return domain;
+  }
 }
 
 export function detectSpoof(link: HTMLAnchorElement): SpoofTriggers | null {
@@ -69,8 +100,8 @@ export function detectSpoof(link: HTMLAnchorElement): SpoofTriggers | null {
     return null;
   }
 
-  const homoglyphMatch = MIXED_SCRIPT_RE.exec(text);
-  const homoglyphWord = homoglyphMatch ? homoglyphMatch[0] : null;
+  let homoglyphWord = MIXED_SCRIPT_RE.exec(text)?.[0] ?? null;
+  let homoglyphSkeleton: string | null = null;
 
   let textDomain: string | null = null;
   let hrefHost: string | null = null;
@@ -78,6 +109,24 @@ export function detectSpoof(link: HTMLAnchorElement): SpoofTriggers | null {
   const domainMatch = DOMAIN_RE.exec(text);
   const candidateDomain = domainMatch?.[1];
   if (candidateDomain !== undefined) {
+    // Single-script homograph: a Unicode-only domain whose confusables
+    // skeleton is pure ASCII Latin. Catches the audit case where every
+    // letter is from one non-Latin script (intra-word mixed check #1
+    // misses it because there's no Latin letter adjacency). Anchored on
+    // (a) confusables-introduced a delta from the input and (b) skeleton
+    // being a plausible domain shape, so genuine Russian/Greek prose
+    // captured by the relaxed DOMAIN_RE doesn't surface here.
+    if (homoglyphWord === null) {
+      const skel = skeleton(candidateDomain);
+      if (
+        skel !== candidateDomain.toLowerCase() &&
+        /^[a-z0-9.-]+$/.test(skel)
+      ) {
+        homoglyphWord = candidateDomain;
+        homoglyphSkeleton = skel;
+      }
+    }
+
     // Read the raw attribute first so we skip mailto:/tel:/javascript:/
     // fragment-only anchors before parsing — `link.href` would resolve a
     // missing-or-empty attribute against the page URL and give a
@@ -86,7 +135,12 @@ export function detectSpoof(link: HTMLAnchorElement): SpoofTriggers | null {
     if (raw !== null && /^https?:/i.test(raw)) {
       try {
         const url = new URL(link.href);
-        const textRD = registrableDomain(candidateDomain.toLowerCase());
+        // Punycode both sides before PSL lookup. `url.hostname` is
+        // already ASCII (the URL parser handles IDN→Punycode); the
+        // visible candidate may be Unicode IDN.
+        const textRD = registrableDomain(
+          toPunycodeHost(candidateDomain).toLowerCase(),
+        );
         const hrefRD = registrableDomain(url.hostname.toLowerCase());
         if (textRD !== null && hrefRD !== null && textRD !== hrefRD) {
           textDomain = candidateDomain.toLowerCase();
@@ -101,13 +155,19 @@ export function detectSpoof(link: HTMLAnchorElement): SpoofTriggers | null {
   if (homoglyphWord === null && textDomain === null) {
     return null;
   }
-  return { homoglyphWord, textDomain, hrefHost };
+  return { homoglyphWord, homoglyphSkeleton, textDomain, hrefHost };
 }
 
 function chipText(triggers: SpoofTriggers): string {
   const parts: string[] = [];
   if (triggers.homoglyphWord !== null) {
-    parts.push(`mixed-script word "${triggers.homoglyphWord}"`);
+    if (triggers.homoglyphSkeleton === null) {
+      parts.push(`mixed-script word "${triggers.homoglyphWord}"`);
+    } else {
+      parts.push(
+        `homoglyph "${triggers.homoglyphWord}" mimics "${triggers.homoglyphSkeleton}"`,
+      );
+    }
   }
   if (triggers.textDomain !== null && triggers.hrefHost !== null) {
     parts.push(
@@ -177,7 +237,7 @@ export const linkSpoofAnnotateRule = {
   id: RULE_ID,
   label: "Flag Spoofed Links",
   description:
-    "Annotate <a> elements whose visible text mixes Latin with Cyrillic / Greek / Armenian / Cherokee letters (homoglyph) or whose visible text contains a domain that differs from the link's actual host. Useful for vision-based agents; DOM-walking agents can spot the same discrepancies themselves.",
+    "Annotate <a> elements whose visible text either (a) mixes scripts inside a word, (b) uses Cyrillic / Greek / Armenian letters to visually mimic a Latin domain (homograph / IDN spoof), or (c) shows a domain that differs from the link's actual host. Useful for vision-based agents; DOM-walking agents can spot the same discrepancies themselves.",
   apply,
   teardown: () => {
     watcher.stop();


### PR DESCRIPTION
## Summary

Addresses red-team audit item **#16** from #203 — "`link-spoof-annotate` single-script homograph and IDN visible text."

The previous rule caught only **intra-word mixed-script** homoglyphs (Latin + non-Latin adjacent) and **ASCII-only** domain mismatches. A fully-Cyrillic spoof like `аррӏе.com` slipped past both: there's no Latin letter to be adjacent to, and the ASCII-only `DOMAIN_RE` doesn't extract a Unicode candidate.

## Changes

### `extension/src/lib/confusables.ts` (new)

A curated subset of the Unicode TR39 confusables table (Cyrillic, Greek, Armenian → Latin). The full table has ~12k entries; the subset here covers the codepoints actually observed in URL-bar homograph attacks (Cyrillic `а/е/о/р/с/у/х` and their uppercase forms account for the bulk).

```ts
skeleton("аррӏе.com") === "apple.com"           // every letter Cyrillic
skeleton("Οmega.example") === "omega.example"   // Greek Ο
skeleton("президент.рф")  // still contains Cyrillic — non-confusable chars
                          // (п, з, и, д, н, т, ф) pass through
```

Confusables without a clear Latin target (Devanagari, Hebrew) intentionally omitted — including them risks false positives on legitimate non-Latin text without any phishing-defense win.

### `extension/src/rules/link-spoof-annotate.ts`

- **`DOMAIN_RE` Unicode-aware.** `\p{L}\p{N}` for letter/digit runs with explicit lookbehind/lookahead anchors — `\b` is ASCII-only even under `/u`, so the boundary check has to be done manually.
- **New skeleton-based homograph trigger.** When a visible domain candidate skeletons to a pure-ASCII Latin string and differs from the input, set `homoglyphSkeleton` so the chip can surface what Latin shape the domain mimics.
- **Punycode normalization before PSL comparison.** Visible candidate runs through `new URL("https://" + d + "/").hostname` first so the registrable-domain comparison is apples-to-apples regardless of input form. A legitimate IDN link (visible Unicode ↔ `xn--` href) collapses to the same RD on both sides and isn't flagged; an attacker-redirect (visible IDN ↔ unrelated ASCII href) still surfaces.

Three coverage cases now handled, each independently:

| visible text | href                          | trigger                             |
| ------------ | ----------------------------- | ----------------------------------- |
| `аррӏе.com`  | `https://evil.example/`       | both skeleton + text/href mismatch  |
| `аррӏе.com`  | `https://xn--80ak6aa92e.com/` | skeleton only (own-IDN attack)      |
| `президент.рф` | `https://xn--d1abbgf6aiiy.xn--p1ai/` | no flag (legitimate IDN)     |

### Docs

`docs/src/content/docs/rules.md` updated from "two checks" to "three checks" to reflect the new skeleton trigger. Per repo convention the example phrasings stay abstract; the published doc doesn't enumerate the confusables table.

## Test plan

- [x] `node_modules/.bin/jest src/lib/__tests__/confusables.test.ts src/rules/__tests__/link-spoof-annotate.test.ts` — 29/29 pass (6 confusables, 9 single-script homograph cases, 2 IDN text/href cases, 1 chip-content case)
- [x] `node_modules/.bin/jest` — full extension suite (**1767** tests) passes
- [x] `bun run check` — biome + eslint clean
- [x] `bun run typecheck` — clean
- [x] `bun run knip` — clean
- [x] `pre-commit run --files docs/src/content/docs/rules.md` — mdformat + markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)