### PR TITLE
Fix: main-world shadow-root probe for definitive closed-shadow detection (#203)

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -479,28 +479,48 @@ the new threat.
 - **Default:** off
 - **Top frame only**
 
-Heuristically detect pages that render content inside closed shadow roots and
-prepend a screen-reader-only landmark noting that the extension cannot see
-inside those shadow trees. Complements the open-shadow-root coverage described
-in [Coverage scope](#coverage-scope) above by giving the agent a positive signal
-at read-time that a known blind spot is in use on this page.
+Detect pages that attach closed shadow roots and prepend a screen-reader-only
+landmark noting that the extension cannot see inside those shadow trees.
+Complements the open-shadow-root coverage described in
+[Coverage scope](#coverage-scope) above by giving the agent a positive signal at
+read-time that a known blind spot is in use on this page.
 
-Detection is necessarily heuristic: by spec, an element with `mode: "closed"` is
-indistinguishable from an element with no shadow root at all from outside
-JavaScript. The rule looks for the structural shape strongly correlated with
-"closed shadow host": an upgraded custom element (hyphenated tag name, defined
-in `customElements`) with no light-DOM children, no `host.shadowRoot`, and a
-non-zero rendered box. Built-in elements with UA shadow roots (`<input>`,
-`<details>`, `<video>`) are filtered out for free — their tag names contain no
-hyphen. Declarative shadow DOM with `shadowrootmode="closed"` is
-indistinguishable from imperative closed shadows after parsing and is not
-separately surfaced; the open variant of declarative shadow DOM is covered by
-the regular open-shadow plumbing described in [Coverage scope](#coverage-scope).
+Two detection paths feed the landmark:
 
-The landmark says "may contain content ABS cannot see," not "this is definitely
-a closed shadow root" — a custom element that renders via canvas, WebGL, or
-`::before` background-image with no actual shadow root will trip the heuristic
-too. Off by default while the false-positive rate is characterized.
+1. **Main-world probe (primary).** When the rule is enabled, a page-world wrap
+   over `Element.prototype.attachShadow` runs at `document_start`. Any call with
+   `mode: "closed"` dispatches a binary signal that the landmark listens for.
+   The wrap runs in the page's own JavaScript world because page-script
+   attachments hit the page's prototype copy, which is a distinct object from
+   the isolated-world copy the rule engine sees. No shadow contents are exposed
+   by the probe — only the binary "attachment happened" signal crosses worlds,
+   preserving the spec-mandated encapsulation of closed mode.
+
+2. **Structural heuristic (fallback).** Looks for the shape strongly correlated
+   with a closed shadow host: an upgraded custom element (hyphenated tag name,
+   defined in `customElements`) with no light-DOM children, no
+   `host.shadowRoot`, and a non-zero rendered box. Built-in elements with UA
+   shadow roots (`<input>`, `<details>`, `<video>`) are filtered out for free —
+   their tag names contain no hyphen. The heuristic covers the active tab
+   between toggle-on and the moment the probe injects into it; on subsequent
+   navigations the probe runs at `document_start` and the heuristic becomes
+   redundant.
+
+The heuristic path has a known false positive: a custom element that renders via
+canvas, WebGL, or `::before` background-image with no actual shadow root will
+trip it. The landmark text reads "may contain content ABS cannot see," not "this
+is definitely a closed shadow root." The main-world probe is definitive when
+both signals are available.
+
+Declarative shadow DOM with `shadowrootmode="closed"` is not surfaced by either
+path. The parser materializes the shadow without going through `attachShadow`,
+so the probe doesn't see it; and the materialized closed root is
+indistinguishable from "no shadow" from outside JS, so the heuristic can't catch
+it reliably either. The open variant of declarative shadow DOM is covered by the
+regular open-shadow plumbing described in [Coverage scope](#coverage-scope).
+
+Off by default while the false-positive rate of the heuristic path is
+characterized.
 
 ### Visual identity spoofing
 

--- a/extension/build.ts
+++ b/extension/build.ts
@@ -140,6 +140,15 @@ async function build(): Promise<void> {
       // `lib/checkout-checkbox-defense-source.ts` and
       // `lib/checkout-checkbox-defense-registration.ts`.
       join(SRC, "checkout-checkbox-defense.ts"),
+      // Standalone main-world bundle registered by the background worker
+      // whenever `closed-shadow-root-annotate` is enabled. Wraps
+      // `Element.prototype.attachShadow` and `setHTMLUnsafe` in the page
+      // world so page-script shadow attachments (which never touch the
+      // isolated-world copies of those prototypes) emit the events the
+      // `closed-shadow-root-annotate` and `shadow-roots` consumers rely
+      // on. See `lib/shadow-root-probe-source.ts` and
+      // `lib/shadow-root-probe-registration.ts`.
+      join(SRC, "shadow-root-probe.ts"),
     ],
     outdir: DIST,
     target: "browser",

--- a/extension/knip.json
+++ b/extension/knip.json
@@ -8,6 +8,7 @@
     "src/options.tsx",
     "src/webdriver-probe.ts",
     "src/checkout-checkbox-defense.ts",
+    "src/shadow-root-probe.ts",
     "eslint-rules/index.js"
   ],
   "project": ["src/**/*.{ts,tsx}", "scripts/**/*.ts", "eslint-rules/**/*.js"],

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -16,6 +16,8 @@ import type {
 import { subscribeEnforcementEnabled } from "./lib/enforcement";
 import { startClassifyPortListener } from "./lib/llm-background";
 import { log } from "./lib/log";
+import { startShadowRootProbeRegistration } from "./lib/shadow-root-probe-registration";
+import { installShadowRootProbe } from "./lib/shadow-root-probe-source";
 import { ruleStatesStorage } from "./lib/storage";
 import { startWebdriverProbeRegistration } from "./lib/webdriver-probe-registration";
 import { installProbe } from "./lib/webdriver-probe-source";
@@ -312,6 +314,33 @@ chrome.runtime.onMessage.addListener(
       return undefined;
     }
 
+    if (message.type === "inject-shadow-root-probe") {
+      const tabId = sender.tab?.id;
+      if (typeof tabId !== "number") {
+        return undefined;
+      }
+      const frameId = sender.frameId;
+      // Same shape as the other main-world fallbacks: the registered
+      // content script covers future navigations; this round-trip wraps
+      // attachShadow / setHTMLUnsafe on the tab the user was already
+      // viewing when they toggled `closed-shadow-root-annotate` on.
+      // installShadowRootProbe's `__abs_shadow_root_probe_installed`
+      // guard makes a redundant call a no-op in the page world.
+      chrome.scripting
+        .executeScript({
+          target: {
+            tabId,
+            frameIds: typeof frameId === "number" ? [frameId] : undefined,
+          },
+          world: "MAIN",
+          func: installShadowRootProbe,
+        })
+        .catch((error: unknown) => {
+          log("inject-shadow-root-probe executeScript failed", { error });
+        });
+      return undefined;
+    }
+
     if (message.type === "rule-count") {
       const tabId = sender.tab?.id;
       const frameId = sender.frameId;
@@ -422,3 +451,13 @@ startWebdriverProbeRegistration();
 // `node.checked = true` through the page's own prototype copy. See
 // `lib/checkout-checkbox-defense-registration.ts`.
 startCheckoutCheckboxDefenseRegistration();
+
+// Same lifecycle for `closed-shadow-root-annotate`'s page-world
+// shadow-root probe. Wraps `Element.prototype.attachShadow` and
+// `setHTMLUnsafe` in the page world so attachments issued by page
+// scripts (which hit the page's own prototype copies, not the
+// isolated-world ones the rule engine sees) emit the events the
+// isolated-world consumers in `lib/shadow-roots.ts` and
+// `rules/closed-shadow-root-annotate.ts` rely on. See
+// `lib/shadow-root-probe-registration.ts`.
+startShadowRootProbeRegistration();

--- a/extension/src/lib/__tests__/shadow-root-probe-registration.test.ts
+++ b/extension/src/lib/__tests__/shadow-root-probe-registration.test.ts
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Exercises the dynamic main-world content-script registration for the
+// shadow-root probe. Mirrors `webdriver-probe-registration.test.ts` —
+// the module syncs chrome.scripting state against (rule-enabled AND
+// enforcement-enabled), so the test covers the four corners plus the
+// no-op short-circuits when the desired state already matches.
+//
+// Identifiers are prefixed `shadowProbeReg`/`ShadowProbeReg` to avoid
+// colliding with the same shapes in the sibling
+// `webdriver-probe-registration.test.ts`. Both files have no
+// import/export statements, so TypeScript treats them as global scripts
+// under `tsconfig.test.json` and identical top-level names from
+// different test files merge. Biome's `noExportsInTest` rule blocks
+// the more conventional `export {}` script-to-module workaround.
+
+jest.mock("nanoid", () => ({ nanoid: () => "test-ref" }));
+jest.mock("abort-utils", () => ({
+  ReusableAbortController: class {
+    abort(): void {
+      // noop
+    }
+    get signal(): AbortSignal {
+      return new AbortController().signal;
+    }
+  },
+  onAbort: (): (() => void) => () => {
+    // noop
+  },
+}));
+
+const shadowProbeRegisterMock = chrome.scripting
+  .registerContentScripts as unknown as jest.Mock;
+const shadowProbeUnregisterMock = chrome.scripting
+  .unregisterContentScripts as unknown as jest.Mock;
+const shadowProbeGetRegisteredMock = chrome.scripting
+  .getRegisteredContentScripts as unknown as jest.Mock;
+
+interface ShadowProbeRegistrationModule {
+  startShadowRootProbeRegistration: () => void;
+}
+
+interface ShadowProbeRegisteredScript {
+  id: string;
+  matches: string[];
+  js: string[];
+  runAt: string;
+  world: string;
+  allFrames: boolean;
+}
+
+function shadowProbeFlushPromises(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+async function shadowProbeLoadModule(
+  overrides: Record<string, boolean>,
+  enforcementEnabled = true,
+  initiallyRegistered = false,
+): Promise<{ module: ShadowProbeRegistrationModule }> {
+  let module!: ShadowProbeRegistrationModule;
+
+  await jest.isolateModulesAsync(async () => {
+    process.env.EXTENSION_DEFAULT_OVERRIDES = JSON.stringify(overrides);
+
+    const registered: ShadowProbeRegisteredScript[] = initiallyRegistered
+      ? [
+          {
+            id: "closed-shadow-root-annotate-main-world",
+            matches: ["<all_urls>"],
+            js: ["shadow-root-probe.js"],
+            runAt: "document_start",
+            world: "MAIN",
+            allFrames: true,
+          },
+        ]
+      : [];
+
+    shadowProbeRegisterMock.mockImplementation(
+      (scripts: ShadowProbeRegisteredScript[]): Promise<void> => {
+        registered.push(...scripts);
+        return Promise.resolve();
+      },
+    );
+    shadowProbeUnregisterMock.mockImplementation(
+      (filter: { ids: string[] }): Promise<void> => {
+        for (const id of filter.ids) {
+          const index = registered.findIndex((script) => script.id === id);
+          if (index !== -1) {
+            registered.splice(index, 1);
+          }
+        }
+        return Promise.resolve();
+      },
+    );
+    shadowProbeGetRegisteredMock.mockImplementation(
+      (filter?: { ids?: string[] }): Promise<ShadowProbeRegisteredScript[]> => {
+        if (!filter?.ids) {
+          return Promise.resolve([...registered]);
+        }
+        return Promise.resolve(
+          registered.filter((script) => filter.ids?.includes(script.id)),
+        );
+      },
+    );
+
+    const enforcement = await import("../enforcement");
+    await enforcement.enforcementStorage.set(enforcementEnabled);
+
+    module = await import("../shadow-root-probe-registration");
+  });
+
+  return { module };
+}
+
+beforeEach(() => {
+  shadowProbeRegisterMock.mockReset();
+  shadowProbeUnregisterMock.mockReset();
+  shadowProbeGetRegisteredMock.mockReset();
+});
+
+afterEach(() => {
+  delete process.env.EXTENSION_DEFAULT_OVERRIDES;
+});
+
+describe("startShadowRootProbeRegistration", () => {
+  it("registers the main-world script on startup when the rule is enabled", async () => {
+    const { module } = await shadowProbeLoadModule({
+      "closed-shadow-root-annotate": true,
+    });
+
+    module.startShadowRootProbeRegistration();
+    await shadowProbeFlushPromises();
+
+    expect(shadowProbeRegisterMock).toHaveBeenCalledTimes(1);
+    const [scripts] = shadowProbeRegisterMock.mock.calls[0] as [
+      ShadowProbeRegisteredScript[],
+    ];
+    expect(scripts[0]).toMatchObject({
+      id: "closed-shadow-root-annotate-main-world",
+      matches: ["<all_urls>"],
+      js: ["shadow-root-probe.js"],
+      runAt: "document_start",
+      world: "MAIN",
+      allFrames: true,
+    });
+  });
+
+  it("does not register when the rule is disabled", async () => {
+    const { module } = await shadowProbeLoadModule({
+      "closed-shadow-root-annotate": false,
+    });
+
+    module.startShadowRootProbeRegistration();
+    await shadowProbeFlushPromises();
+
+    expect(shadowProbeRegisterMock).not.toHaveBeenCalled();
+    expect(shadowProbeUnregisterMock).not.toHaveBeenCalled();
+  });
+
+  it("unregisters when an already-registered script becomes ineligible", async () => {
+    const { module } = await shadowProbeLoadModule(
+      { "closed-shadow-root-annotate": false },
+      true,
+      /* initiallyRegistered */ true,
+    );
+
+    module.startShadowRootProbeRegistration();
+    await shadowProbeFlushPromises();
+
+    expect(shadowProbeUnregisterMock).toHaveBeenCalledWith({
+      ids: ["closed-shadow-root-annotate-main-world"],
+    });
+  });
+
+  it("does not re-register if the desired state already matches", async () => {
+    const { module } = await shadowProbeLoadModule(
+      { "closed-shadow-root-annotate": true },
+      true,
+      /* initiallyRegistered */ true,
+    );
+
+    module.startShadowRootProbeRegistration();
+    await shadowProbeFlushPromises();
+
+    expect(shadowProbeRegisterMock).not.toHaveBeenCalled();
+    expect(shadowProbeUnregisterMock).not.toHaveBeenCalled();
+  });
+
+  it("treats enforcement-off as if the rule were disabled", async () => {
+    const { module } = await shadowProbeLoadModule(
+      { "closed-shadow-root-annotate": true },
+      /* enforcementEnabled */ false,
+    );
+
+    module.startShadowRootProbeRegistration();
+    await shadowProbeFlushPromises();
+
+    expect(shadowProbeRegisterMock).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/lib/__tests__/shadow-root-probe-source.property.test.ts
+++ b/extension/src/lib/__tests__/shadow-root-probe-source.property.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment jsdom
+ */
+// Property tests for the page-world shadow-root probe. Two invariants:
+//
+//   1. Event counts equal call counts. For any random sequence of
+//      attachShadow / setHTMLUnsafe operations, the listener tally for
+//      each event kind matches the number of corresponding operations.
+//      Catches regressions where a wrap swallows events on some shape
+//      (e.g. forgets to fire on a no-op setHTMLUnsafe call).
+//   2. abs:shadow-discover detail.target is the operation's receiver.
+//      Catches regressions where a refactor passes the wrong reference
+//      (the resulting ShadowRoot vs. the host element, or document vs.
+//      the receiver).
+
+import fc from "fast-check";
+
+import { installShadowRootProbe } from "../shadow-root-probe-source";
+
+interface ProbeWindow {
+  __abs_shadow_root_probe_installed?: boolean;
+}
+
+const ORIGINAL_ATTACH_SHADOW = Element.prototype.attachShadow;
+interface ElementSetHTMLUnsafeCapable {
+  setHTMLUnsafe?: (this: Element, html: string) => void;
+}
+const ORIGINAL_ELEMENT_SET_HTML = (
+  Element.prototype as ElementSetHTMLUnsafeCapable
+).setHTMLUnsafe;
+
+function resetProbe(): void {
+  delete (globalThis as unknown as ProbeWindow)
+    .__abs_shadow_root_probe_installed;
+  Element.prototype.attachShadow = ORIGINAL_ATTACH_SHADOW;
+  if (ORIGINAL_ELEMENT_SET_HTML) {
+    (Element.prototype as ElementSetHTMLUnsafeCapable).setHTMLUnsafe =
+      ORIGINAL_ELEMENT_SET_HTML;
+  }
+}
+
+type Op =
+  | { kind: "attach-open"; hostIndex: number }
+  | { kind: "attach-closed"; hostIndex: number }
+  | { kind: "set-html"; hostIndex: number };
+
+const opArb = (hostCount: number): fc.Arbitrary<Op> =>
+  fc.oneof(
+    fc.record({
+      kind: fc.constant<"attach-open">("attach-open"),
+      hostIndex: fc.integer({ min: 0, max: hostCount - 1 }),
+    }),
+    fc.record({
+      kind: fc.constant<"attach-closed">("attach-closed"),
+      hostIndex: fc.integer({ min: 0, max: hostCount - 1 }),
+    }),
+    fc.record({
+      kind: fc.constant<"set-html">("set-html"),
+      hostIndex: fc.integer({ min: 0, max: hostCount - 1 }),
+    }),
+  );
+
+const sequenceArb = fc
+  .integer({ min: 1, max: 6 })
+  .chain((hostCount) =>
+    fc
+      .array(opArb(hostCount), { minLength: 1, maxLength: 16 })
+      .map((ops) => ({ hostCount, ops })),
+  );
+
+describe("installShadowRootProbe — property: event tally matches op tally", () => {
+  it("dispatches exactly one event per op of the matching kind", () => {
+    fc.assert(
+      fc.property(sequenceArb, ({ hostCount, ops }) => {
+        resetProbe();
+        document.body.innerHTML = "";
+        installShadowRootProbe.call(globalThis as unknown as Window);
+
+        const hosts = Array.from({ length: hostCount }, () => {
+          const host = document.createElement("div");
+          document.body.append(host);
+          return host;
+        });
+
+        const closedEvents: Event[] = [];
+        const discoverEvents: Array<CustomEvent<{ target?: unknown }>> = [];
+        const onClosed = (event: Event): void => {
+          closedEvents.push(event);
+        };
+        const onDiscover = (event: Event): void => {
+          discoverEvents.push(event as CustomEvent<{ target?: unknown }>);
+        };
+        document.addEventListener("abs:closed-shadow-attached", onClosed);
+        document.addEventListener("abs:shadow-discover", onDiscover);
+
+        // Track which hosts already received a shadow — attachShadow
+        // throws on a second attach to the same host. Skip duplicates
+        // so the property assertion compares against the number of
+        // *successful* attach calls, not the number of attempts.
+        const attached = new Set<number>();
+        let attachOpenCount = 0;
+        let attachClosedCount = 0;
+        let setHtmlCount = 0;
+
+        for (const op of ops) {
+          const host = hosts[op.hostIndex];
+          if (!host) {
+            continue;
+          }
+          if (op.kind === "attach-open") {
+            if (attached.has(op.hostIndex)) {
+              continue;
+            }
+            attached.add(op.hostIndex);
+            host.attachShadow({ mode: "open" });
+            attachOpenCount += 1;
+          } else if (op.kind === "attach-closed") {
+            if (attached.has(op.hostIndex)) {
+              continue;
+            }
+            attached.add(op.hostIndex);
+            host.attachShadow({ mode: "closed" });
+            attachClosedCount += 1;
+          } else {
+            // set-html: only run if jsdom-extras polyfilled setHTMLUnsafe.
+            if (
+              typeof (Element.prototype as ElementSetHTMLUnsafeCapable)
+                .setHTMLUnsafe !== "function"
+            ) {
+              continue;
+            }
+            host.setHTMLUnsafe("<span>plain</span>");
+            setHtmlCount += 1;
+          }
+        }
+
+        expect(closedEvents).toHaveLength(attachClosedCount);
+        // Open attach AND set-html both fire abs:shadow-discover, so the
+        // total tally is the sum.
+        expect(discoverEvents).toHaveLength(attachOpenCount + setHtmlCount);
+
+        document.removeEventListener("abs:closed-shadow-attached", onClosed);
+        document.removeEventListener("abs:shadow-discover", onDiscover);
+      }),
+      { numRuns: 50 },
+    );
+  });
+});
+
+describe("installShadowRootProbe — property: discover target equals receiver", () => {
+  it("event.detail.target is exactly the host element for attachShadow open", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 8 }), (count) => {
+        resetProbe();
+        document.body.innerHTML = "";
+        installShadowRootProbe.call(globalThis as unknown as Window);
+
+        const hosts = Array.from({ length: count }, () => {
+          const host = document.createElement("div");
+          document.body.append(host);
+          return host;
+        });
+
+        const received: unknown[] = [];
+        const onDiscover = (event: Event): void => {
+          const detail = (event as CustomEvent<{ target?: unknown }>).detail;
+          received.push(detail.target);
+        };
+        document.addEventListener("abs:shadow-discover", onDiscover);
+
+        for (const host of hosts) {
+          host.attachShadow({ mode: "open" });
+        }
+
+        expect(received).toEqual(hosts);
+
+        document.removeEventListener("abs:shadow-discover", onDiscover);
+      }),
+      { numRuns: 20 },
+    );
+  });
+});

--- a/extension/src/lib/__tests__/shadow-root-probe-source.test.ts
+++ b/extension/src/lib/__tests__/shadow-root-probe-source.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @jest-environment jsdom
+ */
+// Tests for the page-world shadow-root probe. The probe function runs
+// inside the page world in production; jsdom's single-world model means
+// installing it in the test world exercises the same code path.
+//
+// Each test isolates the probe state by clearing the FLAG sentinel and
+// restoring the originals captured at module load. Without this the
+// second test would observe the wraps from the first.
+
+import { installShadowRootProbe } from "../shadow-root-probe-source";
+
+interface ProbeWindow {
+  __abs_shadow_root_probe_installed?: boolean;
+}
+
+interface ElementSetHTMLUnsafeCapable {
+  setHTMLUnsafe?: (this: Element, html: string) => void;
+}
+interface ShadowSetHTMLUnsafeCapable {
+  setHTMLUnsafe?: (this: ShadowRoot, html: string) => void;
+}
+
+const ORIGINAL_ATTACH_SHADOW = Element.prototype.attachShadow;
+const ORIGINAL_ELEMENT_SET_HTML = (
+  Element.prototype as ElementSetHTMLUnsafeCapable
+).setHTMLUnsafe;
+const ORIGINAL_SHADOW_SET_HTML = (
+  ShadowRoot.prototype as ShadowSetHTMLUnsafeCapable
+).setHTMLUnsafe;
+
+function resetProbeFlag(): void {
+  delete (globalThis as unknown as ProbeWindow)
+    .__abs_shadow_root_probe_installed;
+}
+
+function captureEvents(type: string): {
+  events: Array<CustomEvent<unknown>>;
+  off: () => void;
+} {
+  const events: Array<CustomEvent<unknown>> = [];
+  const handler = (event: Event): void => {
+    events.push(event as CustomEvent<unknown>);
+  };
+  document.addEventListener(type, handler);
+  return {
+    events,
+    off: () => {
+      document.removeEventListener(type, handler);
+    },
+  };
+}
+
+function restorePrototypes(): void {
+  Element.prototype.attachShadow = ORIGINAL_ATTACH_SHADOW;
+  // exactOptionalPropertyTypes: only re-attach setHTMLUnsafe if jsdom
+  // (or its polyfill) provided one originally. A bare prototype without
+  // the method is a valid configuration; restoring `undefined` would
+  // be a type error and a worse runtime state than leaving the slot
+  // missing.
+  if (ORIGINAL_ELEMENT_SET_HTML) {
+    (Element.prototype as ElementSetHTMLUnsafeCapable).setHTMLUnsafe =
+      ORIGINAL_ELEMENT_SET_HTML;
+  }
+  if (ORIGINAL_SHADOW_SET_HTML) {
+    (ShadowRoot.prototype as ShadowSetHTMLUnsafeCapable).setHTMLUnsafe =
+      ORIGINAL_SHADOW_SET_HTML;
+  }
+}
+
+beforeEach(() => {
+  resetProbeFlag();
+  restorePrototypes();
+  document.body.innerHTML = "";
+});
+
+afterAll(() => {
+  resetProbeFlag();
+  restorePrototypes();
+});
+
+describe("installShadowRootProbe — attachShadow wrap", () => {
+  it("dispatches abs:closed-shadow-attached on a closed attachShadow call", () => {
+    installShadowRootProbe.call(globalThis as unknown as Window);
+    const capture = captureEvents("abs:closed-shadow-attached");
+
+    const host = document.createElement("div");
+    host.attachShadow({ mode: "closed" });
+
+    expect(capture.events).toHaveLength(1);
+    capture.off();
+  });
+
+  it("dispatches abs:shadow-discover with the host on an open attachShadow call", () => {
+    installShadowRootProbe.call(globalThis as unknown as Window);
+    const capture = captureEvents("abs:shadow-discover");
+
+    const host = document.createElement("div");
+    host.attachShadow({ mode: "open" });
+
+    expect(capture.events).toHaveLength(1);
+    const detail = capture.events[0]?.detail as
+      | { target?: unknown }
+      | undefined;
+    expect(detail?.target).toBe(host);
+    capture.off();
+  });
+
+  it("returns the real ShadowRoot regardless of mode", () => {
+    installShadowRootProbe.call(globalThis as unknown as Window);
+
+    const openHost = document.createElement("div");
+    const openRoot = openHost.attachShadow({ mode: "open" });
+    expect(openRoot).toBe(openHost.shadowRoot);
+
+    const closedHost = document.createElement("div");
+    const closedRoot = closedHost.attachShadow({ mode: "closed" });
+    // The page caller still receives the closed root — only `host.shadowRoot`
+    // returns null from outside.
+    expect(closedRoot).toBeInstanceOf(ShadowRoot);
+    expect(closedHost.shadowRoot).toBeNull();
+  });
+
+  it("does not fire the closed-shadow signal on an open attach", () => {
+    installShadowRootProbe.call(globalThis as unknown as Window);
+    const capture = captureEvents("abs:closed-shadow-attached");
+
+    document.createElement("div").attachShadow({ mode: "open" });
+
+    expect(capture.events).toHaveLength(0);
+    capture.off();
+  });
+});
+
+describe("installShadowRootProbe — setHTMLUnsafe wraps", () => {
+  it("dispatches abs:shadow-discover with the receiver on Element.setHTMLUnsafe", () => {
+    if (
+      typeof (Element.prototype as ElementSetHTMLUnsafeCapable)
+        .setHTMLUnsafe !== "function"
+    ) {
+      // jsdom build without setHTMLUnsafe — skip; the jsdom-extras shim
+      // ships one in the actual content-script test runner, but a bare
+      // probe test shouldn't depend on it.
+      return;
+    }
+    installShadowRootProbe.call(globalThis as unknown as Window);
+    const capture = captureEvents("abs:shadow-discover");
+
+    const host = document.createElement("div");
+    document.body.append(host);
+    host.setHTMLUnsafe("<span>plain</span>");
+
+    expect(capture.events).toHaveLength(1);
+    const detail = capture.events[0]?.detail as
+      | { target?: unknown }
+      | undefined;
+    expect(detail?.target).toBe(host);
+    capture.off();
+  });
+
+  it("dispatches abs:shadow-discover with the shadow on ShadowRoot.setHTMLUnsafe", () => {
+    if (
+      typeof (ShadowRoot.prototype as ShadowSetHTMLUnsafeCapable)
+        .setHTMLUnsafe !== "function"
+    ) {
+      return;
+    }
+    installShadowRootProbe.call(globalThis as unknown as Window);
+    const capture = captureEvents("abs:shadow-discover");
+
+    const host = document.createElement("div");
+    const shadow = host.attachShadow({ mode: "open" });
+    document.body.append(host);
+    // Clear the discover call from the attachShadow above.
+    capture.events.length = 0;
+
+    shadow.setHTMLUnsafe("<span>x</span>");
+
+    expect(capture.events).toHaveLength(1);
+    const detail = capture.events[0]?.detail as
+      | { target?: unknown }
+      | undefined;
+    expect(detail?.target).toBe(shadow);
+    capture.off();
+  });
+});
+
+describe("installShadowRootProbe — idempotency", () => {
+  it("is a no-op when called a second time", () => {
+    installShadowRootProbe.call(globalThis as unknown as Window);
+    // Wrap stored after first call; second call must not re-wrap so the
+    // listener fires exactly once per attachShadow.
+    installShadowRootProbe.call(globalThis as unknown as Window);
+
+    const capture = captureEvents("abs:closed-shadow-attached");
+    document.createElement("div").attachShadow({ mode: "closed" });
+    expect(capture.events).toHaveLength(1);
+    capture.off();
+  });
+});
+
+describe("installShadowRootProbe — event independence", () => {
+  it("does not stamp closed listeners with detail (no shadow contents cross)", () => {
+    // Contract: the closed-shadow signal carries no information about
+    // the host or root. Documented as part of preserving the spec's
+    // encapsulation guarantee; assert it in case a future "convenient
+    // payload" tweak forgets it.
+    installShadowRootProbe.call(globalThis as unknown as Window);
+    const capture = captureEvents("abs:closed-shadow-attached");
+
+    document.createElement("div").attachShadow({ mode: "closed" });
+
+    expect(capture.events[0]?.detail).toBeNull();
+    capture.off();
+  });
+});

--- a/extension/src/lib/__tests__/shadow-roots.test.ts
+++ b/extension/src/lib/__tests__/shadow-roots.test.ts
@@ -249,3 +249,58 @@ describe("setHTMLUnsafe — declarative shadow DOM", () => {
     expect(getOpenShadowRoots().has(firstRoot as ShadowRoot)).toBe(true);
   });
 });
+
+describe("abs:shadow-discover listener — main-world probe bridge", () => {
+  // The page-world probe (lib/shadow-root-probe-source.ts) dispatches
+  // `abs:shadow-discover` with the receiver node on event.detail.target
+  // whenever a page-script attachShadow or setHTMLUnsafe call lands in
+  // the page world. The isolated-world listener installed by
+  // installShadowRootHook walks the target with discoverShadowRootsIn.
+  // Without the listener, page-script open-shadow attachments would
+  // only be picked up by the MutationObserver host-insertion path,
+  // which can miss attachments on already-connected hosts.
+
+  it("registers an open shadow when the probe dispatches with the host", () => {
+    const host = document.createElement("div");
+    const root = host.attachShadow({ mode: "open" });
+    document.body.append(host);
+    __resetShadowRootsForTesting();
+    expect(getOpenShadowRoots().has(root)).toBe(false);
+
+    document.dispatchEvent(
+      new CustomEvent("abs:shadow-discover", { detail: { target: host } }),
+    );
+
+    expect(getOpenShadowRoots().has(root)).toBe(true);
+  });
+
+  it("walks a ShadowRoot target dispatched by the probe", () => {
+    const host = document.createElement("div");
+    const root = host.attachShadow({ mode: "open" });
+    document.body.append(host);
+    const inner = document.createElement("section");
+    const innerRoot = inner.attachShadow({ mode: "open" });
+    root.append(inner);
+    __resetShadowRootsForTesting();
+
+    document.dispatchEvent(
+      new CustomEvent("abs:shadow-discover", { detail: { target: root } }),
+    );
+
+    expect(getOpenShadowRoots().has(innerRoot)).toBe(true);
+  });
+
+  it("no-ops on a non-Node target (forged dispatch defense)", () => {
+    const listener = jest.fn();
+    subscribeShadowRootAttached(listener);
+
+    document.dispatchEvent(
+      new CustomEvent("abs:shadow-discover", {
+        detail: { target: "not-a-node" },
+      }),
+    );
+    document.dispatchEvent(new CustomEvent("abs:shadow-discover"));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/lib/shadow-root-probe-registration.ts
+++ b/extension/src/lib/shadow-root-probe-registration.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Background-side registration for the `closed-shadow-root-annotate`
+// rule's main-world probe. When the rule is enabled, `shadow-root-probe.js`
+// is registered via `chrome.scripting.registerContentScripts` with
+// `world: "MAIN"` and `runAt: "document_start"` so the wraps over
+// `Element.prototype.attachShadow` / `setHTMLUnsafe` land before any
+// page script that attaches shadow roots during initial parse.
+//
+// `allFrames: true` because shadow roots can be attached in any frame and
+// same-origin iframes have their own copies of those prototypes. Each
+// frame's probe wraps its own world-local prototypes — there is no
+// cross-frame sharing the way same-origin documents share scriptable
+// global state.
+//
+// When the rule is disabled (or enforcement is off), the registration is
+// removed so future navigations get clean prototypes. Already-loaded
+// tabs retain whatever wrap they had until the user reloads — same
+// constraint as static content_scripts and as the sibling
+// `webdriver-probe` / `checkout-checkbox-defense` registrations.
+//
+// The rule's own `apply` covers the currently-open tab by asking the
+// background worker (via an `inject-shadow-root-probe` message) to run
+// the probe through `chrome.scripting.executeScript` — dynamic
+// registrations only take effect on subsequent navigations, so without
+// that round-trip the user would have to reload the active tab. This
+// module is purely the registration life-cycle for the standalone bundle.
+
+import {
+  getEnforcementEnabled,
+  subscribeEnforcementEnabled,
+} from "./enforcement";
+import { log } from "./log";
+import { getRuleStates, subscribe } from "./storage";
+
+const SCRIPT_ID = "closed-shadow-root-annotate-main-world";
+const SCRIPT_FILE = "shadow-root-probe.js";
+
+async function shouldBeRegistered(): Promise<boolean> {
+  const [states, enforcementEnabled] = await Promise.all([
+    getRuleStates(),
+    getEnforcementEnabled(),
+  ]);
+  return enforcementEnabled && Boolean(states["closed-shadow-root-annotate"]);
+}
+
+async function isRegistered(): Promise<boolean> {
+  try {
+    const registered = await chrome.scripting.getRegisteredContentScripts({
+      ids: [SCRIPT_ID],
+    });
+    return registered.length > 0;
+  } catch (error) {
+    // getRegisteredContentScripts throws if no script with the id exists
+    // in some Chrome versions; treat that as "not registered" rather than
+    // a failure mode that prevents registration.
+    log("shadow-root-probe registration: getRegistered threw", { error });
+    return false;
+  }
+}
+
+async function register(): Promise<void> {
+  try {
+    await chrome.scripting.registerContentScripts([
+      {
+        id: SCRIPT_ID,
+        matches: ["<all_urls>"],
+        js: [SCRIPT_FILE],
+        runAt: "document_start",
+        world: "MAIN",
+        // allFrames: shadow roots attach inside any frame, and each frame
+        // has its own copy of Element.prototype / ShadowRoot.prototype.
+        // Without per-frame injection, attachments in same-origin
+        // subframes would still bypass the probe.
+        allFrames: true,
+        persistAcrossSessions: true,
+      },
+    ]);
+    log("shadow-root-probe registered at document_start (main world)");
+  } catch (error) {
+    log("shadow-root-probe registration failed", { error });
+  }
+}
+
+async function unregister(): Promise<void> {
+  try {
+    await chrome.scripting.unregisterContentScripts({ ids: [SCRIPT_ID] });
+    log("shadow-root-probe unregistered");
+  } catch (error) {
+    // Unregister fails if the script wasn't registered to begin with;
+    // that's a benign state, not a problem.
+    log("shadow-root-probe unregister no-op", { error });
+  }
+}
+
+async function sync(): Promise<void> {
+  const [target, current] = await Promise.all([
+    shouldBeRegistered(),
+    isRegistered(),
+  ]);
+  if (target === current) {
+    return;
+  }
+  await (target ? register() : unregister());
+}
+
+// Wire up the registration life-cycle. Called once from background.ts.
+export function startShadowRootProbeRegistration(): void {
+  // Initial reconciliation when the service worker spins up — covers both
+  // first install and SW restarts on Chrome's idle timer.
+  void sync();
+  subscribe(() => {
+    void sync();
+  });
+  subscribeEnforcementEnabled(() => {
+    void sync();
+  });
+}

--- a/extension/src/lib/shadow-root-probe-source.ts
+++ b/extension/src/lib/shadow-root-probe-source.ts
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Page-world (main-world) probe over the shadow-root attachment surface.
+// The isolated-world hook in `lib/shadow-roots.ts` patches the same
+// methods on the isolated copy of `Element.prototype` / `ShadowRoot.prototype`,
+// but a page script that calls `host.attachShadow(...)` or
+// `host.setHTMLUnsafe(...)` hits the *page*'s prototypes — a distinct
+// object from the one the content script sees. Without this probe in the
+// page world, the patches in `shadow-roots.ts` only fire for the
+// content-script's own calls and the jsdom-shimmed test paths.
+//
+// Two outputs cover the rule pipeline's two needs:
+//
+//   1. Closed-shadow attachment detection (`abs:closed-shadow-attached`).
+//      `closed-shadow-root-annotate` consumes this for a definitive
+//      "closed shadow root attached" signal that supersedes the
+//      heuristic walk and lifts the structural-shape false positives
+//      (canvas-rendered custom elements, `::before` decorations, etc.).
+//      No detail is sent — closed shadow contents must remain opaque to
+//      every isolated-world consumer; only the binary signal crosses.
+//
+//   2. Open-shadow / DSD discovery (`abs:shadow-discover`). Dispatched
+//      with `detail: { target }` where `target` is the receiver node
+//      (host element for attachShadow + Element.setHTMLUnsafe;
+//      ShadowRoot for ShadowRoot.setHTMLUnsafe). DOM-node references
+//      survive cross-realm in Chrome content scripts, so the
+//      isolated-world handler in `shadow-roots.ts` reads
+//      `event.detail.target` and routes it through `discoverShadowRootsIn`.
+//
+// Shared between two delivery paths, mirroring the webdriver-probe /
+// checkout-checkbox-defense pattern:
+//
+//   1. Dynamic content-script registration in the background worker
+//      (`chrome.scripting.registerContentScripts` with `world: "MAIN"`
+//      and `runAt: "document_start"`). Primary path for any navigation
+//      that happens *after* the user enables `closed-shadow-root-annotate`.
+//      Runs before the page's first script, so attachments issued during
+//      initial HTML parse and from `document_start` framework bundles
+//      are caught.
+//
+//   2. On-demand `chrome.scripting.executeScript` with `world: "MAIN"`,
+//      driven by the rule's `apply` sending an
+//      `inject-shadow-root-probe` message at `document_idle`. Covers
+//      the tab the user was already viewing when they toggled the rule
+//      on (dynamic registrations only take effect on subsequent
+//      navigations). The fallback misses early-parse attachments, but
+//      attachments from `DOMContentLoaded` / `load` handlers, custom
+//      element upgrades, and post-hydration `setHTMLUnsafe` are still
+//      caught.
+//
+// The function must not reference any module-scope identifiers — only
+// the function body's source crosses into the page world (either via
+// `executeScript({ func })` from the background worker or via the
+// bundled `shadow-root-probe.js` entry point). Event names are
+// hard-coded here as literals and re-declared as module constants in
+// the consumers; tests assert the two agree.
+
+export function installShadowRootProbe(this: Window): void {
+  const FLAG = "__abs_shadow_root_probe_installed";
+  const probeWindow = this as Window & Record<string, unknown>;
+  if (probeWindow[FLAG]) {
+    return;
+  }
+  probeWindow[FLAG] = true;
+
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const originalAttachShadow = Element.prototype.attachShadow;
+  try {
+    Element.prototype.attachShadow = function patched(
+      this: Element,
+      init: ShadowRootInit,
+    ): ShadowRoot {
+      const root = originalAttachShadow.call(this, init);
+      try {
+        if (init.mode === "closed") {
+          document.dispatchEvent(new CustomEvent("abs:closed-shadow-attached"));
+        } else {
+          document.dispatchEvent(
+            new CustomEvent("abs:shadow-discover", {
+              detail: { target: this },
+            }),
+          );
+        }
+      } catch {
+        // Some pages frame-bust by replacing CustomEvent or dispatchEvent;
+        // swallow and continue so the page's attachShadow result is
+        // returned untouched.
+      }
+      return root;
+    };
+  } catch {
+    // Element.prototype.attachShadow may be locked non-writable in a
+    // future hardening; give up silently rather than break the page.
+  }
+
+  interface ElementSetHTMLUnsafeCapable {
+    setHTMLUnsafe?: (this: Element, html: string) => void;
+  }
+  interface ShadowSetHTMLUnsafeCapable {
+    setHTMLUnsafe?: (this: ShadowRoot, html: string) => void;
+  }
+
+  const elementProto = Element.prototype as ElementSetHTMLUnsafeCapable;
+  const originalElementSet = elementProto.setHTMLUnsafe;
+  if (typeof originalElementSet === "function") {
+    try {
+      elementProto.setHTMLUnsafe = function patched(
+        this: Element,
+        html: string,
+      ): void {
+        originalElementSet.call(this, html);
+        try {
+          document.dispatchEvent(
+            new CustomEvent("abs:shadow-discover", {
+              detail: { target: this },
+            }),
+          );
+        } catch {
+          // see attachShadow note
+        }
+      };
+    } catch {
+      // setHTMLUnsafe was sealed; give up silently.
+    }
+  }
+
+  const shadowProto = ShadowRoot.prototype as ShadowSetHTMLUnsafeCapable;
+  const originalShadowSet = shadowProto.setHTMLUnsafe;
+  if (typeof originalShadowSet === "function") {
+    try {
+      shadowProto.setHTMLUnsafe = function patched(
+        this: ShadowRoot,
+        html: string,
+      ): void {
+        originalShadowSet.call(this, html);
+        try {
+          document.dispatchEvent(
+            new CustomEvent("abs:shadow-discover", {
+              detail: { target: this },
+            }),
+          );
+        } catch {
+          // see attachShadow note
+        }
+      };
+    } catch {
+      // see Element.setHTMLUnsafe note
+    }
+  }
+}

--- a/extension/src/lib/shadow-roots.ts
+++ b/extension/src/lib/shadow-roots.ts
@@ -28,8 +28,21 @@
 // to walk the receiver after the call so any newly-materialized open shadow
 // is registered. Closed DSD is invisible by the same spec contract as
 // imperative closed shadows.
+//
+// The patches above live in the isolated world. Page-script calls to
+// `attachShadow` / `setHTMLUnsafe` go through the page's own prototype
+// copies and never hit the isolated-world wraps. The main-world probe in
+// `lib/shadow-root-probe-source.ts` (registered when
+// `closed-shadow-root-annotate` is enabled) closes that gap by wrapping
+// the same methods in the page world and dispatching an
+// `abs:shadow-discover` CustomEvent on the document with
+// `detail: { target }`. The listener here translates each event into a
+// `discoverShadowRootsIn(target)` walk so subscribers see roots
+// regardless of which world attached them.
 
 const HOOK_INSTALLED = Symbol.for("abs.shadowRootHookInstalled");
+
+const SHADOW_DISCOVER_EVENT = "abs:shadow-discover";
 
 const openShadowRoots = new Set<ShadowRoot>();
 const attachListeners = new Set<(root: ShadowRoot) => void>();
@@ -60,6 +73,30 @@ export function installShadowRootHook(): void {
   };
 
   patchSetHTMLUnsafe();
+  installShadowDiscoverListener();
+}
+
+// Subscribes to `abs:shadow-discover` events dispatched by the main-world
+// probe in `lib/shadow-root-probe-source.ts`. Each event carries the
+// receiver node (host element or ShadowRoot) on `event.detail.target`;
+// DOM-node references survive cross-realm in Chrome content scripts, so
+// the handler can route the target straight through the existing
+// `discoverShadowRootsIn` walk. The instanceof gate filters forged
+// dispatches (any page can fire `abs:shadow-discover` with an arbitrary
+// detail, but a non-Node target would no-op anyway — the check just
+// avoids running the walk for clearly bogus payloads).
+function installShadowDiscoverListener(): void {
+  document.addEventListener(SHADOW_DISCOVER_EVENT, (event) => {
+    // event.detail is typed `unknown` at the CustomEvent boundary; a
+    // forged dispatch could omit it entirely, hence the explicit narrow.
+    const detail = (event as CustomEvent<unknown>).detail as {
+      target?: unknown;
+    } | null;
+    const target = detail ? detail.target : undefined;
+    if (target instanceof Node) {
+      discoverShadowRootsIn(target);
+    }
+  });
 }
 
 // `setHTMLUnsafe` is the only post-parse opt-in path that honors declarative

--- a/extension/src/rules/__tests__/closed-shadow-root-annotate.test.ts
+++ b/extension/src/rules/__tests__/closed-shadow-root-annotate.test.ts
@@ -290,6 +290,71 @@ describe("closedShadowRootAnnotateRule.apply", () => {
   });
 });
 
+describe("closedShadowRootAnnotateRule main-world probe integration", () => {
+  it("stamps the landmark when the probe dispatches abs:closed-shadow-attached with no heuristic match", () => {
+    // No custom-element hosts in the page — the heuristic would never
+    // trip — but the page-world probe fires the event directly. This
+    // covers the case the heuristic would miss: a closed shadow on a
+    // non-custom-element (e.g. a `<div>`), which the future-work probe
+    // was specifically introduced to catch.
+    document.body.innerHTML = "<div><p>plain content</p></div>";
+
+    closedShadowRootAnnotateRule.apply(document.body);
+    expect(document.querySelector(LANDMARK_SELECTOR)).toBeNull();
+
+    document.dispatchEvent(new CustomEvent("abs:closed-shadow-attached"));
+
+    expect(document.querySelector(LANDMARK_SELECTOR)).not.toBeNull();
+  });
+
+  it("requests probe injection on apply (background fallback for the active tab)", () => {
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    const requested = sendMessageMock.mock.calls.some(
+      ([message]: [unknown]) =>
+        (message as { type?: string }).type === "inject-shadow-root-probe",
+    );
+    expect(requested).toBe(true);
+  });
+
+  it("does not re-stamp on subsequent probe events (per-document dedupe)", () => {
+    closedShadowRootAnnotateRule.apply(document.body);
+
+    document.dispatchEvent(new CustomEvent("abs:closed-shadow-attached"));
+    document.dispatchEvent(new CustomEvent("abs:closed-shadow-attached"));
+    document.dispatchEvent(new CustomEvent("abs:closed-shadow-attached"));
+
+    expect(document.querySelectorAll(LANDMARK_SELECTOR)).toHaveLength(1);
+  });
+
+  it("stops listening for probe events after teardown", () => {
+    closedShadowRootAnnotateRule.apply(document.body);
+    closedShadowRootAnnotateRule.teardown();
+
+    document.dispatchEvent(new CustomEvent("abs:closed-shadow-attached"));
+
+    expect(document.querySelector(LANDMARK_SELECTOR)).toBeNull();
+  });
+
+  it("emits exactly one rule-detection when the probe is the trigger", () => {
+    document.body.innerHTML = "<div><p>plain</p></div>";
+    closedShadowRootAnnotateRule.apply(document.body);
+    sendMessageMock.mockClear();
+
+    document.dispatchEvent(new CustomEvent("abs:closed-shadow-attached"));
+
+    expect(detectionCalls()).toHaveLength(1);
+    expect(detectionCalls()[0]).toEqual({
+      type: "rule-detection",
+      payload: {
+        kind: "closed-shadow-root",
+        host: globalThis.location.hostname,
+        url: globalThis.location.href,
+      },
+    });
+  });
+});
+
 describe("closedShadowRootAnnotateRule rule-detection emission", () => {
   it("does not emit on apply when no hosts match", () => {
     document.body.innerHTML = "<p>plain content</p>";

--- a/extension/src/rules/closed-shadow-root-annotate.ts
+++ b/extension/src/rules/closed-shadow-root-annotate.ts
@@ -1,69 +1,89 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-// Heuristically flag pages that render content inside closed shadow roots so
-// the agent's accessibility-tree view of the document carries an explicit
-// note that ABS has a blind spot here. Closed shadow roots are opt-out of
-// every external JS API by spec — `host.shadowRoot` returns `null`, adopted
-// stylesheets and MutationObserver do not cross the boundary, and no
-// supported API undoes that. Documented as a coverage gap in
-// `docs/src/content/docs/rules.md`; this rule lets the agent learn the same
-// thing at read-time.
+// Flag pages that render content inside closed shadow roots so the agent's
+// accessibility-tree view of the document carries an explicit note that ABS
+// has a blind spot here. Closed shadow roots are opt-out of every external
+// JS API by spec — `host.shadowRoot` returns `null`, adopted stylesheets
+// and MutationObserver do not cross the boundary, and no supported API
+// undoes that. Documented as a coverage gap in
+// `docs/src/content/docs/rules.md`; this rule lets the agent learn the
+// same thing at read-time.
 //
-// Detection is heuristic, not definitive. We cannot enumerate closed shadow
-// roots directly — the entire point of `mode: "closed"` is that the page
-// is indistinguishable from an element with no shadow root at all from
-// outside JS. Instead, the rule looks for a structural shape that's
-// strongly correlated with "this element has a closed shadow root":
+// Two detection paths feed the landmark, ORed:
 //
-//   1. Tag name contains a hyphen — required for valid custom element names
-//      (per the Web Components spec). UA-shadowed built-ins (`<input>`,
-//      `<details>`, `<video>`, `<select>`, `<textarea>`) are filtered out
-//      for free because they don't have hyphenated names.
-//   2. `customElements.get(tagName.toLowerCase())` returns a constructor —
-//      the element has been upgraded. Unupgraded custom elements haven't
-//      had their constructor run yet, so they can't have called
-//      `attachShadow`.
-//   3. `element.shadowRoot === null` — there's no open shadow root for
-//      ABS to scan into. (Open-shadow elements are handled by the
-//      Tier-1/2/3 shadow-piercing plumbing — issue #164.)
-//   4. No light-DOM children — `element.children.length === 0` and no
-//      non-whitespace direct text. A custom element with no light children
-//      that still renders something is almost certainly using shadow DOM
-//      for its UI, and combined with (3) that shadow must be closed.
-//   5. Visibly rendering — `getBoundingClientRect()` reports a non-zero
-//      box. Avoids flagging custom elements that are defined but unused
-//      (zero-sized stubs). In jsdom the rect is always zero, so this
-//      gate is bypassed when both dimensions are zero — same convention
-//      as `newsletter-modal-hide`.
+//   1. Main-world probe (primary). When the rule is enabled, the
+//      background worker registers `shadow-root-probe.js` as a
+//      `world: "MAIN"`, `runAt: "document_start"` content script
+//      (`lib/shadow-root-probe-registration.ts`) that wraps
+//      `Element.prototype.attachShadow` in the page world. Any call
+//      with `init.mode === "closed"` dispatches an
+//      `abs:closed-shadow-attached` CustomEvent on the document; the
+//      listener here stamps the landmark on first event. The wrap
+//      sees attachments issued by page scripts directly — the
+//      isolated-world copy of the same prototype is a different
+//      object, so page-script `attachShadow` calls would otherwise
+//      never be observable from an isolated-world rule. The probe
+//      delivers a definitive signal that supersedes the structural
+//      heuristic below (no canvas/WebGL false positives, catches
+//      closed shadows on non-custom-element hosts).
 //
-// Known false positive: a custom element that renders via canvas/WebGL or
-// `::before` background-image without any shadow DOM still trips the
-// heuristic. We accept this — the landmark text says "may contain
-// content ABS cannot see," not "this is definitely a closed shadow root."
+//   2. Structural heuristic (fallback). Triggered on `apply` and on
+//      every subtree mutation while the rule is on. Necessary because
+//      the registered main-world probe lands only on navigations made
+//      after the rule was enabled — the active tab the user toggled
+//      it on for is covered by the rule's `apply`-time
+//      `inject-shadow-root-probe` round-trip (mirrors
+//      `webdriver-probe-annotate`), but that round-trip happens at
+//      `document_idle`, so closed shadows attached during the active
+//      tab's initial parse won't fire the probe. The heuristic looks
+//      for the structural shape strongly correlated with "closed
+//      shadow host":
 //
-// Known false negatives:
-//   - Declarative shadow DOM with `shadowrootmode="closed"` — the template
-//     is consumed during HTML parsing, never goes through
-//     `Element.prototype.attachShadow`, and the materialized closed root
-//     is indistinguishable from "no shadow" the same as imperative
-//     closed shadows. The open variant of declarative shadow DOM is
-//     covered by the regular open-shadow plumbing — initial-parse roots
-//     are walked at content-script startup, and the `setHTMLUnsafe`
-//     patch in `shadow-roots.ts` registers any open shadow materialized
-//     post-parse.
-//   - Closed shadows on non-custom elements (e.g., a page that attaches a
-//     closed shadow to a `<div>`). Rare in practice — closed mode is
-//     almost always paired with the custom element pattern — and a
-//     hyphen-less filter would balloon false positives across the whole
-//     document.
+//        a. Tag name contains a hyphen — required for valid custom
+//           element names (per the Web Components spec). UA-shadowed
+//           built-ins (`<input>`, `<details>`, `<video>`, `<select>`,
+//           `<textarea>`) are filtered out for free because they don't
+//           have hyphenated names.
+//        b. `customElements.get(tagName.toLowerCase())` returns a
+//           constructor — the element has been upgraded. Unupgraded
+//           custom elements haven't had their constructor run yet, so
+//           they can't have called `attachShadow`.
+//        c. `element.shadowRoot === null` — there's no open shadow
+//           root for ABS to scan into. (Open-shadow elements are
+//           handled by the Tier-1/2/3 shadow-piercing plumbing —
+//           issue #164.)
+//        d. No light-DOM children — `element.children.length === 0`
+//           and no non-whitespace direct text. A custom element with
+//           no light children that still renders something is almost
+//           certainly using shadow DOM for its UI, and combined with
+//           (c) that shadow must be closed.
+//        e. Visibly rendering — `getBoundingClientRect()` reports a
+//           non-zero box. Avoids flagging custom elements that are
+//           defined but unused (zero-sized stubs). In jsdom the rect
+//           is always zero, so this gate is bypassed when both
+//           dimensions are zero — same convention as
+//           `newsletter-modal-hide`.
 //
-// Future work: a main-world probe that wraps `Element.prototype.attachShadow`
-// in the page realm and reports calls with `init.mode === "closed"`, the
-// same delivery pattern as `webdriver-probe-annotate`. Would catch the
-// non-custom-element case (3) above with high specificity. Skipped for
-// now to keep the rule a single-file isolated-world change; revisit if
-// the heuristic produces too much noise in the wild.
+// Known false positive on the heuristic path: a custom element that
+// renders via canvas/WebGL or `::before` background-image without any
+// shadow DOM still trips it. The landmark text reads "may contain
+// content ABS cannot see," not "this is definitely a closed shadow
+// root." The main-world probe is definitive on the navigations it
+// covers and is preferred when both signals are available.
+//
+// Known false negatives that even the main-world probe doesn't cover:
+//   - Declarative shadow DOM with `shadowrootmode="closed"` — the
+//     template is consumed during HTML parsing, never goes through
+//     `Element.prototype.attachShadow`, so the wrap never sees it. The
+//     materialized closed root is also indistinguishable from "no
+//     shadow" from outside JS, so the heuristic can't catch it
+//     reliably either. The open variant of declarative shadow DOM is
+//     covered by the regular open-shadow plumbing — initial-parse
+//     roots are walked at content-script startup, and the
+//     `setHTMLUnsafe` patches in `shadow-roots.ts` (isolated world)
+//     and `shadow-root-probe-source.ts` (page world) register any
+//     open shadow materialized post-parse.
 
 import type { RuleDetectionMessage } from "../lib/detection-messages";
 import { RULE_ATTR } from "../lib/dom-markers";
@@ -78,6 +98,12 @@ const LANDMARK_SELECTOR = `section[${RULE_ATTR}="${RULE_ID}"]`;
 
 const LANDMARK_TEXT =
   "This page renders content inside one or more closed shadow roots. The contents of those shadow roots are invisible to this extension and may include text, controls, or instructions that are not reflected in the rest of the page's accessible content.";
+
+const PROBE_EVENT = "abs:closed-shadow-attached";
+
+const INJECT_PROBE_MESSAGE = { type: "inject-shadow-root-probe" } as const;
+
+let probeListenerAttached = false;
 
 function hasLightContent(element: Element): boolean {
   if (element.children.length > 0) {
@@ -194,13 +220,52 @@ const watcher = createSubtreeWatcher({
   },
 });
 
+// The main-world probe (lib/shadow-root-probe-source.ts) dispatches this
+// event on the document for every page-script `attachShadow(... mode:
+// "closed" ...)` call. The probe sends no detail — closed shadow contents
+// must stay opaque to every consumer; only the binary "an attachment
+// happened" signal crosses worlds. The listener stamps the landmark on
+// first event, and ensureLandmark's per-document dedupe short-circuits
+// every subsequent event for the page's lifetime.
+function onClosedShadowAttached(): void {
+  ensureLandmark();
+}
+
+function requestProbeInjection(): void {
+  // Service worker may be asleep / receiver not yet ready; swallow
+  // rejection so unhandled-promise warnings don't surface on every page
+  // load. installShadowRootProbe is idempotent via its FLAG sentinel, so
+  // re-requests on the same document are no-ops in the page world.
+  chrome.runtime.sendMessage(INJECT_PROBE_MESSAGE).catch(() => {
+    // noop
+  });
+}
+
 function apply(root: ParentNode): void {
+  if (!probeListenerAttached) {
+    document.addEventListener(PROBE_EVENT, onClosedShadowAttached);
+    probeListenerAttached = true;
+  }
+  // Ask the background to run the probe on this tab — covers the tab
+  // the user was already viewing when they toggled the rule on, since
+  // the dynamic main-world registration only takes effect on
+  // subsequent navigations.
+  requestProbeInjection();
   scan(root);
   watcher.start(root);
 }
 
 function teardown(): void {
   watcher.stop();
+  if (probeListenerAttached) {
+    document.removeEventListener(PROBE_EVENT, onClosedShadowAttached);
+    probeListenerAttached = false;
+  }
+  // The page-world wrap on Element.prototype.attachShadow is left in
+  // place intentionally — same posture as webdriver-probe-annotate's
+  // Navigator.prototype.webdriver wrap. The landmark is the user-visible
+  // signal; the wrap itself is plumbing and re-enabling later still
+  // benefits from the existing patch on the same document.
   for (const node of document.querySelectorAll(LANDMARK_SELECTOR)) {
     node.remove();
   }
@@ -210,7 +275,7 @@ export const closedShadowRootAnnotateRule = {
   id: RULE_ID,
   label: "Flag Closed Shadow Roots",
   description:
-    "Heuristically detect when a page renders content inside closed shadow roots (custom elements that visibly render with no light-DOM children). If detected, add a screen-reader-only landmark noting that the extension cannot see inside those shadow trees.",
+    "Detect when a page attaches closed shadow roots via a main-world probe over Element.prototype.attachShadow, with a structural heuristic as a fallback. If detected, add a screen-reader-only landmark noting that the extension cannot see inside those shadow trees.",
   // Closed shadow roots in cross-origin iframes are handled — or not — by
   // the iframe's own document; injecting a per-frame landmark there isn't
   // useful since the agent reads the top frame's a11y tree.
@@ -218,3 +283,5 @@ export const closedShadowRootAnnotateRule = {
   apply,
   teardown,
 } satisfies Rule;
+
+export { INJECT_PROBE_MESSAGE, PROBE_EVENT };

--- a/extension/src/shadow-root-probe.ts
+++ b/extension/src/shadow-root-probe.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Build entrypoint for the page-world shadow-root probe. Registered
+// dynamically by the background worker via
+// `chrome.scripting.registerContentScripts` with `world: "MAIN"` and
+// `runAt: "document_start"` whenever `closed-shadow-root-annotate` is
+// enabled. Runs before the page's first script so the wraps over
+// `Element.prototype.attachShadow` and `setHTMLUnsafe` land before any
+// framework bundle caches the descriptors.
+//
+// Kept tiny on purpose — the bundled output ships into every page-world
+// at document_start, so anything imported here lands in the page's JS
+// heap. Pull only from `lib/shadow-root-probe-source.ts`, which is
+// dependency-free for the same reason.
+
+import { installShadowRootProbe } from "./lib/shadow-root-probe-source";
+
+installShadowRootProbe.call(globalThis as unknown as Window);


### PR DESCRIPTION
## Summary

Addresses red-team audit item **#1 (closed shadow root content invisible)** and the open-shadow blind spot called out in PR #211's footnote, both from #203.

Wraps `Element.prototype.attachShadow`, `Element.prototype.setHTMLUnsafe`, and `ShadowRoot.prototype.setHTMLUnsafe` in the **page world** via the same delivery pattern as `webdriver-probe-annotate` and `checkout-checkbox-sanitize`. The isolated-world copies of these prototypes are distinct objects from the page-world copies, so the existing patches in `lib/shadow-roots.ts` only fired for isolated-world callers and jsdom-shimmed test paths — page-script attachments slipped past entirely.

Two events bridge across worlds:

- **`abs:closed-shadow-attached`** → consumed by `closed-shadow-root-annotate` for a definitive landmark stamp. Supersedes the structural heuristic — no canvas/WebGL false positives, catches closed shadows on non-custom-element hosts. Carries **no detail** so closed shadow contents remain opaque to every consumer.
- **`abs:shadow-discover`** with `detail.target` → consumed by `shadow-roots.ts`, routes the receiver through `discoverShadowRootsIn` so page-script open-shadow attachments and `setHTMLUnsafe` receivers are no longer invisible to the isolated-world rule engine.

The structural heuristic stays as the gap-filler for the active tab between toggle-on and the moment the `executeScript` fallback injects the probe.

## Notable choices

- **Gated on `closed-shadow-root-annotate`** — the registration lifecycle (`lib/shadow-root-probe-registration.ts`) mirrors `webdriver-probe-registration.ts`: enrolled when (enforcement on) AND (rule enabled). Keeps the page-world surface gated to opt-in users.
- **`allFrames: true`** — shadow roots attach in any frame and same-origin iframes have their own prototype copies, so per-frame injection is required.
- **No detail on closed events** — preserves the spec's encapsulation guarantee. A parity test asserts `event.detail === null` so a future "convenient payload" tweak can't silently leak host or root references.
- **Forged-dispatch defense** — the isolated-world `abs:shadow-discover` listener gates on `target instanceof Node` so a page firing `abs:shadow-discover` with garbage detail no-ops cleanly.
- **Closed DSD still uncovered** — `<template shadowrootmode=\"closed\">` is consumed by the HTML parser without going through `attachShadow`, so the probe doesn't see it. The materialized root is also indistinguishable from \"no shadow\" externally, so the heuristic can't catch it reliably either. Documented in the rule's header.
- **Docs reflect current behavior only** — `docs/src/content/docs/rules.md` rewrites the `closed-shadow-root-annotate` section around the new probe-primary / heuristic-fallback split. The coverage-scope section is unchanged (open-shadow story is materially the same — the probe is belt-and-suspenders for open).
- **Test isolation note** — the new registration test prefixes its identifiers (`shadowProbeRegisterMock`, `ShadowProbeRegistrationModule`, etc.) so they don't collide with the identical shapes in `webdriver-probe-registration.test.ts`. Both files have no top-level import/export and TypeScript treats them as scripts that share global scope; Biome's `noExportsInTest` rule blocks the `export {}` workaround.

## Test plan

- [x] `npx jest src/lib/__tests__/shadow-root-probe-source.test.ts` — 8 tests covering attachShadow open/closed dispatch, setHTMLUnsafe receiver dispatch, idempotency, no-detail-on-closed contract.
- [x] `npx jest src/lib/__tests__/shadow-root-probe-source.property.test.ts` — 2 property invariants: event count equals op count across random attachShadow/setHTMLUnsafe sequences; discover-event target equals the receiver.
- [x] `npx jest src/lib/__tests__/shadow-root-probe-registration.test.ts` — 5 tests covering the four enabled/registered corners plus the no-op short-circuit.
- [x] `npx jest src/lib/__tests__/shadow-roots.test.ts` — 3 new tests on the `abs:shadow-discover` listener: open-root registration from probe dispatch, ShadowRoot-target walking, forged-dispatch defense.
- [x] `npx jest src/rules/__tests__/closed-shadow-root-annotate.test.ts` — 5 new tests on the probe integration: landmark stamped from event alone (no heuristic match), `inject-shadow-root-probe` requested on apply, per-document dedupe on repeated events, listener removed on teardown, rule-detection emitted exactly once.
- [x] `npx jest` — full extension suite, 93 suites / 1856 tests pass.
- [x] `bun run check` — biome + eslint clean.
- [x] `bun run typecheck` — clean.
- [x] `bun run knip` — clean (entry added for the new bundle).
- [x] `bun run build` — extension builds; `dist/shadow-root-probe.js` ships as its own bundle.
- [x] `pre-commit run --files docs/src/content/docs/rules.md` — mdformat + markdownlint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)