### PR TITLE
Docs: list remaining bypass gaps as known limitations (#203)

### DIFF
--- a/docs/src/content/docs/rules.md
+++ b/docs/src/content/docs/rules.md
@@ -53,6 +53,15 @@ handful of hardened embeds, but they are a known gap. The optional
 [Flag Closed Shadow Roots](#flag-closed-shadow-roots-experimental) rule can
 heuristically warn the agent at read-time when this gap is in use.
 
+**Extension presence is observable.** The rules leave rendered artifacts on the
+page — click-to-reveal placeholders, screen-reader-only landmarks, inline
+annotation chips, neutralized button labels — so a sophisticated site that
+fingerprints for those artifacts can detect ABS and serve a different DOM under
+that fingerprint than it would to an unprotected browser. The rule engine only
+sees what the page renders, so any content shaped by such adaptation is read by
+the rules as legitimate page content. Counter-cloaking from a content script is
+structurally out of scope.
+
 ## Indirect prompt injection
 
 Remove or neutralize content that could carry attacker-controlled instructions
@@ -72,6 +81,14 @@ delivery vector documented in those threat models.
 Hide page sections matching known prompt-injection patterns. The pattern set is
 intentionally not reproduced in docs — see the project README for how patterns
 are sourced and shipped.
+
+The bundle is a finite, curated catalog of phrasings observed in the literature
+and in fixtures. Payloads outside the catalog — novel framings, instruction
+shapes drawn from agent APIs the bundle does not yet cover, role markers from
+chat formats outside the set — pass through. The same bundle backs
+`meta-injection-strip`, `attribute-injection-sanitize`, `json-ld-sanitize`,
+`html-comment-strip`, and `svg-text-strip`, so coverage in those rules is
+bounded by the same catalog.
 
 #### Redact Encoded Payloads
 
@@ -639,6 +656,11 @@ sections. The snapshot-and-confirm approach follows Mathur et al.
 mutations over time and comparing successive snapshots to confirm a ticking
 value.
 
+Timers that reset to their starting value on each tick — and timers rendered via
+`<canvas>` or WebGL rather than DOM text — are not detected: the snapshot
+comparison requires a parseable text representation whose value strictly
+decreases across the 1.5s window.
+
 ### Scarcity
 
 #### Hide Scarcity Warnings
@@ -837,6 +859,12 @@ The underlying control is preserved — only its visible label and any matching
 `aria-label` / `title` are rewritten — so the agent can still click it normally.
 Plain decline labels like "No thanks", "Decline", "Maybe later", "Skip", and
 "Continue as guest" are left untouched.
+
+Coverage is English-only — the phrase set ships in English and does not run
+across localized variants of the same buttons. Buttons whose decline action is
+conveyed entirely by an icon, with no text label and no accessible name on
+`aria-label` / `title`, are out of scope: the rule matches against textual
+labels and has nothing to rewrite when there is no text.
 
 Cataloged as *Confirmshaming* in Brignull's deceptive.design
 [[10]](#ref-brignull) and as part of the *Misdirection* family in Mathur et al.


### PR DESCRIPTION
## Summary

- Audits the #203 red-team checklist against merged fixes and surfaces the four items that won't be closed in code as documented limitations.
- Rule-specific gaps are collocated with their rules; cross-cutting extension-presence note lives under Coverage scope.
- Phrasing stays abstract per repo convention — no injection examples, no roadmap language.

## Gaps documented

- **Coverage scope — extension presence is observable.** Sites that fingerprint ABS artifacts (placeholders, landmarks, chips, neutralized labels) can cloak content; counter-cloaking from a content script is out of scope. (Audit #17.)
- **`prompt-injection-redact` — closed pattern bundle.** Catalog is finite; novel framings pass through. Limitation propagates to the five rules sharing the bundle (`meta-injection-strip`, `attribute-injection-sanitize`, `json-ld-sanitize`, `html-comment-strip`, `svg-text-strip`). (Audit #8.)
- **`countdown-timer-redact` — reset-on-tick and canvas timers.** Snapshot-and-confirm needs a parseable text representation whose value strictly decreases. (Audit #20.)
- **`confirmshame-sanitize` — English-only, text-only.** Phrase set ships in English; icon-only buttons with no accessible name are out of scope. (Audit #22.)

Items #1–#7, #9–#16, #18, #19, #21 are already closed by merged PRs.

## Test plan

- [ ] CI: Pre-commit hooks (mdformat / markdown lint) pass.
- [ ] Spot-check rendered output on the Starlight site — new paragraphs render under Coverage scope and under the three rule subsections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)