### PR TITLE
Add: debugTrace build-time default + JSONL export schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,19 @@ Which rules ship on by default is enumerated in
 To ship a build with a custom set without forking the repo, pass an override
 file to `bun run build`. The file is a flat JSON object whose keys are rule ids
 (same keys the Options-page export uses) plus a small set of reserved non-rule
-keys — currently `optionsButton` (boolean, default off) to enable the floating
-on-page button that opens the options page. See
+keys:
+
+- `optionsButton` (boolean, default off) — floating on-page button that opens
+  the options page.
+- `runOnInactiveTabs` (boolean, default off) — keep observing while the tab is
+  hidden.
+- `debugTrace` (boolean, default off) — start with the dev-mode trace recorder
+  enabled so the popup's **Export** button can dump a JSONL trace without a
+  human flipping the toggle. Intended for automation builds (CDP, Browserbase).
+  The export shape is documented in
+  [`extension/data/debug-trace.schema.json`](./extension/data/debug-trace.schema.json).
+
+See
 [`extension/data/defaults-overrides.example.json`](./extension/data/defaults-overrides.example.json)
 for a starting template:
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -104,6 +104,16 @@ set of reserved keys is also accepted for non-rule build-time toggles:
   accessibility-tree agents, sidebar extensions) — without this, a page that
   mutates while hidden could reach the consumer unredacted.
 
+- `debugTrace` (boolean, default **off**) — start with the dev-mode debug-trace
+  recorder enabled. The recorder captures every rule-driven mutation (selector,
+  before/after `outerHTML`, segment id) and persists it to IndexedDB at the
+  extension origin so the popup's **Export** button can dump a JSONL trace.
+  Enable in builds you ship to automation harnesses (CDP-driven browsers,
+  Browserbase sessions) where you want post-hoc visibility into what the
+  extension touched without a human flipping the popup toggle. The export shape
+  is documented in
+  [`extension/data/debug-trace.schema.json`](https://github.com/pixiebrix/agent-browser-shield/blob/main/extension/data/debug-trace.schema.json).
+
 The file may be partial; rules not listed keep the committed default. Unknown
 keys (neither a registered rule id nor a reserved key) and non-boolean values
 fail the build with a message naming them.

--- a/extension/build.ts
+++ b/extension/build.ts
@@ -105,7 +105,8 @@ async function build(): Promise<void> {
     const changed =
       Object.keys(overrides.rules).length +
       (overrides.optionsButton === undefined ? 0 : 1) +
-      (overrides.runOnInactiveTabs === undefined ? 0 : 1);
+      (overrides.runOnInactiveTabs === undefined ? 0 : 1) +
+      (overrides.debugTrace === undefined ? 0 : 1);
     console.log(
       `Applying ${changed} build-time default override(s) from ${defaultsPath}.`,
     );
@@ -171,6 +172,9 @@ async function build(): Promise<void> {
         overrides.runOnInactiveTabs === undefined
           ? ""
           : String(overrides.runOnInactiveTabs),
+      ),
+      "process.env.EXTENSION_DEBUG_TRACE_DEFAULT": JSON.stringify(
+        overrides.debugTrace === undefined ? "" : String(overrides.debugTrace),
       ),
     },
   });

--- a/extension/data/debug-trace.schema.json
+++ b/extension/data/debug-trace.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pixiebrix.github.io/agent-browser-shield/schemas/debug-trace.schema.json",
+  "title": "Agent Browser Shield debug-trace entry",
+  "description": "One entry in the JSONL export produced by the popup's \"Export\" button when the debug-trace toggle is enabled. The export file contains one JSON-encoded entry per line in chronological order; this schema describes a single line. Entry shapes mirror the `DebugTraceEntry` union in extension/src/lib/detection-messages.ts.",
+  "oneOf": [
+    { "$ref": "#/$defs/SegmentEntry" },
+    { "$ref": "#/$defs/RuleApplicationEntry" },
+    { "$ref": "#/$defs/NavigationEntry" }
+  ],
+  "$defs": {
+    "SegmentEntry": {
+      "type": "object",
+      "description": "Boundary marker emitted by the content script at the start of a logical segment (initial load, route change, modal open, mutation burst). Subsequent rule-application entries carry the same `segmentId` until the next marker.",
+      "additionalProperties": false,
+      "required": ["type", "segmentId", "kind", "timestamp", "meta"],
+      "properties": {
+        "type": { "const": "segment" },
+        "segmentId": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Monotonically increasing within a single content script. Combined with tabId + frameId by the background to form a stable key."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "initial-load",
+            "route-change",
+            "modal-open",
+            "mutation-burst"
+          ]
+        },
+        "timestamp": {
+          "type": "integer",
+          "description": "Unix epoch milliseconds at emit time (Date.now)."
+        },
+        "meta": {
+          "type": "object",
+          "description": "Per-kind context. URLs for route-change / initial-load, selectors for modal-open, pending count for mutation-burst.",
+          "additionalProperties": { "type": ["string", "number"] }
+        }
+      }
+    },
+    "RuleApplicationEntry": {
+      "type": "object",
+      "description": "Single rule-driven mutation captured around the mutator. `beforeHtml` / `afterHtml` are the outerHTML of the element pre/post mutation; `cssOnly` events match without mutating the DOM (stylesheet-driven hides).",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "segmentId",
+        "ruleId",
+        "kind",
+        "timestamp",
+        "selector",
+        "beforeHtml",
+        "afterHtml"
+      ],
+      "properties": {
+        "type": { "const": "rule-application" },
+        "segmentId": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Segment id this event is attributed to. Zero before the first explicit segment marker."
+        },
+        "ruleId": {
+          "type": "string",
+          "description": "Rule id as defined in extension/src/rules/rule-metadata.ts."
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["hide", "mask", "strip", "sanitize", "flag", "embed"],
+          "description": "Mutation shape. Multiple rule labels can map to the same kind."
+        },
+        "timestamp": { "type": "integer" },
+        "selector": {
+          "type": "string",
+          "description": "Selector that matched the original element when known, otherwise a structural fingerprint from describeNode."
+        },
+        "beforeHtml": {
+          "type": "string",
+          "description": "outerHTML immediately before the mutation. Empty for inline placeholders, which store the raw text snippet in `beforeText`."
+        },
+        "afterHtml": {
+          "type": "string",
+          "description": "outerHTML of the replacement placeholder, or empty for in-place hides (the original node stays in the DOM, just display:none)."
+        },
+        "beforeText": {
+          "type": "string",
+          "description": "Original text replaced by an inline placeholder. Only populated for `mask` events."
+        },
+        "cssOnly": {
+          "type": "boolean",
+          "const": true,
+          "description": "Present and true when the rule hides via injected stylesheet rather than an element-level write. `beforeHtml` and `afterHtml` are identical for these events. Absent on every other event."
+        }
+      }
+    },
+    "NavigationEntry": {
+      "type": "object",
+      "description": "Top-level navigation marker emitted by the background service worker on every chrome.tabs.onUpdated loading transition. Lets the trace span multiple page loads in the same tab.",
+      "additionalProperties": false,
+      "required": ["type", "url", "timestamp"],
+      "properties": {
+        "type": { "const": "navigation" },
+        "url": {
+          "type": ["string", "null"],
+          "description": "Tab URL at the moment the loading transition fired. May be the previous URL on a same-page reload, or the new URL on a cross-page navigation. Null when the tab has no URL yet (initial new-tab navigation)."
+        },
+        "timestamp": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/extension/data/defaults-overrides.example.json
+++ b/extension/data/defaults-overrides.example.json
@@ -4,5 +4,6 @@
   "irrelevant-sections-redact": true,
 
   "optionsButton": true,
-  "runOnInactiveTabs": false
+  "runOnInactiveTabs": false,
+  "debugTrace": false
 }

--- a/extension/scripts/__tests__/load-default-overrides.test.ts
+++ b/extension/scripts/__tests__/load-default-overrides.test.ts
@@ -103,6 +103,42 @@ describe("loadDefaultOverrides", () => {
     ).toThrow(/non-boolean values for: runOnInactiveTabs/);
   });
 
+  it("extracts the debugTrace reserved key alongside rules", () => {
+    const file = writeFile(
+      "with-debug-trace.json",
+      JSON.stringify({ "pii-redact": true, debugTrace: true }),
+    );
+    expect(
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toEqual({
+      rules: { "pii-redact": true },
+      debugTrace: true,
+    });
+  });
+
+  it("accepts debugTrace on its own", () => {
+    const file = writeFile(
+      "only-debug-trace.json",
+      JSON.stringify({ debugTrace: false }),
+    );
+    expect(
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toEqual({
+      rules: {},
+      debugTrace: false,
+    });
+  });
+
+  it("rejects a non-boolean debugTrace value", () => {
+    const file = writeFile(
+      "bad-debug-trace.json",
+      JSON.stringify({ debugTrace: "on" }),
+    );
+    expect(() =>
+      loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+    ).toThrow(/non-boolean values for: debugTrace/);
+  });
+
   it("throws when the file does not exist", () => {
     expect(() =>
       loadDefaultOverrides({

--- a/extension/scripts/load-default-overrides.ts
+++ b/extension/scripts/load-default-overrides.ts
@@ -25,12 +25,17 @@ export interface DefaultOverrides {
   rules: Record<string, boolean>;
   optionsButton?: boolean;
   runOnInactiveTabs?: boolean;
+  debugTrace?: boolean;
 }
 
 // Reserved top-level keys are not rule ids; the loader maps each one to a
 // typed field on `DefaultOverrides`. Add new build-time toggles here as they
 // appear.
-const RESERVED_KEYS = new Set<string>(["optionsButton", "runOnInactiveTabs"]);
+const RESERVED_KEYS = new Set<string>([
+  "optionsButton",
+  "runOnInactiveTabs",
+  "debugTrace",
+]);
 
 export function loadDefaultOverrides(
   options: LoadOverridesOptions,
@@ -77,10 +82,19 @@ export function loadDefaultOverrides(
         nonBooleanIds.push(key);
         continue;
       }
-      if (key === "optionsButton") {
-        result.optionsButton = value;
-      } else if (key === "runOnInactiveTabs") {
-        result.runOnInactiveTabs = value;
+      switch (key) {
+        case "optionsButton": {
+          result.optionsButton = value;
+          break;
+        }
+        case "runOnInactiveTabs": {
+          result.runOnInactiveTabs = value;
+          break;
+        }
+        case "debugTrace": {
+          result.debugTrace = value;
+          break;
+        }
       }
       continue;
     }

--- a/extension/src/globals.d.ts
+++ b/extension/src/globals.d.ts
@@ -14,5 +14,9 @@ declare namespace NodeJS {
     // `"true"` / `"false"` to force a value, or empty string when the
     // defaults file did not set `optionsButton`.
     EXTENSION_OPTIONS_BUTTON_DEFAULT: string;
+    // Build-time default for the dev-mode debug-trace toggle. Literal
+    // `"true"` / `"false"` to force a value, or empty string when the
+    // defaults file did not set `debugTrace`.
+    EXTENSION_DEBUG_TRACE_DEFAULT: string;
   }
 }

--- a/extension/src/lib/__tests__/debug-trace-default.test.ts
+++ b/extension/src/lib/__tests__/debug-trace-default.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Verifies that `debugTraceStorage` reads its initial default from
+// `process.env.EXTENSION_DEBUG_TRACE_DEFAULT` (substituted by build.ts when
+// the operator supplies a defaults file with a `debugTrace` field). Mirrors
+// the structure of `options-button-toggle.test.ts`: env var is read at
+// module load, so each case sets the value and reloads the module via
+// `jest.isolateModulesAsync`. The webext-storage stub
+// (jest.config.cjs `moduleNameMapper`) is re-instantiated inside the isolate
+// so `get()` returns the freshly derived default rather than a stored value
+// from a previous case.
+
+import type { debugTraceStorage as Storage } from "../debug-trace";
+
+interface ToggleModule {
+  debugTraceStorage: typeof Storage;
+  DEBUG_TRACE_ENABLED_DEFAULT: boolean;
+}
+
+async function loadToggle(): Promise<ToggleModule> {
+  let module!: ToggleModule;
+  await jest.isolateModulesAsync(async () => {
+    module = await import("../debug-trace");
+  });
+  return module;
+}
+
+describe("debugTraceStorage default", () => {
+  const original = (process.env as Record<string, string | undefined>)
+    .EXTENSION_DEBUG_TRACE_DEFAULT;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete (process.env as Record<string, unknown>)
+        .EXTENSION_DEBUG_TRACE_DEFAULT;
+    } else {
+      process.env.EXTENSION_DEBUG_TRACE_DEFAULT = original;
+    }
+  });
+
+  it("falls back to the committed default when the env var is empty", async () => {
+    process.env.EXTENSION_DEBUG_TRACE_DEFAULT = "";
+    const { debugTraceStorage, DEBUG_TRACE_ENABLED_DEFAULT } =
+      await loadToggle();
+    expect(await debugTraceStorage.get()).toBe(DEBUG_TRACE_ENABLED_DEFAULT);
+  });
+
+  it("uses true when the build-time override is 'true'", async () => {
+    process.env.EXTENSION_DEBUG_TRACE_DEFAULT = "true";
+    const { debugTraceStorage } = await loadToggle();
+    expect(await debugTraceStorage.get()).toBe(true);
+  });
+
+  it("uses false when the build-time override is 'false'", async () => {
+    process.env.EXTENSION_DEBUG_TRACE_DEFAULT = "false";
+    const { debugTraceStorage } = await loadToggle();
+    expect(await debugTraceStorage.get()).toBe(false);
+  });
+
+  it("ignores unrecognized strings and falls back to the committed default", async () => {
+    process.env.EXTENSION_DEBUG_TRACE_DEFAULT = "yes";
+    const { debugTraceStorage, DEBUG_TRACE_ENABLED_DEFAULT } =
+      await loadToggle();
+    expect(await debugTraceStorage.get()).toBe(DEBUG_TRACE_ENABLED_DEFAULT);
+  });
+});

--- a/extension/src/lib/debug-trace.ts
+++ b/extension/src/lib/debug-trace.ts
@@ -36,15 +36,34 @@ import type {
 
 export const DEBUG_TRACE_ENABLED_DEFAULT = false;
 
+// `process.env.EXTENSION_DEBUG_TRACE_DEFAULT` is substituted by build.ts when
+// the operator passes a defaults file with a `debugTrace` field. Literal
+// `"true"` / `"false"` forces a value; empty string falls back to the
+// committed default above. The build-time toggle is the only knob that ships
+// debug trace on by default — operators who want every fresh `chrome.storage`
+// to start with the recorder enabled (e.g. for CDP-driven automation that
+// scrapes the trace from IDB) flip it via the defaults file rather than
+// touching the popup on every session.
+function resolveDefault(): boolean {
+  const raw = process.env.EXTENSION_DEBUG_TRACE_DEFAULT;
+  if (raw === "true") {
+    return true;
+  }
+  if (raw === "false") {
+    return false;
+  }
+  return DEBUG_TRACE_ENABLED_DEFAULT;
+}
+
 // Storage key intentionally matches the existing prefix; popup reads via
 // `useChromeStorageValue` and content script reads via a cached subscribe
 // (see `enabled` below).
 export const debugTraceStorage = createChromeStorageValue<boolean>({
   key: "agent-browser-shield.debug-trace-enabled",
-  defaultValue: DEBUG_TRACE_ENABLED_DEFAULT,
+  defaultValue: resolveDefault(),
 });
 
-let enabled = DEBUG_TRACE_ENABLED_DEFAULT;
+let enabled = resolveDefault();
 let segmentCounter = 0;
 let initPromise: Promise<void> | null = null;
 
@@ -153,7 +172,7 @@ export function recordRuleApplication(input: RuleApplicationInput): void {
 // Test-only: reset module state between cases. The subscribe install
 // would otherwise carry the storage listener across tests.
 export function __resetDebugTraceForTesting(): void {
-  enabled = DEBUG_TRACE_ENABLED_DEFAULT;
+  enabled = resolveDefault();
   segmentCounter = 0;
   initPromise = null;
 }


### PR DESCRIPTION
## Summary

- New reserved key `debugTrace` in the build-time defaults override file (alongside `optionsButton` and `runOnInactiveTabs`). When `true`, fresh `chrome.storage` seeds the debug-trace recorder enabled so the popup's **Export** button can dump a JSONL trace without a human flipping the toggle. Wired via a new `EXTENSION_DEBUG_TRACE_DEFAULT` build-time substitution, mirroring the existing `options-button-toggle.ts` / `run-on-inactive-tabs.ts` pattern.
- Intended use case: CDP/Browserbase automation that scrapes the IDB-backed trace from a fresh session (e.g. for post-hoc visibility into what the extension touched on each step).
- Adds `extension/data/debug-trace.schema.json` — JSON Schema (draft 2020-12) describing the union of entries emitted into the JSONL export, mirroring the `DebugTraceEntry` union in `detection-messages.ts`. Linked from the README + install docs so downstream consumers can validate.
- README and `docs/src/content/docs/install.md` updated with the new reserved key and a pointer to the export schema. Example overrides file gets a `debugTrace` line so the knob is visible.

## Test plan

- [x] `bun run check` (extension/) — biome + eslint clean
- [x] `bun run test` (extension/) — full suite, 1885 tests pass, including 4 new `loadDefaultOverrides` cases and 4 new `debugTraceStorage` env-default cases (mirrors `optionsButtonStorage` pattern)
- [x] `pre-commit run` on touched docs/JSON — mdformat reflowed install.md once, then passed on re-run
- [x] `bun run build --defaults <{"debugTrace":true}>` — verified the substituted bundle contains `const raw = "true";` inside `resolveDefault()` and the storage seeded to `true` for fresh installs; default build (no override) still seeds `false`
- [ ] Smoke-test in Chrome: load the override'd `dist/`, open the popup on a fresh profile, confirm "Debug trace" checkbox starts ticked and exports JSONL

🤖 Generated with [Claude Code](https://claude.com/claude-code)