### PR TITLE
Fix: docs home before/after grid renders as raw markdown after Astro 6.4 bump

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -17,9 +17,16 @@ safer, and more accurate.
 <LinkButton href="https://github.com/pixiebrix/agent-browser-shield" icon="external">View on GitHub</LinkButton>
 <LinkButton href="https://clawhub.ai/pixiebrix/agent-browser-shield" icon="external">Skill on ClawHub</LinkButton>
 
-| Before                                            | After                                           |
-| ------------------------------------------------- | ----------------------------------------------- |
-| <Image src={beforeImage} alt="Before agent-browser-shield" /> | <Image src={afterImage} alt="After agent-browser-shield" /> |
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-block: 1.5rem;">
+  <figure style="margin: 0;">
+    <Image src={beforeImage} alt="Before agent-browser-shield" />
+    <figcaption style="text-align: center; font-weight: 600; margin-top: 0.5rem;">Before</figcaption>
+  </figure>
+  <figure style="margin: 0;">
+    <Image src={afterImage} alt="After agent-browser-shield" />
+    <figcaption style="text-align: center; font-weight: 600; margin-top: 0.5rem;">After</figcaption>
+  </figure>
+</div>
 
 ## Benefits
 


### PR DESCRIPTION
## Summary

- The before/after comparison on the docs home page was rendering as a literal `| Before | After |` text block with the images dropped underneath instead of side-by-side.
- Root cause: Astro 6.4 (bumped in #202, `6.3.7` → `6.4.2`) stopped parsing GFM table rows whose cells contain JSX expressions. The `<Image>` components still rendered, but the surrounding pipes were emitted as literal text inside a `<p>`.
- Replaced the markdown table in `docs/src/content/docs/index.mdx` with a CSS-grid `<div>` of `<figure>` elements so the comparison renders again. `index.mdx` was the only docs page using a markdown table, so no other surface to fix.

## Test plan

- [ ] `bun run build` in `docs/` succeeds
- [ ] `docs/dist/index.html` contains the `<figure>` grid (not a `<p>` with literal pipes)
- [ ] Visual check on `bun run preview` — Before and After screenshots render side-by-side with captions

🤖 Generated with [Claude Code](https://claude.com/claude-code)