### PR TITLE
Add: tabId + frameId on debug-trace records (JSONL + CDP)

### DIFF
--- a/docs/src/content/docs/debug-trace.md
+++ b/docs/src/content/docs/debug-trace.md
@@ -92,10 +92,12 @@ flip).
 
 ## Event shape
 
-Each entry returned by the dump (and each JSONL line in the export) matches the
+Each record returned by the dump (and each JSONL line in the export) matches the
 schema in
 [`extension/data/debug-trace.schema.json`](https://github.com/pixiebrix/agent-browser-shield/blob/main/extension/data/debug-trace.schema.json).
-The three top-level entry types are:
+Every record wraps an `entry` with the `tabId` and `frameId` it was recorded
+against, so traces from multiple frames (or concatenated across tabs) keep their
+attribution. The `entry` is one of three shapes:
 
 - **`segment`** — bookkeeping marker emitted at initial load, route changes,
   modal opens, and large mutation bursts. Subsequent rule-application entries

--- a/docs/src/content/docs/debug-trace.md
+++ b/docs/src/content/docs/debug-trace.md
@@ -95,9 +95,9 @@ flip).
 Each record returned by the dump (and each JSONL line in the export) matches the
 schema in
 [`extension/data/debug-trace.schema.json`](https://github.com/pixiebrix/agent-browser-shield/blob/main/extension/data/debug-trace.schema.json).
-Every record wraps an `entry` with the `tabId` and `frameId` it was recorded
-against, so traces from multiple frames (or concatenated across tabs) keep their
-attribution. The `entry` is one of three shapes:
+Every record carries the `tabId` and `frameId` it was recorded against, so
+traces from multiple frames (or concatenated across tabs) keep their
+attribution. The `type` discriminator picks one of three shapes:
 
 - **`segment`** — bookkeeping marker emitted at initial load, route changes,
   modal opens, and large mutation bursts. Subsequent rule-application entries

--- a/extension/bun.lock
+++ b/extension/bun.lock
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.16",
+        "@cfworker/json-schema": "^4.1.1",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint/js": "10.0.1",
         "@resvg/resvg-js": "^2.6.2",
@@ -139,6 +140,8 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
+
+    "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 

--- a/extension/data/debug-trace.schema.json
+++ b/extension/data/debug-trace.schema.json
@@ -1,13 +1,29 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://pixiebrix.github.io/agent-browser-shield/schemas/debug-trace.schema.json",
-  "title": "Agent Browser Shield debug-trace entry",
-  "description": "One entry in the JSONL export produced by the popup's \"Export\" button when the debug-trace toggle is enabled. The export file contains one JSON-encoded entry per line in chronological order; this schema describes a single line. Entry shapes mirror the `DebugTraceEntry` union in extension/src/lib/detection-messages.ts.",
-  "oneOf": [
-    { "$ref": "#/$defs/SegmentEntry" },
-    { "$ref": "#/$defs/RuleApplicationEntry" },
-    { "$ref": "#/$defs/NavigationEntry" }
-  ],
+  "title": "Agent Browser Shield debug-trace stored event",
+  "description": "One stored event in the JSONL export produced by the popup's \"Export\" button when the debug-trace toggle is enabled. The export file contains one JSON-encoded stored event per line in chronological order; this schema describes a single line. The wrapper carries the tabId/frameId the background recorded against IDB; the nested `entry` mirrors the `DebugTraceEntry` union in extension/src/lib/detection-messages.ts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["tabId", "frameId", "entry"],
+  "properties": {
+    "tabId": {
+      "type": "integer",
+      "description": "chrome.tabs id the event was recorded against."
+    },
+    "frameId": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Frame id within the tab. 0 for the top frame; positive for subframes. The `navigation` entry type is emitted only for the top frame."
+    },
+    "entry": {
+      "oneOf": [
+        { "$ref": "#/$defs/SegmentEntry" },
+        { "$ref": "#/$defs/RuleApplicationEntry" },
+        { "$ref": "#/$defs/NavigationEntry" }
+      ]
+    }
+  },
   "$defs": {
     "SegmentEntry": {
       "type": "object",

--- a/extension/data/debug-trace.schema.json
+++ b/extension/data/debug-trace.schema.json
@@ -1,37 +1,47 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://pixiebrix.github.io/agent-browser-shield/schemas/debug-trace.schema.json",
-  "title": "Agent Browser Shield debug-trace stored event",
-  "description": "One stored event in the JSONL export produced by the popup's \"Export\" button when the debug-trace toggle is enabled. The export file contains one JSON-encoded stored event per line in chronological order; this schema describes a single line. The wrapper carries the tabId/frameId the background recorded against IDB; the nested `entry` mirrors the `DebugTraceEntry` union in extension/src/lib/detection-messages.ts.",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["tabId", "frameId", "entry"],
-  "properties": {
-    "tabId": {
-      "type": "integer",
-      "description": "chrome.tabs id the event was recorded against."
-    },
-    "frameId": {
-      "type": "integer",
-      "minimum": 0,
-      "description": "Frame id within the tab. 0 for the top frame; positive for subframes. The `navigation` entry type is emitted only for the top frame."
-    },
-    "entry": {
-      "oneOf": [
-        { "$ref": "#/$defs/SegmentEntry" },
-        { "$ref": "#/$defs/RuleApplicationEntry" },
-        { "$ref": "#/$defs/NavigationEntry" }
-      ]
-    }
-  },
+  "title": "Agent Browser Shield debug-trace record",
+  "description": "One record returned by `window.__abs_dumpTrace()` or written as one line of the popup's JSONL export when the debug-trace toggle is enabled. Each record is a `DebugTraceEntry` (segment marker, rule application, or navigation) plus the `tabId` / `frameId` it was captured in. The IDB-internal `addedAt` is not exposed — every entry carries its own `timestamp` stamped at content-script emit time.",
+  "oneOf": [
+    { "$ref": "#/$defs/SegmentEntry" },
+    { "$ref": "#/$defs/RuleApplicationEntry" },
+    { "$ref": "#/$defs/NavigationEntry" }
+  ],
   "$defs": {
+    "TabFrame": {
+      "type": "object",
+      "description": "Recording context shared by every record. Lets consumers attribute and group events across frames or concatenated tab traces.",
+      "required": ["tabId", "frameId"],
+      "properties": {
+        "tabId": {
+          "type": "integer",
+          "description": "chrome.tabs id the event was recorded against."
+        },
+        "frameId": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Frame id within the tab. 0 for the top frame; positive for subframes. `navigation` records are emitted only for the top frame."
+        }
+      }
+    },
     "SegmentEntry": {
       "type": "object",
-      "description": "Boundary marker emitted by the content script at the start of a logical segment (initial load, route change, modal open, mutation burst). Subsequent rule-application entries carry the same `segmentId` until the next marker.",
+      "description": "Boundary marker emitted by the content script at the start of a logical segment (initial load, route change, modal open, mutation burst). Subsequent rule-application records carry the same `segmentId` until the next marker.",
       "additionalProperties": false,
-      "required": ["type", "segmentId", "kind", "timestamp", "meta"],
+      "required": [
+        "type",
+        "tabId",
+        "frameId",
+        "segmentId",
+        "kind",
+        "timestamp",
+        "meta"
+      ],
       "properties": {
         "type": { "const": "segment" },
+        "tabId": { "$ref": "#/$defs/TabFrame/properties/tabId" },
+        "frameId": { "$ref": "#/$defs/TabFrame/properties/frameId" },
         "segmentId": {
           "type": "integer",
           "minimum": 1,
@@ -63,6 +73,8 @@
       "additionalProperties": false,
       "required": [
         "type",
+        "tabId",
+        "frameId",
         "segmentId",
         "ruleId",
         "kind",
@@ -73,6 +85,8 @@
       ],
       "properties": {
         "type": { "const": "rule-application" },
+        "tabId": { "$ref": "#/$defs/TabFrame/properties/tabId" },
+        "frameId": { "$ref": "#/$defs/TabFrame/properties/frameId" },
         "segmentId": {
           "type": "integer",
           "minimum": 0,
@@ -115,9 +129,11 @@
       "type": "object",
       "description": "Top-level navigation marker emitted by the background service worker on every chrome.tabs.onUpdated loading transition. Lets the trace span multiple page loads in the same tab.",
       "additionalProperties": false,
-      "required": ["type", "url", "timestamp"],
+      "required": ["type", "tabId", "frameId", "url", "timestamp"],
       "properties": {
         "type": { "const": "navigation" },
+        "tabId": { "$ref": "#/$defs/TabFrame/properties/tabId" },
+        "frameId": { "$ref": "#/$defs/TabFrame/properties/frameId" },
         "url": {
           "type": ["string", "null"],
           "description": "Tab URL at the moment the loading transition fired. May be the previous URL on a same-page reload, or the new URL on a cross-page navigation. Null when the tab has no URL yet (initial new-tab navigation)."

--- a/extension/package.json
+++ b/extension/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
+    "@cfworker/json-schema": "^4.1.1",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
     "@eslint/js": "10.0.1",
     "@resvg/resvg-js": "^2.6.2",

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -4,6 +4,7 @@
 import { startCheckoutCheckboxDefenseRegistration } from "./lib/checkout-checkbox-defense-registration";
 import { installCheckoutCheckboxDefense } from "./lib/checkout-checkbox-defense-source";
 import { debugTraceStorage } from "./lib/debug-trace";
+import { toExportedRecord } from "./lib/debug-trace-export";
 import {
   appendEvent as appendDebugTraceEvent,
   clearTab as clearDebugTraceTab,
@@ -447,8 +448,13 @@ chrome.runtime.onMessage.addListener(
       // (up to its 10s timeout). `return true` keeps the message
       // channel open until `sendResponse` fires.
       void getDebugTraceForTab(tabId)
-        .then((entries) => {
-          const response: GetTabDebugTraceResponse = { entries };
+        .then((stored) => {
+          // Flatten to the public wire shape: `addedAt` is internal IDB
+          // bookkeeping and the tabId/frameId live on the entry, matching
+          // `extension/data/debug-trace.schema.json`.
+          const response: GetTabDebugTraceResponse = {
+            entries: stored.map((record) => toExportedRecord(record)),
+          };
           sendResponse(response);
         })
         .catch((error: unknown) => {

--- a/extension/src/lib/__tests__/debug-trace-export.test.ts
+++ b/extension/src/lib/__tests__/debug-trace-export.test.ts
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Schema-conformance check for the popup's JSONL export. Reads the same
+// `extension/data/debug-trace.schema.json` the README/docs link to and
+// validates every line `buildJsonl` emits with @cfworker/json-schema. If a
+// field is added to a `DebugTraceEntry` variant (or the wrapper) without a
+// corresponding schema bump, the existing fixture covers the existing
+// variants and the new field would either be flagged by `additionalProperties:
+// false` or land here as a fixture omission.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Validator } from "@cfworker/json-schema";
+import { buildJsonl, toExportedRecord } from "../debug-trace-export";
+import type { DebugTraceStoredEntry } from "../detection-messages";
+
+const schema = JSON.parse(
+  readFileSync(
+    join(__dirname, "..", "..", "..", "data", "debug-trace.schema.json"),
+    "utf8",
+  ),
+) as Record<string, unknown>;
+
+const validator = new Validator(schema, "2020-12");
+
+function expectValid(line: string): void {
+  const parsed: unknown = JSON.parse(line);
+  const result = validator.validate(parsed);
+  if (!result.valid) {
+    throw new Error(
+      `JSONL line did not match schema:\n${line}\nerrors: ${JSON.stringify(
+        result.errors,
+        null,
+        2,
+      )}`,
+    );
+  }
+}
+
+// One stored record per entry variant the recorder can emit. Mirrors the
+// shapes in `lib/debug-trace.ts` (segment, rule-application) and the
+// background's navigation marker.
+function fixtures(): DebugTraceStoredEntry[] {
+  return [
+    {
+      tabId: 42,
+      frameId: 0,
+      addedAt: 1_700_000_000_000,
+      entry: {
+        type: "segment",
+        segmentId: 1,
+        kind: "initial-load",
+        timestamp: 1_700_000_000_000,
+        meta: { url: "https://example.com/" },
+      },
+    },
+    {
+      tabId: 42,
+      frameId: 0,
+      addedAt: 1_700_000_000_100,
+      entry: {
+        type: "rule-application",
+        segmentId: 1,
+        ruleId: "hidden-affiliate-sanitize",
+        kind: "sanitize",
+        timestamp: 1_700_000_000_100,
+        selector: "a.ref-link",
+        beforeHtml:
+          "<a class='ref-link' href='https://aff.example/?ref=x'>x</a>",
+        afterHtml: "<a class='ref-link' href='https://aff.example/'>x</a>",
+      },
+    },
+    {
+      tabId: 42,
+      frameId: 7,
+      addedAt: 1_700_000_000_200,
+      entry: {
+        type: "rule-application",
+        segmentId: 2,
+        ruleId: "pii-mask",
+        kind: "mask",
+        timestamp: 1_700_000_000_200,
+        selector: "span.email",
+        beforeHtml: "",
+        afterHtml: "<span class='abs-placeholder' />",
+        beforeText: "alice@example.com",
+      },
+    },
+    {
+      tabId: 42,
+      frameId: 0,
+      addedAt: 1_700_000_000_300,
+      entry: {
+        type: "rule-application",
+        segmentId: 2,
+        ruleId: "tracker-hide",
+        kind: "hide",
+        timestamp: 1_700_000_000_300,
+        selector: ".tracker-pixel",
+        beforeHtml: "<img class='tracker-pixel' />",
+        afterHtml: "<img class='tracker-pixel' />",
+        cssOnly: true,
+      },
+    },
+    {
+      tabId: 42,
+      frameId: 0,
+      addedAt: 1_700_000_000_400,
+      entry: {
+        type: "navigation",
+        url: "https://example.com/next",
+        timestamp: 1_700_000_000_400,
+      },
+    },
+    {
+      tabId: 42,
+      frameId: 0,
+      addedAt: 1_700_000_000_500,
+      entry: {
+        type: "navigation",
+        url: null,
+        timestamp: 1_700_000_000_500,
+      },
+    },
+  ];
+}
+
+function firstFixture(): DebugTraceStoredEntry {
+  const [first, ...rest] = fixtures();
+  if (!first) {
+    throw new Error("fixtures() must return at least one record");
+  }
+  void rest;
+  return first;
+}
+
+describe("debug-trace JSONL export", () => {
+  it("strips addedAt and keeps tabId / frameId / entry", () => {
+    const stored = firstFixture();
+    const exported = toExportedRecord(stored);
+    expect(exported).toEqual({
+      tabId: stored.tabId,
+      frameId: stored.frameId,
+      entry: stored.entry,
+    });
+    expect(exported).not.toHaveProperty("addedAt");
+  });
+
+  it("produces one JSON-encoded record per line", () => {
+    const stored = fixtures();
+    const jsonl = buildJsonl(stored);
+    const lines = jsonl.split("\n");
+    expect(lines).toHaveLength(stored.length);
+    // No trailing newline — splitting again must not yield empties.
+    expect(lines.at(-1)).not.toBe("");
+  });
+
+  it("every line validates against extension/data/debug-trace.schema.json", () => {
+    const jsonl = buildJsonl(fixtures());
+    for (const line of jsonl.split("\n")) {
+      expectValid(line);
+    }
+  });
+
+  it("rejects a line that drops tabId (schema is load-bearing)", () => {
+    // Smoke test that the validator actually rejects something — if it
+    // accepted everything, the schema test would silently pass even on a
+    // shape regression. Construct a payload missing `tabId` and assert
+    // the validator catches it.
+    const { tabId: _tabId, ...withoutTabId } = toExportedRecord(firstFixture());
+    const result = validator.validate(withoutTabId);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/extension/src/lib/__tests__/debug-trace-export.test.ts
+++ b/extension/src/lib/__tests__/debug-trace-export.test.ts
@@ -136,15 +136,16 @@ function firstFixture(): DebugTraceStoredEntry {
 }
 
 describe("debug-trace JSONL export", () => {
-  it("strips addedAt and keeps tabId / frameId / entry", () => {
+  it("flattens stored records into entry + tabId + frameId", () => {
     const stored = firstFixture();
     const exported = toExportedRecord(stored);
     expect(exported).toEqual({
+      ...stored.entry,
       tabId: stored.tabId,
       frameId: stored.frameId,
-      entry: stored.entry,
     });
     expect(exported).not.toHaveProperty("addedAt");
+    expect(exported).not.toHaveProperty("entry");
   });
 
   it("produces one JSON-encoded record per line", () => {

--- a/extension/src/lib/debug-trace-export.ts
+++ b/extension/src/lib/debug-trace-export.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// JSONL serialization for the popup's "Export" button. Lives in `lib/` so
+// the schema-conformance test can validate the output without dragging the
+// popup React hook into the test harness.
+//
+// Each line is the IDB-stored event minus `addedAt` (the background's
+// append timestamp is internal bookkeeping; each entry already carries its
+// own `timestamp` stamped at content-script emit time). The on-wire shape
+// matches `extension/data/debug-trace.schema.json` and the value returned
+// by `window.__abs_dumpTrace()`.
+
+import omit from "lodash/omit";
+import type { DebugTraceStoredEntry } from "./detection-messages";
+
+export type ExportedTraceRecord = Omit<DebugTraceStoredEntry, "addedAt">;
+
+export function toExportedRecord(
+  stored: DebugTraceStoredEntry,
+): ExportedTraceRecord {
+  return omit(stored, "addedAt");
+}
+
+export function buildJsonl(stored: DebugTraceStoredEntry[]): string {
+  return stored
+    .map((record) => JSON.stringify(toExportedRecord(record)))
+    .join("\n");
+}

--- a/extension/src/lib/debug-trace-export.ts
+++ b/extension/src/lib/debug-trace-export.ts
@@ -1,25 +1,33 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
-// JSONL serialization for the popup's "Export" button. Lives in `lib/` so
-// the schema-conformance test can validate the output without dragging the
-// popup React hook into the test harness.
-//
-// Each line is the IDB-stored event minus `addedAt` (the background's
-// append timestamp is internal bookkeeping; each entry already carries its
-// own `timestamp` stamped at content-script emit time). The on-wire shape
-// matches `extension/data/debug-trace.schema.json` and the value returned
-// by `window.__abs_dumpTrace()`.
+// Public on-wire shape for the popup's JSONL export and the
+// `window.__abs_dumpTrace()` CDP path. Both surfaces serve the same
+// schema (`extension/data/debug-trace.schema.json`): the recorded
+// `DebugTraceEntry` plus the `tabId` / `frameId` it was captured in.
+// The IDB-internal `addedAt` is internal bookkeeping and is not exposed
+// — each entry already carries its own `timestamp` stamped at
+// content-script emit time, which is the field a consumer correlating
+// with page activity wants.
 
-import omit from "lodash/omit";
-import type { DebugTraceStoredEntry } from "./detection-messages";
+import type {
+  DebugTraceEntry,
+  DebugTraceStoredEntry,
+} from "./detection-messages";
 
-export type ExportedTraceRecord = Omit<DebugTraceStoredEntry, "addedAt">;
+export type ExportedTraceRecord = DebugTraceEntry & {
+  tabId: number;
+  frameId: number;
+};
 
 export function toExportedRecord(
   stored: DebugTraceStoredEntry,
 ): ExportedTraceRecord {
-  return omit(stored, "addedAt");
+  return {
+    ...stored.entry,
+    tabId: stored.tabId,
+    frameId: stored.frameId,
+  };
 }
 
 export function buildJsonl(stored: DebugTraceStoredEntry[]): string {

--- a/extension/src/lib/detection-messages.ts
+++ b/extension/src/lib/detection-messages.ts
@@ -212,6 +212,9 @@ export interface GetTabDebugTraceRequest {
   type: "get-tab-debug-trace";
 }
 
+// Flat on-wire shape returned to the page world. Defined in
+// `lib/debug-trace-export.ts` so this messages module stays free of
+// the wire-shape helper.
 export interface GetTabDebugTraceResponse {
-  entries: DebugTraceStoredEntry[];
+  entries: Array<DebugTraceEntry & { tabId: number; frameId: number }>;
 }

--- a/extension/src/popup/use-tab-debug-trace.ts
+++ b/extension/src/popup/use-tab-debug-trace.ts
@@ -76,9 +76,10 @@ export function useTabDebugTrace(tabId: number | null): TabDebugTrace {
   // stream the export through `jq -c`, grep for a rule id, or diff two
   // captures without parsing the whole file. file-saver triggers an
   // anchor-based download from the popup's extension origin — no
-  // chrome.downloads permission needed. Per-line shape is defined by
-  // `buildJsonl` and asserted against `data/debug-trace.schema.json` in
-  // `__tests__/debug-trace-export.test.ts`.
+  // chrome.downloads permission needed. Per-line shape is the
+  // `ExportedTraceRecord` defined by `lib/debug-trace-export.ts`
+  // (`DebugTraceEntry` + `tabId` + `frameId`), asserted against
+  // `data/debug-trace.schema.json` in `__tests__/debug-trace-export.test.ts`.
   const exportJsonl = useCallback(async () => {
     if (tabId === null) {
       return;

--- a/extension/src/popup/use-tab-debug-trace.ts
+++ b/extension/src/popup/use-tab-debug-trace.ts
@@ -14,6 +14,7 @@
 
 import { saveAs } from "file-saver";
 import { useCallback, useEffect, useState } from "react";
+import { buildJsonl } from "../lib/debug-trace-export";
 import {
   clearTab,
   getEventsForTab,
@@ -75,15 +76,15 @@ export function useTabDebugTrace(tabId: number | null): TabDebugTrace {
   // stream the export through `jq -c`, grep for a rule id, or diff two
   // captures without parsing the whole file. file-saver triggers an
   // anchor-based download from the popup's extension origin — no
-  // chrome.downloads permission needed.
+  // chrome.downloads permission needed. Per-line shape is defined by
+  // `buildJsonl` and asserted against `data/debug-trace.schema.json` in
+  // `__tests__/debug-trace-export.test.ts`.
   const exportJsonl = useCallback(async () => {
     if (tabId === null) {
       return;
     }
     const stored = await getEventsForTab(tabId);
-    const payload = stored
-      .map((record) => JSON.stringify(record.entry))
-      .join("\n");
+    const payload = buildJsonl(stored);
     const blob = new Blob([payload], {
       type: "application/x-ndjson;charset=utf-8",
     });


### PR DESCRIPTION
## Summary

- Add `tabId` and `frameId` to every record in the popup's JSONL export and the `window.__abs_dumpTrace()` CDP response. Today the JSONL drops both (`tabId` only appears in the filename, `frameId` is lost entirely); the CDP path returned them via an envelope. The two surfaces now share one flat shape: `DebugTraceEntry + tabId + frameId`. `addedAt` is internal IDB bookkeeping and is not exposed (each entry carries its own `timestamp` stamped at content-script emit time).
- Update `extension/data/debug-trace.schema.json` to put `tabId` / `frameId` on each entry variant (segment / rule-application / navigation) so the public schema covers both surfaces with no envelope.
- New `lib/debug-trace-export.ts` exports `toExportedRecord` + `buildJsonl`. The popup hook and the background's CDP handler both call into it so the wire shape lives in one place.
- New schema-conformance test (`lib/__tests__/debug-trace-export.test.ts`) reads the actual schema file from disk and runs each emitted line through `@cfworker/json-schema`. Adding a field to a `DebugTraceEntry` variant without bumping the schema fails the test (`additionalProperties: false` + a negative-control case that drops `tabId`).
- Docs (`docs/src/content/docs/debug-trace.md`) updated: the prose that previously said "the three top-level entry types are" now describes records as `type`-discriminated with `tabId` / `frameId` on every record.

## Test plan

- [x] `bun run check` (biome + eslint) — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 1910 tests pass (4 new in `debug-trace-export.test.ts`)
- [x] `bun run knip` — clean
- [x] `pre-commit run` on changed files — passes mdformat, biome, eslint, copyright headers
- [ ] Manual: load the unpacked extension, enable the popup's debug trace, click Export — confirm each JSONL line has top-level `type`, `tabId`, `frameId`.
- [ ] Manual: in a CDP-driven harness, call `await window.__abs_dumpTrace()` and confirm each element is the flat shape (no `entry` / `addedAt` envelope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)