### PR TITLE
Docs: backfill MADR 4.0 decisions/ for load-bearing decisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,16 @@ Ideas explored in this repository:
   irrelevant content, hiding user-generated comments which could contain
   prompt-injection attacks, etc.
 
+## Architecture decisions
+
+Load-bearing decisions are recorded as [MADR 4.0](https://adr.github.io/madr/)
+ADRs under [`decisions/`](./decisions/). Read the [index](./decisions/README.md)
+before making changes that touch a recorded decision — rule taxonomy, frame
+execution, DOM markers, the `lib/` ↔ `rules/` boundary, SPA re-scan,
+scrub-don't-detach, shadow-DOM coverage, rule defaults, telemetry posture,
+injection-pattern handling, lint stack, background-worker purity, CSS-first
+hide, and the release flow.
+
 ## Reference
 
 - Upload extension for use with browserbase:

--- a/decisions/0001-source-available-license-and-cla.md
+++ b/decisions/0001-source-available-license-and-cla.md
@@ -1,0 +1,86 @@
+---
+status: accepted
+date: 2025-10-09
+---
+
+# Source-available PolyForm Shield 1.0.0 license + CLA
+
+## Context and Problem Statement
+
+`agent-browser-shield` is published publicly and is intended to be usable
+commercially, internally, or for research, while still allowing PixieBrix to
+fund continued development against well-resourced competitors that could fork
+the project and ship a rival. The choice of license also has to be compatible
+with accepting outside contributions whose copyright the contributors retain.
+
+## Decision Drivers
+
+- "Permissive OSS licenses are great for adoption but they don't give us a way
+  to fund continued development of `agent-browser-shield` against well-resourced
+  competitors who could fork it and ship a rival product." (`LICENSING.md` §"Why
+  not Apache 2.0 or MIT?")
+- The need to keep the source open and freely usable, "including by commercial
+  users", while reserving the right to ship a competing agent-protection product
+  for PixieBrix's commercial customers (`LICENSING.md`).
+- The need for outside contributions to be re-licensable under commercial terms
+  so PixieBrix can sell commercial licenses to would-be competitors
+  (`LICENSING.md` §"Contributions").
+
+## Considered Options
+
+- Apache 2.0 / MIT (permissive OSS).
+- PolyForm Shield 1.0.0 (source-available with a competitor carve-out).
+
+## Decision Outcome
+
+Chosen option: **PolyForm Shield 1.0.0**, applied via `LICENSE` and explained in
+`LICENSING.md`, plus a Contributor License Agreement that all contributors sign
+once on their first PR. The CLA grants PixieBrix the right to relicense
+contributions, "including under commercial terms — which is what lets us sell
+commercial licenses to would-be competitors while keeping the project
+source-available for everyone else" (`LICENSING.md` §"Contributions").
+
+### Consequences
+
+- Good, because use is permitted "for any purpose, including commercial use",
+  subject to a single carve-out: building "a product that competes with
+  `agent-browser-shield` or with any PixieBrix product built on top of it"
+  requires a commercial license (`LICENSING.md` §"What's allowed for free",
+  §"What requires a commercial license").
+- Good, because contributors retain copyright while PixieBrix gets the
+  re-licensing right needed to sustain a commercial track (`LICENSING.md`
+  §"Contributions").
+- Neutral, because dependencies licensed under Apache 2.0 / MIT / BSD / ISC
+  remain under their own terms; the combined work is bound by PolyForm Shield
+  because of this project's license, not theirs (`LICENSING.md`
+  §"Dependencies").
+
+### Confirmation
+
+- The `LICENSE` file at the repo root holds the PolyForm Shield 1.0.0 text.
+- The CLA flow is enforced by `CONTRIBUTING.md` §"Legal: license and CLA" and
+  the `.github/CLA.md` document linked from contributor onboarding.
+
+## Pros and Cons of the Options
+
+### Apache 2.0 / MIT
+
+- Good, because permissive OSS licenses help adoption (`LICENSING.md` §"Why not
+  Apache 2.0 or MIT?").
+- Bad, because they "don't give us a way to fund continued development of
+  `agent-browser-shield` against well-resourced competitors who could fork it
+  and ship a rival product." (`LICENSING.md` §"Why not Apache 2.0 or MIT?").
+
+### PolyForm Shield 1.0.0
+
+- Good, because it "keeps the source open and freely usable — including by
+  commercial users — while reserving the right to ship a competing
+  agent-protection product for PixieBrix's commercial customers."
+  (`LICENSING.md` §"Why not Apache 2.0 or MIT?").
+
+## More Information
+
+- [`LICENSE`](../LICENSE)
+- [`LICENSING.md`](../LICENSING.md)
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) §"Legal: license and CLA"
+- [`.github/CLA.md`](../.github/CLA.md)

--- a/decisions/0002-rule-id-naming-taxonomy.md
+++ b/decisions/0002-rule-id-naming-taxonomy.md
@@ -1,0 +1,109 @@
+---
+status: accepted
+date: 2026-06-03
+---
+
+# Rule ID naming taxonomy (`<target>-<verb>`, five canonical verbs)
+
+## Context and Problem Statement
+
+Rule IDs had drifted to "10 verbs across 28 rules" — `hide`, `mask`, `flag`,
+`scrub`, `suppress`, `neutralize`, `clear`, `redact`, `sanitize`, `strip` — with
+no shared definition of what each verb meant. PR #105 called this "verb
+proliferation" and PR #95 §"Summary" notes there was "no canonical naming
+reference for the 24th" rule when the count reached that point.
+
+The most load-bearing piece is the surface-level "hide" semantics:
+`selector-hide-rule.ts` already toggled between two distinct mechanisms via
+`removeEntirely`. Nine rules called `replaceWithBlockPlaceholder` (detach +
+reveal placeholder); four called `removeEntirely: true` (in-place
+`display: none`). They shared the `-hide` suffix even though they did different
+things (PR #105 §"What changed").
+
+## Decision Drivers
+
+- "Collapse the verb proliferation in rule IDs (10 verbs across 28 rules) into a
+  five-verb canonical taxonomy that names the DOM operation, not the intent."
+  (PR #105 §"Summary")
+- The verb has to describe what the rule does to the DOM, not the threat it
+  addresses, so a contributor can pick the verb correctly from the rule's
+  implementation (PR #105 §"Summary"; `CONTRIBUTING.md` §"Rule ID naming").
+- `-helper` is reserved for non-defensive agent affordances such as
+  `search-url-helper` (`CONTRIBUTING.md` §"Rule ID naming"; `AGENTS.md` §"Rule
+  ID naming").
+
+## Considered Options
+
+- Keep the ad-hoc verb set (10 verbs).
+- Adopt a five-verb canonical taxonomy: `annotate`, `hide`, `redact`,
+  `sanitize`, `strip`.
+
+## Decision Outcome
+
+Chosen option: **five-verb canonical taxonomy**, applied to every existing rule
+via the renames listed in PR #105.
+
+| Verb       | Semantics                                                                                                                                                                  |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `annotate` | Add agent-facing info; page content unchanged.                                                                                                                             |
+| `hide`     | Visually conceal with `display: none`; element stays in DOM.                                                                                                               |
+| `redact`   | Replace content with a click-to-reveal placeholder block/token.                                                                                                            |
+| `sanitize` | Element stays; clean attributes / text / state.                                                                                                                            |
+| `strip`    | Remove the agent-readable content from the DOM (usually by blanking the data carrier — attribute value, text node, comment data — so SPA framework references stay valid). |
+
+The hide-vs-redact split follows the implementation: four `removeEntirely: true`
+rules keep `-hide`; nine `replaceWithBlockPlaceholder` rules became `-redact`
+(PR #105 §"What changed"). `-helper` (e.g. `search-url-helper`) sits outside the
+verb set because it "adds capability rather than remove[s] a problem"
+(`CONTRIBUTING.md` §"Rule ID naming").
+
+### Consequences
+
+- Good, because a single verb taxonomy gives contributors and agents a decision
+  rule for every new rule, with an explicit hide-vs-redact decision rule keyed
+  on whether the user could "meaningfully act on the element when it's gone"
+  (`CONTRIBUTING.md` §"Rule ID naming").
+- Bad, because `storage.normalize()` "drops keys not in `RULE_IDS`, so any rule
+  a user explicitly disabled under its old ID will revert to the default on
+  upgrade." (PR #105 §"Caveat: stored user toggles"). PR #105 notes that
+  "default-enabled rules stay default-on, default-off stay default-off — so the
+  visible effect is limited to users who intentionally disabled a now-renamed
+  rule" and that a migration map could close the gap as a follow-up.
+
+### Confirmation
+
+- Custom ESLint rule `agent-browser-shield/rule-id-matches-filename` enforces
+  that on-disk filename matches the declared `id` (`CONTRIBUTING.md` §"Adding a
+  new rule"; PR #29 §"Summary").
+- `extension/src/rules/__tests__/catalog.test.ts` enforces parity between
+  `rule-metadata.ts` and `rules/index.ts` (`AGENTS.md` §"Rule defaults").
+
+## Pros and Cons of the Options
+
+### Keep 10 ad-hoc verbs
+
+- Bad, because there was "no canonical naming reference for the 24th [rule]" (PR
+  #95 §"Summary").
+- Bad, because related rules (e.g. `pii-mask`, `secrets-mask`,
+  `prompt-injection-hide`, `comments-hide`) used different verbs for the same
+  DOM operation (PR #105 §"What changed").
+
+### Five-verb canonical taxonomy
+
+- Good, because rules with the same DOM operation share a verb, including the
+  previously inconsistent placeholder-swap family (`comments`, `footer`,
+  `reviews`, `irrelevant-sections`, `countdown-timer`, `scarcity`,
+  `social-embed`, `cross-origin-frame`, `prompt-injection`) (PR #105 §"What
+  changed").
+- Good, because the taxonomy is mechanically discoverable from the rule's code
+  (PR #105 §"Summary"; `AGENTS.md` §"Rule ID naming").
+
+## More Information
+
+- PR
+  [#105 — Standardize rule-ID verbs (hide / redact / sanitize / strip / annotate)](https://github.com/pixiebrix/agent-browser-shield/pull/105)
+- [`AGENTS.md`](../AGENTS.md) §"Rule ID naming"
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) §"Rule ID naming"
+- PR
+  [#29 — Add ESLint with unicorn plugin and custom rule infrastructure](https://github.com/pixiebrix/agent-browser-shield/pull/29)
+  — `rule-id-matches-filename` custom ESLint rule

--- a/decisions/0003-run-rule-engine-in-all-frames.md
+++ b/decisions/0003-run-rule-engine-in-all-frames.md
@@ -1,0 +1,87 @@
+---
+status: accepted
+date: 2026-05-30
+---
+
+# Run rule engine in all frames
+
+## Context and Problem Statement
+
+The content script originally injected into the top frame only. Rules such as
+PII/secrets redaction, prompt-injection hiding, ads-hide, hidden-text-strip, and
+the comments/reviews family did not "actually reach" content rendered inside
+iframes — Disqus, Trustpilot, AdSense, and third-party comment widgets were
+unprotected (PR #4 §"Summary").
+
+## Decision Drivers
+
+- Reach iframe-embedded content so defenses apply uniformly (PR #4 §"Summary").
+- Cover `about:blank` / `about:srcdoc` subframes that default injection rules
+  don't match (PR #4 §"Summary").
+- Avoid duplicating page-wide chrome (e.g., the floating options badge) once per
+  frame (PR #4 §"Summary").
+
+## Considered Options
+
+- Top-frame only (the previous behavior).
+- All frames, with a per-rule opt-in to skip subframes.
+
+## Decision Outcome
+
+Chosen option: **all frames, with a per-rule `topFrameOnly` opt-in.**
+
+- Manifest enables `all_frames: true` plus `match_origin_as_fallback` so
+  `about:blank` / `about:srcdoc` iframes are also covered (PR #4 §"Summary").
+- The `Rule` type gains an opt-in `topFrameOnly` flag. Rules whose targets are
+  "inherently page-wide" carry it so they don't fire pointlessly in subframes:
+  `footer-hide`, `cookie-banner-hide`, `newsletter-modal-hide`,
+  `chat-widget-hide`, `search-url-helper`, `irrelevant-sections-hide` (PR #4
+  §"Summary").
+- The floating options badge is gated to the top frame only — "no more N badges
+  per page" (PR #4 §"Summary").
+- `lib/frame.ts` is the single source of truth for "are we the top frame", with
+  a defensive `try/catch` around the cross-origin `window.top` access (PR #4
+  §"Summary").
+
+### Consequences
+
+- Good, because frame-gating is a per-rule decision; the default is full
+  coverage (PR #4 §"Summary").
+- Good, because no new host permissions are required: `<all_urls>` in `matches`
+  already covers every origin the script needs to inject into (PR #4 §"Notes").
+- Bad, because `ads-hide` deliberately runs in subframes — many ad networks
+  render the actual ad content inside their iframe — which carries a "Per-frame
+  stylesheet cost (~600KB CSS text per frame) [as] a known tradeoff worth a
+  follow-up perf pass." (PR #4 §"Notes").
+
+### Confirmation
+
+- `extension/src/lib/__tests__/rule-engine.test.ts` covers "the three
+  frame-gating branches (top-frame + frame-agnostic rule applied, top-only rule
+  skipped in subframes, unavailable rule never applied)" (PR #4 §"Summary").
+- The manifest-permission-diff CI workflow (ADR-0005? no — added in PR #56)
+  flags any future widening of `permissions`, `host_permissions`, or `matches`
+  so frame coverage cannot quietly broaden without review (PR #56 §"Summary").
+
+## Pros and Cons of the Options
+
+### Top-frame only
+
+- Bad, because iframe-embedded comment widgets, ad networks, and similar content
+  are never seen by any rule (PR #4 §"Summary").
+
+### All frames + `topFrameOnly` opt-in
+
+- Good, because frame-gating is a per-rule decision (PR #4 §"Summary").
+- Bad, because the EasyList stylesheet has to be present per-frame for in-iframe
+  ads to be hidden (PR #4 §"Notes").
+
+## More Information
+
+- PR
+  [#4 — Run rule engine in all frames](https://github.com/pixiebrix/agent-browser-shield/pull/4)
+- PR
+  [#56 — Add knip, codegen-freshness, and manifest-permission-diff CI checks](https://github.com/pixiebrix/agent-browser-shield/pull/56)
+  — permission-diff workflow
+- Source: `extension/src/lib/frame.ts`,
+  `extension/src/lib/__tests__/rule-engine.test.ts`

--- a/decisions/0004-centralize-dom-markers.md
+++ b/decisions/0004-centralize-dom-markers.md
@@ -1,0 +1,88 @@
+---
+status: accepted
+date: 2026-06-02
+---
+
+# Centralize `data-abs-*` DOM markers in `lib/dom-markers.ts`
+
+## Context and Problem Statement
+
+The extension stamps 10 distinct `data-abs-*` attributes onto pages from 6
+different files. Until PR #95, each file declared its own local `const`. "No
+collision today (verified), but the pattern doesn't scale, and with 23 rules
+already registered there's no canonical naming reference for the 24th" (PR #95
+§"Summary").
+
+## Decision Drivers
+
+- A single canonical location for every `data-abs-*` attribute so collisions and
+  naming drift fail at lint time, not in production (PR #95 §"Summary").
+- A naming convention discoverable from the registry — engine-level markers vs.
+  per-rule markers — so future markers fit the established shape (`AGENTS.md`
+  §"DOM marker attributes").
+
+## Considered Options
+
+- Keep per-rule local `const` declarations (the prior state).
+- Re-export every marker through `placeholder.ts`.
+- Introduce `extension/src/lib/dom-markers.ts` as the single source of truth and
+  block raw `data-abs-…` literals via ESLint.
+
+## Decision Outcome
+
+Chosen option: **`extension/src/lib/dom-markers.ts` as the single source of
+truth**, enforced by an ESLint `no-restricted-syntax` rule that blocks raw
+`data-abs-…` string and template literals everywhere except the registry itself
+(PR #95 §"Summary"; `AGENTS.md` §"DOM marker attributes").
+
+Conventions:
+
+- Engine-level markers are named `<PURPOSE>_ATTR` (`RULE_ATTR`, `REVEALED_ATTR`,
+  `HIDDEN_ATTR`, `PLACEHOLDER_MODE_ATTR`).
+- Per-rule markers are named `<RULE>_<PURPOSE>_ATTR` (`CART_ADDON_FLAGGED_ATTR`,
+  `CHECKOUT_CHECKBOX_CLEARED_ATTR`, the four `CONFIRMSHAME_ORIGINAL_*_ATTR`s).
+- Import the constant; do not inline the literal (`AGENTS.md` §"DOM marker
+  attributes").
+
+### Consequences
+
+- Good, because "future collisions or convention drift fail lint instead of
+  slipping through review" (PR #95 §"Summary").
+- Good, because the registry doubles as the naming reference for new rules,
+  closing out the third item from the agent-readiness audit (PR #95 §"Summary").
+- Neutral, because all existing importers were updated in a single sweep: 6 rule
+  files, 4 lib files, 9 test files (PR #95 §"Summary").
+
+### Confirmation
+
+- Lint rule verified to fire "on both literal forms" (inline string and template
+  literal) (PR #95 §"Test plan").
+- `AGENTS.md` §"DOM marker attributes" documents the registry and lint
+  enforcement so authors and agents look in one place.
+
+## Pros and Cons of the Options
+
+### Per-rule local `const`s
+
+- Bad, because there is no naming reference for new markers, and silent
+  collisions are possible at scale (PR #95 §"Summary").
+
+### Re-export through `placeholder.ts`
+
+- Bad, because "the indirection would dilute the 'one canonical location' goal a
+  new agent needs." (PR #95 §"Summary"; "Re-exports through `placeholder.ts`
+  were considered and rejected".)
+
+### Central `lib/dom-markers.ts` registry + lint enforcement
+
+- Good, because lint fails on the wrong spelling — drift cannot land silently
+  (PR #95 §"Summary").
+- Good, because the engine-vs-per-rule naming split makes the registry's own
+  contents navigable (PR #95 §"Summary"; `AGENTS.md`).
+
+## More Information
+
+- PR
+  [#95 — Centralize data-abs-\* DOM markers in lib/dom-markers.ts](https://github.com/pixiebrix/agent-browser-shield/pull/95)
+- [`AGENTS.md`](../AGENTS.md) §"DOM marker attributes"
+- Source: `extension/src/lib/dom-markers.ts`, `extension/eslint.config.js`

--- a/decisions/0005-lib-rules-import-boundary.md
+++ b/decisions/0005-lib-rules-import-boundary.md
@@ -1,0 +1,88 @@
+---
+status: accepted
+date: 2026-06-02
+---
+
+# Enforce `lib/` ↔ `rules/` import boundary via ESLint
+
+## Context and Problem Statement
+
+The codebase had developed an unspoken module-boundary discipline: rule files
+were leaves with no imports from sibling rules, and shared helpers lived in
+`lib/`. PR #85 set out to lock that discipline in "so a new contributor or agent
+can't quietly drift past it." The code was already clean against both zones; the
+PR added enforcement without any code relocation (PR #85 §"Summary").
+
+## Decision Drivers
+
+- Rule files should be leaves; "shared helpers belong in `../lib`; the catalog
+  stays confined to `./index.ts`, the single place that's allowed to enumerate
+  every rule." (PR #85 §"Summary")
+- `lib/` helpers must not "reach into a specific rule file. … Reaching into one
+  rule from a helper quietly couples that helper to one rule's internals and
+  pushes the next rule that needs the same hook into copy-paste." (PR #85
+  §"Summary")
+
+## Considered Options
+
+- Document the convention only (the pre-existing state).
+- Enforce both directions of the boundary at lint time via
+  `import-x/no-restricted-paths`.
+
+## Decision Outcome
+
+Chosen option: **enforce both directions at lint time.**
+
+- Rule files can only import `./types` and `./*.generated.ts` from sibling rule
+  files (PR #85 §"Summary").
+- `lib/` can only reach `rules/index`, `rules/types`, and `rules/*.generated.ts`
+  (PR #85 §"Summary").
+- Implemented as "two ESLint flat-config blocks at the bottom of
+  `extension/eslint.config.js`, each scoped to one side of the boundary via
+  `files` + `ignores`. Scoping the rule via flat-config `files` is cleaner than
+  encoding the same exclusion list inside `no-restricted-paths` target globs."
+  (PR #85 §"Implementation notes")
+- "`except` patterns are resolved to absolute paths via
+  `path.join(import.meta.dirname, ...)`. `import-x/no-restricted-paths` resolves
+  `from` against `basePath` but hands `except` patterns to Minimatch raw — so
+  relative globs like `**/types.ts` silently fail to match when the absolute
+  import path contains a dot-prefixed segment … Resolving ourselves dodges both
+  pitfalls." (PR #85 §"Implementation notes")
+
+### Consequences
+
+- Good, because boundary drift fails lint locally and in CI; the lint rule does
+  not require any code relocation today and stays useful for every future
+  contributor or agent (PR #85 §"Summary").
+- Neutral, because the implementation uses absolute paths in `except` globs to
+  work around the import-x/Minimatch dotfile interaction (PR #85
+  §"Implementation notes").
+
+### Confirmation
+
+- "Verified the rules zone fires by injecting
+  `import { adsHideRule } from './ads-hide'` into a scratch file under
+  `src/rules/`." (PR #85 §"Test plan")
+- "Verified the lib zone fires by injecting
+  `import { adsHideRule } from '../rules/ads-hide'` into a scratch file under
+  `src/lib/`." (PR #85 §"Test plan")
+
+## Pros and Cons of the Options
+
+### Document only
+
+- Bad, because there is nothing to stop a coding agent or new contributor from
+  quietly drifting past the convention (PR #85 §"Summary").
+
+### Lint enforcement via `import-x/no-restricted-paths`
+
+- Good, because the boundary is enforced mechanically and at the editor (PR #85
+  §"Summary").
+- Good, because the per-zone flat-config scoping keeps each rule's globs simple
+  (PR #85 §"Implementation notes").
+
+## More Information
+
+- PR
+  [#85 — Enforce lib/↔rules/ import boundary via no-restricted-paths](https://github.com/pixiebrix/agent-browser-shield/pull/85)
+- Source: `extension/eslint.config.js`

--- a/decisions/0006-re-scan-spa-mutations.md
+++ b/decisions/0006-re-scan-spa-mutations.md
@@ -1,0 +1,92 @@
+---
+status: accepted
+date: 2026-06-02
+---
+
+# Re-scan SPA-mutated subtrees via a shared subtree watcher
+
+## Context and Problem Statement
+
+Rules' `apply()` runs once at `document_idle`. Client-side route changes in SPAs
+(React Router, Vue Router, etc.) swap subtrees in and out without a new page
+load, so anything that only ran in `apply` will never see post-navigation
+content — and many target classes (PII, secrets, scarcity badges, hidden text)
+are exactly the kind of late-mounted content SPAs are built on (`AGENTS.md`
+§"Rule authoring: re-scan SPA mutations").
+
+PR #87 surfaced the gap concretely: "`pii-mask` and `secrets-mask` were the only
+DOM-mutating rules without a `createSubtreeWatcher`, so on SPAs they only
+scanned the initial `document_idle` snapshot. The demo site's `/checkout` view
+(and any client-side route swap) rendered card numbers, SSNs, and API keys that
+the rules never saw." (PR #87 §"Summary")
+
+## Decision Drivers
+
+- Late-mounted content (SPAs, infinite scroll) must be covered as reliably as
+  initial-render content (PR #87 §"Summary"; `AGENTS.md` §"Rule authoring:
+  re-scan SPA mutations").
+- The watcher must not loop on its own placeholder insertions (PR #87
+  §"Summary": "the rule does not loop on its own placeholder insertion.").
+
+## Considered Options
+
+- Per-rule, ad-hoc `MutationObserver` plumbing.
+- Shared `createSubtreeWatcher` factory from
+  `extension/src/lib/subtree-watcher.ts`, with `skipPlaceholderSubtrees: true`
+  for rules that insert placeholders.
+
+## Decision Outcome
+
+Chosen option: **shared `createSubtreeWatcher`, wired into any rule that mutates
+the DOM.** Default to it. "Mirror the pattern used in `pii-redact`,
+`secrets-redact`, `scarcity-redact`, `hidden-text-strip`, etc.: a shared
+`scanAndX(root)` function called by both `apply` and the watcher's `onSubtrees`,
+plus a `teardown` that calls `watcher.stop()`. Skip the watcher only when there
+is nothing to re-scan after initial load — e.g., a one-shot landmark injection —
+and call that out in a comment." (`AGENTS.md` §"Rule authoring: re-scan SPA
+mutations")
+
+`skipPlaceholderSubtrees: true` is the standard option for rules that insert
+placeholders, so the watcher does not loop on the rule's own output (PR #87
+§"Summary").
+
+### Consequences
+
+- Good, because new DOM-mutating rules default to the shared watcher, which
+  makes SPA coverage the floor rather than the ceiling (`AGENTS.md` §"Rule
+  authoring: re-scan SPA mutations").
+- Good, because the recommendation is captured in `AGENTS.md` so future coding
+  agents and contributors find it without searching for a precedent.
+
+### Confirmation
+
+- "Adds lazy-load tests for both rules: masks content appended after `apply`,
+  `teardown` stops the observer, and the rule does not loop on its own
+  placeholder insertion." (PR #87 §"Summary")
+- Manual reproduction documented for the demo site's `/checkout` view (PR #87
+  §"Test plan").
+
+## Pros and Cons of the Options
+
+### Per-rule, ad-hoc `MutationObserver`
+
+- Bad, because earlier coverage gaps existed precisely because the two redaction
+  rules predated a shared utility (PR #87 §"Summary").
+
+### Shared `createSubtreeWatcher`
+
+- Good, because the placeholder-loop guard, throttling, and other shared
+  concerns are implemented once.
+- Good, because `AGENTS.md` captures the rule of thumb so future rule authors do
+  not rediscover it.
+
+## More Information
+
+- PR
+  [#87 — Re-scan SPA-mutated subtrees in pii-mask and secrets-mask](https://github.com/pixiebrix/agent-browser-shield/pull/87)
+- [`AGENTS.md`](../AGENTS.md) §"Rule authoring: re-scan SPA mutations"
+- Source: `extension/src/lib/subtree-watcher.ts`
+- Related: issue
+  [#150 — Perf: speed up rule application during fast infinite scroll and SPA route transitions](https://github.com/pixiebrix/agent-browser-shield/issues/150)
+  — Tier 1S "Route-change signal" and "Pause-and-batch around route transitions"
+  build on this contract.

--- a/decisions/0007-scrub-instead-of-detach-for-framework-dom.md
+++ b/decisions/0007-scrub-instead-of-detach-for-framework-dom.md
@@ -1,0 +1,143 @@
+---
+status: accepted
+date: 2026-06-05
+---
+
+# Scrub the data carrier; do not detach framework-rendered DOM
+
+## Context and Problem Statement
+
+Four `strip` rules (`meta-injection-strip`, `noscript-strip`,
+`html-comment-strip`, `hidden-text-strip`) called `.remove()` on DOM nodes the
+page framework had rendered and was tracking for unmount. When React Router (and
+equivalents in Vue / Svelte / Astro / htmx head-merge) tried to reconcile those
+nodes out on route change, "`removeChild` threw inside the commit phase and
+stranded the route mid-render." (PR #176 §"Summary")
+
+User-visible symptom on the demo site: clicking the RiverMart logo from a
+product detail page updated the URL but never repainted the home content,
+"because React 19 hoists `<title>` and three `<meta>` tags from
+`ProductDetail.tsx` into `<head>`, `meta-injection-strip` detached them on
+match, and React's next commit tried to `removeChild` nodes whose `parentNode`
+was already `null`." (PR #176 §"Summary")
+
+## Decision Drivers
+
+- Defenses against prompt-injection / cross-origin trickery should not break the
+  page's framework reconciliation, since that's a guaranteed regression on every
+  navigation.
+- The `strip` verb's contract needs to be safe for SPA frameworks by default
+  (`AGENTS.md` §"Rule ID naming": "Most strip rules blank the data carrier
+  (attribute value, text node, comment data) rather than detach the element, so
+  SPA frameworks (React 19 metadata, Vue Teleport, Astro view transitions) keep
+  live references to the rendered node and reconcile cleanly on route change.").
+
+## Considered Options
+
+- Keep calling `element.remove()` on matched carriers (the prior behavior).
+- Blank the carrier data in place (attribute value, `textContent`, or `Text`
+  node data); leave the element attached.
+- Detach only when the rule's target is a node the page framework does not own
+  (e.g., inline SVG sprite definitions).
+
+## Decision Outcome
+
+Chosen option: **blank the carrier; do not detach framework-rendered nodes.**
+
+- `meta-injection-strip` blanks `content=""` on matching `<meta>` (was
+  `element.remove()`) (PR #176 §"Summary").
+- `noscript-strip` blanks `<noscript>` children via `textContent = ""` (was
+  `element.remove()`) (PR #176 §"Summary").
+- `html-comment-strip` blanks `comment.data` only when the data matches
+  `INJECTION_PATTERNS` (was: unconditional removal of every comment outside
+  `<script>` / `<style>` / `<noscript>`) (PR #176 §"Summary"). "The
+  injection-match gate naturally preserves React Suspense markers (`$`, `/$`,
+  `$?`, …) without an explicit allowlist." (PR #176 §"Summary")
+- `hidden-text-strip` walks `SHOW_TEXT` and blanks each Text node's `data` (was
+  `element.remove()`) (PR #176 §"Summary").
+
+Carve-out: `svg-sprite-strip` continues to detach its targets because "its
+targets are inline sprite definitions the page framework does not own"
+(`AGENTS.md` §"Rule ID naming").
+
+### Consequences
+
+- Good, because navigation crashes from `removeChild` on detached carriers are
+  eliminated for React 19, Vue Teleport, Astro view transitions, and equivalent
+  frameworks (PR #176 §"Summary"; `AGENTS.md`).
+- Bad (coverage trade-offs explicitly enumerated in PR #176 §"Coverage
+  trade-offs"):
+  1. `meta-injection-strip` — in-place `content` rewrites land on a node the
+     rule has already blanked; the subtree watcher observes `id` / `class` only,
+     so a later poisoned write is visible until the next subtree change
+     re-triggers a scan.
+  2. `noscript-strip` — in-place children replacement inside a kept `<noscript>`
+     is not detected because `stripNoscript`'s `querySelectorAll` walks downward
+     only.
+  3. `html-comment-strip` — comments not matching `INJECTION_PATTERNS` survive.
+     Novel injection phrasings, off-pattern prose, and any benign-looking
+     comments carrying instruction-shaped text that used to be removed now stay
+     visible.
+  4. `hidden-text-strip` — non-text payloads inside hidden subtrees survive.
+     `image alt`, `aria-label`, `title`, SVG `<title>` / `<desc>`, and `data-*`
+     attributes are no longer caught by the wholesale wrapper removal.
+- Memory: the project policy is "Remove over annotate for adversarial content"
+  (per the contributor memory `feedback_defense_remove_over_annotate.md`). This
+  ADR narrows the policy to "remove the content from the carrier, but leave the
+  carrier where the framework put it" rather than weakening the policy itself.
+
+### Confirmation
+
+- Property tests pin the load-bearing invariants and would fail any drift back
+  to detachment:
+  - `html-comment-strip.property.test.ts` — "across all known injection
+    fixtures, comments are blanked but stay attached; across the framework
+    marker set (`$`, `/$`, `$?`, `$!`, `[`, `]`, build stamps, license headers,
+    dev TODOs), comments are left untouched. Catches any future widening of
+    `INJECTION_PATTERNS` that would re-introduce the navigation crash via a
+    different path." (PR #176 §"Property-based tests")
+  - `hidden-text-strip.property.test.ts` — "across the cross-product of
+    hidden-CSS triggers × child-subtree shapes, descendant text is blanked AND
+    every element node inside the hidden box stays attached. Drift back to
+    `element.remove()` or `replaceChildren()` would fail this as a class, not
+    just one specific case." (PR #176 §"Property-based tests")
+- Follow-up issues track the explicit coverage gaps:
+  - Issue [#177](https://github.com/pixiebrix/agent-browser-shield/issues/177) —
+    meta-injection-strip / noscript-strip coverage gaps (closed by PR #180).
+  - Issue [#178](https://github.com/pixiebrix/agent-browser-shield/issues/178) —
+    open: "Decide: restore html-comment-strip broad sweep with framework-marker
+    allowlist".
+  - Issue [#179](https://github.com/pixiebrix/agent-browser-shield/issues/179) —
+    INJECTION_PATTERNS coverage on attribute-targeted rules post-#176.
+
+## Pros and Cons of the Options
+
+### Keep `.remove()` on matched carriers
+
+- Bad, because React 19 metadata hoisting (and equivalents in other modern
+  frameworks) detaches behavior crashes navigation (PR #176 §"Summary").
+
+### Blank the carrier in place
+
+- Good, because "the element references the framework holds stay valid;
+  agent-readable content still goes to empty." (PR #176 §"Summary")
+- Bad, because narrower coverage on several axes (PR #176 §"Coverage
+  trade-offs", items 1–4).
+
+### Detach when the framework does not own the node
+
+- Good, because rules such as `svg-sprite-strip` target inline definitions the
+  framework does not own; detaching is safe there (`AGENTS.md` §"Rule ID
+  naming").
+
+## More Information
+
+- PR
+  [#176 — Fix: scrub instead of detach for framework-rendered DOM](https://github.com/pixiebrix/agent-browser-shield/pull/176)
+- [`AGENTS.md`](../AGENTS.md) §"Rule ID naming" — `strip` verb taxonomy entry
+- Issue
+  [#177 — Close meta-injection-strip / noscript-strip coverage gaps from #176 scrub-don't-detach refactor](https://github.com/pixiebrix/agent-browser-shield/issues/177)
+- Issue
+  [#178 — Decide: restore html-comment-strip broad sweep with framework-marker allowlist](https://github.com/pixiebrix/agent-browser-shield/issues/178)
+- Issue
+  [#179 — Audit INJECTION_PATTERNS coverage on attribute-targeted rules post-#176](https://github.com/pixiebrix/agent-browser-shield/issues/179)

--- a/decisions/0008-shadow-dom-coverage.md
+++ b/decisions/0008-shadow-dom-coverage.md
@@ -1,0 +1,148 @@
+---
+status: accepted
+date: 2026-06-05
+---
+
+# Pierce open shadow roots; document closed shadow roots as out of scope
+
+## Context and Problem Statement
+
+Until issue #164 was closed, "the rule engine and every rule scan the **light
+DOM only**. Content rendered inside an open shadow root is invisible to nearly
+every rule; closed shadow roots are opaque to everything." Issue #164 calls this
+"a systemic blind spot, not a per-rule bug — the asymmetry the injection-defense
+rules exist to close (DOM is readable to agents but invisible to humans) is
+exactly what an attacker gets for free by mounting payloads inside a shadow
+root." (Issue #164 §"Summary")
+
+Three structural facts caused this:
+
+1. `rule.apply()` was only ever called with `document.body` (issue #164 §"Why it
+   happens").
+2. The shared subtree watcher attached `MutationObserver` to `document.body` /
+   `document.head`; "MutationObserver does **not** cross shadow boundaries even
+   with `subtree:true`." (Issue #164 §"Why it happens")
+3. `querySelectorAll` / `closest` / `TreeWalker` stop at shadow boundaries
+   (issue #164 §"Why it happens").
+
+## Decision Drivers
+
+- The high-asymmetry rules (`prompt-injection-redact`, `hidden-text-strip`,
+  `attribute-injection-sanitize`, `encoded-payload-redact`,
+  `unicode-invisibles-strip`, `svg-text-strip`, `svg-sprite-strip`,
+  `html-comment-strip`, `meta-injection-strip`) are entirely defeated by a
+  trivial bypass — wrapping a payload in `<div>.attachShadow({mode:"open"})` —
+  if the engine doesn't pierce open roots (Issue #164 §"What's affected").
+- Closed shadow roots "are opt-out of all external JavaScript access by spec —
+  `host.shadowRoot` is null, `MutationObserver` and `adoptedStyleSheets` don't
+  cross the boundary, and no supported API undoes that." (PR #168 §"Summary")
+- "Trying to read closed shadow roots" is listed explicitly as a non-goal:
+  "There's no supported way; even devtools shadow inspection is gated." (Issue
+  #164 §"Non-goals")
+
+## Considered Options
+
+- Leave shadow content out of scope (the prior behavior).
+- Walk shadow roots from rule code (per-rule changes).
+- Push shadow-awareness into the shared plumbing (watcher + walker + stylesheet)
+  so per-rule code stays as-is.
+
+## Decision Outcome
+
+Chosen option: **push shadow-awareness into the shared plumbing for open roots
+only; document closed roots as out of scope.**
+
+The fix landed across four PRs, tracked under issue #164:
+
+- **#164 Tier 1 — PR #165 — Shadow-aware subtree watcher.** Patches
+  `Element.prototype.attachShadow` at content-script entry to keep a
+  `Set<ShadowRoot>` of open roots; the shared subtree watcher attaches a
+  per-shadow-root `MutationObserver` and fans events into the same subscriber
+  set. "No rule-code changes — every `createSubtreeWatcher` /
+  `createSelectorHideRule` rule now reaches content rendered inside open shadow
+  trees." (PR #165 §"Summary"). "Closed shadow roots stay opaque by design." (PR
+  #165 §"Summary"; explicit skip in `shadow-roots.ts`.)
+- **#164 Tier 2 — PR #166 — Shadow-piercing text walkers.** Replaces the default
+  `TreeWalker` with one that recursively descends shadow trees.
+- **#164 Tier 3 — PR #167 — Shadow-scoped stylesheets via
+  `adoptedStyleSheets`.** EasyList and placeholder CSS apply inside open shadow
+  roots.
+- **#164 Docs — PR #168 — "Docs: closed shadow roots are not protected".** Adds
+  a Coverage Scope subsection to the Rules reference page so users running into
+  a sealed widget understand the gap.
+
+PR #169 adds a heuristic detector for closed shadow roots (extension/data
+pattern), but the closed-root content itself remains out of reach by spec.
+
+### Consequences
+
+- Good, because "the majority of the catalog" — every selector-hide family rule,
+  every text-walk rule, and every per-element rule listed in issue #164 — gains
+  shadow-DOM coverage with no rule-code changes (issue #164 §"Recommended
+  sequencing" PR 1; PR #165 §"Summary").
+- Good, because `adoptedStyleSheets` is "the right primitive — single source of
+  truth, cheap to attach. Same approach would fix placeholder styling inside
+  shadow roots." (Issue #164 §"Tier 3")
+- Bad, because closed shadow roots stay opaque: `host.shadowRoot` is null and
+  there is "no supported API" to undo it (PR #168 §"Summary"; Issue #164
+  §"Non-goals").
+
+### Confirmation
+
+- "`shadow-roots.test.ts` (new) — unit tests for the hook + discovery contract."
+  (PR #165 §"What changed")
+- `shadow-roots.property.test.ts` covers three invariants with fast-check,
+  including "closed shadow roots never enter the open-tracker, for any random
+  tree shape" and "the subtree watcher's dispatch payload covers every
+  open-shadow element and excludes every closed-shadow element, across nested
+  forests." (PR #165 §"What changed")
+- `subtree-watcher.test.ts` adds a `describe("shadow DOM", …)` block covering
+  pre-existing shadow content, post-start attachments, mutations inside shadows,
+  nested shadow roots, late-joining subscribers, the placeholder skip,
+  head-vs-body router isolation, and closed-shadow opacity (PR #165 §"What
+  changed").
+- A `ShadowDomEmbed` was added to the demo home page that "mounts a chat-widget
+  marker and an `ins.adsbygoogle` block inside an open shadow root so reviewers
+  can confirm the dispatcher actually reaches them." (PR #165 §"Summary")
+- Documentation: `docs/src/content/docs/rules.md` Coverage Scope section (PR
+  #168 §"What changed").
+
+## Pros and Cons of the Options
+
+### Leave shadow content out of scope
+
+- Bad, because every injection-defense rule is bypassable by mounting the
+  payload inside a shadow root (Issue #164 §"What's affected").
+
+### Per-rule shadow-walking
+
+- Bad, because every rule has to change, and new rules have to remember to opt
+  in (rejected as the implicit form by Tier 1's "no rule-code changes" framing;
+  Issue #164 §"Non-goals": "Changing every rule's scan signature.").
+
+### Shadow-aware shared plumbing
+
+- Good, because shadow coverage extends to every existing
+  `createSelectorHideRule` / `createSubtreeWatcher` rule and to future ones
+  automatically (PR #165 §"Summary").
+- Good, because `adoptedStyleSheets` consolidates style injection into one
+  mechanism that works for both light and shadow scopes (Issue #164 §"Tier 3").
+- Bad, because closed shadow roots remain out of reach; this is documented as a
+  limitation rather than worked around (PR #168 §"Summary").
+
+## More Information
+
+- Issue
+  [#164 — Audit: rules are blind to content inside shadow roots](https://github.com/pixiebrix/agent-browser-shield/issues/164)
+- PR
+  [#165 — Feat: shadow-aware subtree watcher (#164 Tier 1)](https://github.com/pixiebrix/agent-browser-shield/pull/165)
+- PR
+  [#166 — Feat: shadow-piercing text walkers (#164 Tier 2)](https://github.com/pixiebrix/agent-browser-shield/pull/166)
+- PR
+  [#167 — Feat: shadow-scoped stylesheets via adoptedStyleSheets (#164 Tier 3)](https://github.com/pixiebrix/agent-browser-shield/pull/167)
+- PR
+  [#168 — Docs: closed shadow roots are not protected (#164 follow-up)](https://github.com/pixiebrix/agent-browser-shield/pull/168)
+- PR
+  [#169 — Feat: heuristic detector for closed shadow roots (#164 follow-up)](https://github.com/pixiebrix/agent-browser-shield/pull/169)
+- PR
+  [#217 — Fix: main-world shadow-root probe for definitive closed-shadow detection (#203)](https://github.com/pixiebrix/agent-browser-shield/pull/217)

--- a/decisions/0009-rule-defaults-and-build-time-overrides.md
+++ b/decisions/0009-rule-defaults-and-build-time-overrides.md
@@ -1,0 +1,148 @@
+---
+status: accepted
+date: 2026-06-09
+---
+
+# Rule defaults centralized in `rule-metadata.ts`; build-time override flag
+
+## Context and Problem Statement
+
+Each rule module used to carry its own `defaultEnabled`. Operators deploying the
+extension into agent runtimes (CDP/Browserbase automation, Hermes, OpenClaw,
+etc.) needed a way to ship a build with a custom default rule set without
+forking the repo or flipping toggles via the Options UI each session.
+
+PR #61 moved the defaults out of the rule files into a single committed JSON
+plus generated TS file, and introduced the `--defaults <path>` build flag. A
+later PR (#221) simplified the layout further by collapsing the
+JSON-plus-codegen-plus-generated-file pipeline into a single hand-edited
+`extension/src/rules/rule-metadata.ts`, since "the existing `catalog.test.ts`
+invariant already enforces id parity with `rules/index.ts`, so the codegen layer
+was belt-and-suspenders." (PR #221 §"Rule defaults consolidation")
+
+## Decision Drivers
+
+- A single canonical place for `RuleId`, `RULE_IDS`, and `RULE_DEFAULTS`,
+  imported by `lib/storage.ts`, so the source-of-truth is unambiguous
+  (`AGENTS.md` §"Rule defaults").
+- Operators must be able to "ship a build with a custom default set without
+  their agent flipping toggles via the Options UI each session." (PR #61
+  §"Summary")
+- Build-time overrides must affect fresh `chrome.storage` only — existing user
+  toggles must persist on rebuild (PR #61 §"Summary"; `README.md` §"Customize
+  build-time defaults": "Overrides only apply to fresh `chrome.storage`; users
+  with toggled state keep their preferences.").
+- The override file format must match the Options-page export so the same JSON
+  works in both places (PR #61 §"Summary").
+
+## Considered Options
+
+- Per-rule `defaultEnabled` on each rule module (the original state).
+- Lift defaults to `extension/data/rule-defaults.json` + zod-validated codegen
+  emitting `rule-defaults.generated.ts` (PR #61).
+- Hand-edit a single `extension/src/rules/rule-metadata.ts` and rely on the
+  existing `catalog.test.ts` to enforce parity (PR #221, supersedes PR #61's
+  codegen layer).
+
+## Decision Outcome
+
+Chosen option: **`extension/src/rules/rule-metadata.ts` as the hand-edited
+source of truth for `RuleId`, `RULE_IDS`, and `RULE_DEFAULTS`**, with build-time
+overrides supported via `bun run build --defaults <path>` or
+`EXTENSION_DEFAULTS_FILE=<path>`.
+
+- `rule-metadata.ts` "is the source of truth for `RuleId`, `RULE_IDS`, and
+  `RULE_DEFAULTS`; `extension/src/lib/storage.ts` imports it. It is kept out of
+  `rules/index.ts` so the service-worker bundle doesn't pull rule files'
+  top-level DOM access." (`AGENTS.md` §"Rule defaults")
+- "Adding a rule means appending an entry both here and in `rules/index.ts`; the
+  catalog test in `extension/src/rules/__tests__/catalog.test.ts` enforces that
+  the two stay in sync." (`AGENTS.md` §"Rule defaults")
+- "`extension/build.ts` accepts a `--defaults <path>` CLI flag (or
+  `EXTENSION_DEFAULTS_FILE` env var) pointing at a JSON file in the same shape
+  as the Options-page export. Validated overrides are injected into the bundle
+  via `process.env.EXTENSION_DEFAULT_OVERRIDES`." (`AGENTS.md` §"Rule defaults")
+- Reserved non-rule keys on the override file include `optionsButton`,
+  `runOnInactiveTabs`, and `debugTrace` (`README.md` §"Customize build-time
+  defaults"; PRs #79, #156, #222).
+- Override only affects fresh `chrome.storage`; existing user toggles persist
+  (PR #61 §"Summary"; `README.md` §"Customize build-time defaults").
+
+### Consequences
+
+- Good, because rule-default changes touch a single hand-edited file rather than
+  a JSON-plus-codegen pipeline; the codegen layer that PR #61 introduced was
+  retired in PR #221 as "belt-and-suspenders" given the `catalog.test.ts`
+  invariant.
+- Good, because operators (e.g. CDP / Browserbase automation builds) can flip
+  the baseline without forking the repo (PR #61 §"Summary"; `README.md`
+  §"Customize build-time defaults").
+- Good, because keeping `rule-metadata.ts` out of `rules/index.ts` prevents the
+  service-worker bundle from pulling rule files' top-level DOM access
+  (`AGENTS.md` §"Rule defaults"; see ADR-0013 for the background-worker purity
+  policy).
+- Neutral, because adding a rule now requires two appends — `rule-metadata.ts`
+  and `rules/index.ts` — enforced by the catalog test (`AGENTS.md` §"Rule
+  defaults").
+- Bad / supersession: PR #221 deleted `data/rule-defaults.json`,
+  `data/rule-defaults.schema.ts`, `scripts/build-rule-defaults.ts`,
+  `src/rules/rule-defaults.generated.ts`, the `build-rule-defaults` npm script,
+  the codegen call from `build.ts`, and the corresponding CI codegen-freshness
+  check (PR #221 §"Rule defaults consolidation"). Operators who had an in-house
+  pipeline reading the deleted files need to migrate to the new shape; the
+  user-supplied override format remains "sparse and flat — distinct from the
+  wrapped `{"defaults": {...}}` shape of the deleted source JSON" (PR #221
+  §"Rule defaults consolidation").
+  `extension/data/defaults-overrides.example.json` is the new starting template
+  (PR #221).
+
+### Confirmation
+
+- `extension/src/rules/__tests__/catalog.test.ts` enforces parity between
+  `rule-metadata.ts` and `rules/index.ts` (`AGENTS.md` §"Rule defaults").
+- `--defaults` validation: "unknown rule ids fail the build" (PR #61 §"Summary";
+  PR #61 §"Test plan" includes a synthetic failing case).
+- `check-background-purity.ts` guards the service-worker bundle from rule-file
+  leakage (ADR-0013; PR #130; `AGENTS.md` §"Rule defaults" describes the
+  rationale).
+
+## Pros and Cons of the Options
+
+### Per-rule `defaultEnabled`
+
+- Bad, because every rule file became a `defaultEnabled` source, and there was
+  no one place that could be diffed when shipping a custom build (implicit in PR
+  #61 §"Summary": "Move per-rule `defaultEnabled` out of the 21 rule modules
+  into a single committed `extension/data/rule-defaults.json`").
+
+### JSON + codegen + generated TS (PR #61)
+
+- Good, because the JSON schema gave operators a versioned contract.
+- Bad, because the codegen + generated file pair was "belt-and-suspenders" given
+  that `catalog.test.ts` already enforces parity (PR #221 §"Rule defaults
+  consolidation").
+
+### Hand-edited `rule-metadata.ts` (PR #221, current)
+
+- Good, because there is one hand-edited file to read and review.
+- Good, because removing the codegen layer drops a build step, a generated file,
+  a script, and a CI check (PR #221 §"Rule defaults consolidation").
+- Bad, because operators who had built tooling around the deleted artifacts have
+  to migrate.
+
+## More Information
+
+- PR
+  [#61 — Lift rule defaults to data/rule-defaults.json + build-time override flag](https://github.com/pixiebrix/agent-browser-shield/pull/61)
+- PR
+  [#221 — Refactor: leveled logging + consolidate rule defaults into rule-metadata.ts](https://github.com/pixiebrix/agent-browser-shield/pull/221)
+  — supersedes PR #61's JSON+codegen pipeline
+- PR
+  [#79 — Disable on-page options button by default; make it build-configurable](https://github.com/pixiebrix/agent-browser-shield/pull/79)
+- PR
+  [#156 — Add option to keep watching inactive tabs](https://github.com/pixiebrix/agent-browser-shield/pull/156)
+- PR
+  [#222 — Add: debugTrace build-time default + JSONL export schema](https://github.com/pixiebrix/agent-browser-shield/pull/222)
+- [`AGENTS.md`](../AGENTS.md) §"Rule defaults"
+- [`README.md`](../README.md) §"Customize build-time defaults"
+- `extension/data/defaults-overrides.example.json`

--- a/decisions/0010-no-telemetry.md
+++ b/decisions/0010-no-telemetry.md
@@ -1,0 +1,78 @@
+---
+status: accepted
+date: 2026-06-04
+---
+
+# No telemetry; opt-in LLM rule is the only outbound call
+
+## Context and Problem Statement
+
+`agent-browser-shield` runs as a content script that inspects every page the
+user visits. Telemetry would create both a privacy footprint and a Chrome Web
+Store review surface. PR #134 documents the project's stance so users and
+reviewers don't have to infer it from code.
+
+## Decision Drivers
+
+- The extension already does all rule processing locally; documenting the
+  absence of telemetry makes the privacy story legible (`README.md` §"Privacy";
+  `docs/src/content/docs/index.mdx` Privacy section, via PR #134).
+
+## Considered Options
+
+- Add product analytics / usage telemetry.
+- Ship zero telemetry; explicitly document the one opt-in outbound call.
+
+## Decision Outcome
+
+Chosen option: **zero telemetry, with one explicitly opt-in outbound call.**
+
+- "The extension does not collect, store, or send any telemetry, analytics, or
+  usage data. Rule processing runs locally in your browser; nothing is reported
+  back to PixieBrix or any other server." (`README.md` §"Privacy")
+- "The one outbound network call the extension can make is the optional
+  `irrelevant-sections-redact` rule (off by default), which sends a compressed
+  page tree to OpenAI's API for classification when you enable the rule and
+  configure an API key." (`README.md` §"Privacy")
+- The same wording lands on the docs landing page so the privacy statement
+  appears between the GitHub-star tip and the Disclaimer (PR #134 §"Summary").
+
+### Consequences
+
+- Good, because the privacy footprint is "nothing" by default — there is no
+  analytics ingest to operate, secure, or document beyond this short statement.
+- Neutral, because the LLM-backed rule (`irrelevant-sections-redact`) is off by
+  default and requires the user to supply an API key (PR #26 §"Summary";
+  `README.md` §"Privacy").
+
+### Confirmation
+
+- Privacy statement is reproduced verbatim in `README.md` §"Privacy" and
+  `docs/src/content/docs/index.mdx`; future drift between the two is caught by
+  review (PR #134 §"Test plan": "Skim the README on GitHub after merge to
+  confirm the new section formats cleanly.").
+- The LLM rule's network call is the only place the extension talks to a
+  non-local endpoint; it is opt-in and gated on a user-supplied key (PR #26
+  §"Summary").
+
+## Pros and Cons of the Options
+
+### Add product analytics
+
+- Bad, because it conflicts with the documented "nothing is reported back"
+  stance and would require a corresponding privacy-policy surface (`README.md`
+  §"Privacy").
+
+### Zero telemetry + opt-in LLM call
+
+- Good, because users can verify the stance by inspecting the extension; there
+  is no hidden surface.
+
+## More Information
+
+- PR
+  [#134 — Document that the extension collects no telemetry](https://github.com/pixiebrix/agent-browser-shield/pull/134)
+- PR
+  [#26 — feat(extension): allow user-supplied OpenAI key to enable LLM rule](https://github.com/pixiebrix/agent-browser-shield/pull/26)
+- [`README.md`](../README.md) §"Privacy"
+- `docs/src/content/docs/index.mdx`

--- a/decisions/0011-build-time-decoded-injection-patterns.md
+++ b/decisions/0011-build-time-decoded-injection-patterns.md
@@ -1,0 +1,114 @@
+---
+status: accepted
+date: 2026-05-30
+---
+
+# Encode prompt-injection patterns in YAML, decode at build time
+
+## Context and Problem Statement
+
+`prompt-injection-redact` needs literal regular expressions over adversarial
+phrasing. Two competing constraints:
+
+1. Coding agents reading the repo are tripped up by literal prompt-injection
+   strings in source files (the "readability shield" motivation in PR #5
+   §"Summary").
+2. Chrome Web Store review "treats runtime base64 decoding as obfuscated code",
+   so the **shipped bundle** cannot decode the patterns at runtime (PR #5 §"Part
+   2"; `AGENTS.md` §"Prompt-injection patterns": "this keeps the shipped bundle
+   free of `atob`-decoded strings (which Chrome Web Store review treats as
+   obfuscated code) while still keeping literal adversarial phrasing out of
+   files a coding agent is likely to read.").
+
+## Decision Drivers
+
+- Literal adversarial phrasing must not appear in source files that coding
+  agents are likely to read (PR #5 §"Summary"; user memory
+  `feedback_no_injection_examples_in_docs.md`).
+- The shipped bundle must contain only plaintext regexes; no runtime `atob`
+  decode (PR #5 §"Part 2"; `AGENTS.md`).
+- The source-of-truth for patterns must live in a tracked, reviewable file; the
+  generated TS file must be committed and regenerated automatically by
+  `bun run build` (`AGENTS.md` §"Prompt-injection patterns").
+
+## Considered Options
+
+- Inline plaintext regexes in the rule source.
+- Runtime `atob` decode inside the bundle.
+- Source-of-truth YAML with base64-encoded patterns, decoded at build time and
+  emitted as plaintext `RegExp` literals in a committed generated TS file.
+
+## Decision Outcome
+
+Chosen option: **source-of-truth YAML with base64-encoded patterns; decode at
+build time into a committed generated TS file.**
+
+- "Regex sources for `prompt-injection-redact` live base64-encoded in
+  `extension/data/injection-patterns.yaml`. The codegen in
+  `extension/scripts/build-injection-patterns.ts` decodes them and emits
+  `extension/src/rules/injection-patterns.generated.ts` with plaintext RegExp
+  literals." (`AGENTS.md` §"Prompt-injection patterns")
+- "The generated file is committed and `bun run build` regenerates it; for a
+  manual run use `bun run build-injection-patterns`. To add or change a pattern,
+  edit the YAML and rebuild — do not edit the generated file." (`AGENTS.md`
+  §"Prompt-injection patterns")
+- The same encoding boundary applies inside the repo: test fixtures decode via
+  `atob` but "aren't reachable from any bundle entrypoint, so Bun tree-shakes
+  them out — `grep atob dist/*.js` returns 0 across all four bundles." (PR #5
+  §"Part 2")
+- Patterns in YAML carry a "terse non-adversarial `name`" so review and grep
+  work without exposing the literal text (PR #5 §"Part 2").
+
+### Consequences
+
+- Good, because reading any TypeScript file in `extension/src/` never exposes
+  adversarial phrasing to a coding agent (PR #5 §"Summary").
+- Good, because the shipped bundle ships plaintext regexes only — no runtime
+  `atob` decode (PR #5 §"Part 2"; verification: "`grep atob extension/dist/*.js`
+  — 0 hits across `content.js`, `background.js`, `popup.js`, `options.js`").
+- Bad, because adding or editing a pattern requires base64-encoding the source
+  and re-running the codegen — direct edits to the generated file are explicitly
+  prohibited (`AGENTS.md` §"Prompt-injection patterns").
+- Neutral, because the same source-data + codegen pattern is now used by
+  site-rule data (`extension/data/sites/*.yaml` → `site-data.generated.ts`) and
+  EasyList (`easylist-generic.generated.ts`) — see `AGENTS.md` §"Site-specific
+  rule data" and `README.md` §"Refresh EasyList snapshot".
+
+### Confirmation
+
+- "Plaintext patterns present in shipped bundle (e.g.
+  `ignore.*previous.*instructions`)" (PR #5 §"Verification").
+- "`grep atob extension/dist/*.js` — 0 hits across `content.js`,
+  `background.js`, `popup.js`, `options.js`" (PR #5 §"Verification").
+- CI codegen-freshness step (PR #56 §"Summary") regenerates
+  `injection-patterns.generated.ts` and fails when the committed copy drifts
+  from the YAML inputs.
+
+## Pros and Cons of the Options
+
+### Inline plaintext regexes in source
+
+- Good, because no build-time machinery.
+- Bad, because every coding agent reading the rule file is exposed to
+  adversarial phrasing (PR #5 §"Summary").
+
+### Runtime `atob` decode in the bundle
+
+- Bad, because Chrome Web Store review "treats [it] as obfuscated code" (PR #5
+  §"Part 2"; `AGENTS.md`).
+
+### YAML source + build-time decode
+
+- Good, because both constraints are satisfied: source files stay readable to
+  coding agents, and the bundle stays free of `atob` (PR #5 §"Part 2").
+- Bad, because pattern edits go through base64 encoding + codegen.
+
+## More Information
+
+- PR
+  [#5 — Hide adversarial fixtures from coding agents](https://github.com/pixiebrix/agent-browser-shield/pull/5)
+- PR
+  [#56 — Add knip, codegen-freshness, and manifest-permission-diff CI checks](https://github.com/pixiebrix/agent-browser-shield/pull/56)
+- [`AGENTS.md`](../AGENTS.md) §"Prompt-injection patterns"
+- User memory: `feedback_no_injection_examples_in_docs.md` (keep docs/marketing
+  abstract about injection patterns)

--- a/decisions/0012-biome-plus-eslint-split.md
+++ b/decisions/0012-biome-plus-eslint-split.md
@@ -1,0 +1,100 @@
+---
+status: accepted
+date: 2026-05-31
+---
+
+# Biome + ESLint split with project-specific custom rules
+
+## Context and Problem Statement
+
+The `extension/` package needed both modern, fast formatting/linting and a slot
+for project-specific rules (e.g., the rule-ID/filename invariant from ADR-0002).
+PR #29 chose to run Biome and ESLint side-by-side rather than pick one.
+
+## Decision Drivers
+
+- "Biome continues to own formatting and its recommended lint set" (PR #29
+  §"Summary"; `AGENTS.md` §"Linting": "The split is mechanical — do not
+  duplicate a rule between them.").
+- ESLint is needed for rules Biome doesn't have — modern-API hints from
+  `eslint-plugin-unicorn`, and a local `agent-browser-shield/*` plugin for
+  project-specific invariants (PR #29 §"Summary"; `AGENTS.md`).
+- The custom-rule slot is required by other ADRs (`rule-id-matches-filename` in
+  ADR-0002; `no-restricted-syntax` for `data-abs-…` literals in ADR-0004;
+  `no-restricted-paths` for the lib/rules boundary in ADR-0005).
+
+## Considered Options
+
+- Biome only (skip ESLint entirely).
+- ESLint only.
+- Biome + ESLint, with a mechanical split: Biome owns formatting + recommended
+  rules; ESLint owns rules Biome doesn't have.
+
+## Decision Outcome
+
+Chosen option: **Biome + ESLint with a mechanical split.**
+
+- `extension/biome.json` is the Biome config; `extension/eslint.config.js` is
+  the flat config that "pulls in `@eslint/js`, `typescript-eslint`, and
+  `eslint-plugin-unicorn`, then disables unicorn rules that overlap with Biome
+  or are too opinionated for this repo." (`AGENTS.md` §"Linting")
+- "Custom rules: `extension/eslint-rules/*.js`. Each rule is one file, exported
+  via `extension/eslint-rules/index.js` under the
+  `agent-browser-shield/<rule-name>` namespace. Add a rule by dropping a file in
+  `eslint-rules/`, exporting it from `index.js`, and enabling it in
+  `eslint.config.js`." (`AGENTS.md` §"Linting")
+- "`bun run check` runs Biome then ESLint; `bun run check:fix` runs both with
+  `--fix`/`--write`." (`AGENTS.md` §"Linting")
+- The same pattern was later extended to `demo-site/` and `docs/` (PR #92 —
+  "Expand Biome scope to demo-site and docs"; `AGENTS.md` §"Linting":
+  "`demo-site/` has a smaller ESLint config… `bun run check` in `demo-site/`
+  runs Biome + ESLint.").
+
+### Consequences
+
+- Good, because there is a single command (`bun run check`) that runs both
+  layers and matches CI (per user memory `project_preflight_command.md`:
+  "Pre-push check is `bun run check`, not `bun run lint`").
+- Good, because the custom-rule plugin slot exists and is used by multiple
+  project-specific invariants (PR #29 §"Summary"; ADR-0002, ADR-0004, ADR-0005).
+- Neutral, because contributors have to know that "the split is mechanical — do
+  not duplicate a rule between them." (`AGENTS.md` §"Linting")
+
+### Confirmation
+
+- "Custom rule sanity-checked by temporarily mismatching `RULE_ID` in
+  `scarcity-hide.ts` and confirming it errors" (PR #29 §"Test plan").
+- `bun run check` is the documented pre-push gate (`AGENTS.md` §"Linting";
+  `CONTRIBUTING.md` §"Extension"; user memory `project_preflight_command.md`).
+
+## Pros and Cons of the Options
+
+### Biome only
+
+- Bad, because there is no slot for project-specific lint rules; rules like
+  `rule-id-matches-filename`, the `data-abs-…` literal guard, and the
+  `lib/`↔`rules/` boundary cannot be enforced (PR #29 §"Summary"; see ADR-0002,
+  ADR-0004, ADR-0005).
+
+### ESLint only
+
+- Bad, because Biome's formatting + recommended rule speed is part of the local
+  dev loop (`AGENTS.md` §"Linting"; PR #29 §"Summary").
+
+### Biome + ESLint
+
+- Good, because each tool runs the rules it is best at; the two halves are kept
+  disjoint by construction (`AGENTS.md` §"Linting": "do not duplicate a rule
+  between them.").
+- Good, because the custom-rule scaffold has now backed several load-bearing
+  invariants (PR #29; ADR-0002, ADR-0004, ADR-0005).
+
+## More Information
+
+- PR
+  [#29 — Add ESLint with unicorn plugin and custom rule infrastructure](https://github.com/pixiebrix/agent-browser-shield/pull/29)
+- PR
+  [#92 — Expand Biome scope to demo-site and docs](https://github.com/pixiebrix/agent-browser-shield/pull/92)
+- [`AGENTS.md`](../AGENTS.md) §"Linting"
+- User memory: `project_preflight_command.md` — `bun run check` is the pre-push
+  gate

--- a/decisions/0013-background-worker-purity-canary.md
+++ b/decisions/0013-background-worker-purity-canary.md
@@ -1,0 +1,110 @@
+---
+status: accepted
+date: 2026-06-04
+---
+
+# Keep rule files out of the background service worker; enforce with a build-time purity canary
+
+## Context and Problem Statement
+
+The background service worker is a DOM-less runtime. PR #130 root-caused a crash
+where "the background service worker crashed at load with
+`ReferenceError: HTMLInputElement is not defined` because `lib/storage.ts`
+imported `RuleId`/`RULE_IDS` from `rules/index.ts`, which transitively pulls
+every rule file — including `checkout-checkbox-sanitize.ts`, which captures the
+native `HTMLInputElement.prototype` setter at module top level." (PR #130
+§"Summary")
+
+The crash showed that the import graph leaks rule files into the SW bundle
+silently; once a rule module is reachable from `background.ts`, any top-level
+DOM access in any rule will crash the worker.
+
+## Decision Drivers
+
+- The service worker must boot in a DOM-less runtime; no rule file may appear in
+  its import graph (PR #130 §"Summary").
+- Adding a `--defaults` build flag and other shared metadata to `lib/storage.ts`
+  requires that the storage module avoid the rules barrel (PR #130; ADR-0009).
+
+## Considered Options
+
+- Keep `RULE_IDS` / `RuleId` exports on `rules/index.ts` (the prior shape) and
+  rely on per-module discipline.
+- Move `RULE_IDS` / `RuleId` off `rules/index.ts` into a barrel-free module that
+  the background can safely import; add a build-time check that fails if any
+  rule label leaks into `background.js`.
+
+## Decision Outcome
+
+Chosen option: **move the catalog metadata out of `rules/index.ts` and enforce
+purity with a build-time canary.**
+
+- "Moved the canonical `RuleId` + `RULE_IDS` to
+  `rules/rule-defaults.generated.ts` (derived from its own keys) and switched
+  `storage.ts` to use the runtime values from there with an `import type` for
+  `RuleId`. The SW bundle no longer has any rule file in its import graph." (PR
+  #130 §"Summary"). (PR #221 later consolidated these into `rule-metadata.ts`;
+  see ADR-0009.)
+- "Made `checkout-checkbox-sanitize.ts` lazy-init the prototype lookup so it's
+  also safe to import in DOM-less contexts." (PR #130 §"Summary")
+- Added `scripts/check-background-purity.ts`, wired into `build.ts`: "scans
+  every rule file for its top-level `label: '…'`, asserts none appear in
+  `dist/background.js`, fails the build on a leak. Labels survive Bun's
+  minification and are unique to rule files, so they make a sound canary." (PR
+  #130 §"Summary")
+- The dropped `JSDOM` shim from `scripts/build-rule-defaults.ts` is also a
+  consequence — "codegen is now pure data" (PR #130 §"Summary"). (PR #221 later
+  removed the rule-defaults codegen entirely; see ADR-0009.)
+- The current AGENTS.md captures the resulting invariant: "It is kept out of
+  `rules/index.ts` so the service-worker bundle doesn't pull rule files'
+  top-level DOM access." (`AGENTS.md` §"Rule defaults")
+
+### Consequences
+
+- Good, because a leak into `background.js` fails the build with a pointer to
+  the offending rule file (PR #130 §"Summary").
+- Good, because the build-time canary uses minification-stable string literals
+  (rule labels), which "are unique to rule files, so they make a sound canary."
+  (PR #130 §"Summary")
+- Neutral, because rule files must not put DOM-touching code at module top
+  level; `checkout-checkbox-sanitize.ts` was migrated to lazy-init to fit (PR
+  #130 §"Summary").
+- Bad, because the purity canary's invariant — rule label literals uniquely
+  identify rule files — relies on Bun's minifier not collapsing labels; the
+  synthetic-leak test in PR #130 confirms it for the current build, but a future
+  bundler swap would need to re-validate.
+
+### Confirmation
+
+- "`bun run build.ts` — purity check reports `35 canaries, no leaks`" (PR #130
+  §"Test plan").
+- "Synthetic leak test (injected a rule label literal into `background.ts`) —
+  purity check fails with non-zero exit and a labeled rule-file pointer" (PR
+  #130 §"Test plan").
+- `extension/scripts/check-background-purity.ts` runs from `extension/build.ts`
+  on every build.
+
+## Pros and Cons of the Options
+
+### Per-module discipline only
+
+- Bad, because the original incident demonstrated that a single innocent-looking
+  import (`lib/storage.ts` pulling `rules/index.ts`) drags every rule file into
+  the worker bundle silently (PR #130 §"Summary").
+
+### Decouple catalog metadata + build-time canary
+
+- Good, because both halves of the fix are enforced mechanically: the catalog
+  moves out of `rules/index.ts`, and the canary catches any future
+  reintroduction (PR #130 §"Summary").
+
+## More Information
+
+- PR
+  [#130 — Fix background worker crash by decoupling rules catalog from storage](https://github.com/pixiebrix/agent-browser-shield/pull/130)
+- PR
+  [#221 — Refactor: leveled logging + consolidate rule defaults into rule-metadata.ts](https://github.com/pixiebrix/agent-browser-shield/pull/221)
+  — moves catalog metadata to `rule-metadata.ts`
+- ADR-0009 — Rule defaults centralized in `rule-metadata.ts`
+- [`AGENTS.md`](../AGENTS.md) §"Rule defaults"
+- Source: `extension/scripts/check-background-purity.ts`, `extension/build.ts`

--- a/decisions/0014-css-first-hide-for-selector-only-rules.md
+++ b/decisions/0014-css-first-hide-for-selector-only-rules.md
@@ -1,0 +1,118 @@
+---
+status: accepted
+date: 2026-06-05
+---
+
+# CSS-first hide for selector-only `removeEntirely` rules
+
+## Context and Problem Statement
+
+The `selector-hide-rule` family's "removeEntirely: true" rules toggled
+`display: none` via a JS path: throttled `MutationObserver`, full-document
+`querySelectorAll` against the union of selectors, outermost filter, then a
+per-element marker write. Issue #150 (Tier 2 #13) proposed lifting static
+selectors into an injected stylesheet. PR #173 lifted the first such rule —
+`chat-widget-hide` — and introduced a shared helper for the inject-and- adopt
+pattern.
+
+## Decision Drivers
+
+- "Each chat widget injection triggered a throttled MutationObserver batch →
+  `selectorsFor(url)` → full-document QSA against the union → outermost filter →
+  per-element marker checks → inline `display:none` + `HIDDEN_ATTR` write." (PR
+  #173 §"Perf characteristics")
+- "Stylesheet hides matches as soon as the browser parses them. No observer
+  fire, no QSA per batch, no per-element JS. Lazily-injected widgets (HubSpot's
+  conversations-embed, Intercom's loader) hide at parse time." (PR #173 §"Perf
+  characteristics")
+- Issue #150 documents that uBO / AdGuard ExtendedCss / Brave / Ghostery all
+  converge on "CSS does the hiding, JS only does dispatch and dynamic
+  decoration" (issue #150 §"How major OSS blockers handle this").
+
+## Considered Options
+
+- Keep all selector-hide rules on the JS path.
+- Lift every selector-hide rule into CSS at once.
+- Lift only rules whose selectors are static (no `candidateFilter`); keep the JS
+  path for rules whose hide decision depends on runtime inspection.
+
+## Decision Outcome
+
+Chosen option: **lift static selector-only rules into CSS; `chat-widget-hide` is
+the first.**
+
+- `chat-widget-hide` "is the only `removeEntirely: true` rule with **no
+  `candidateFilter`** — every selector targets a vendor-specific id, class
+  prefix, or iframe attribute (Intercom, Drift, Zendesk, Crisp, Tawk.to,
+  HubSpot, Olark, LiveChat, Freshchat, Zopim). That makes it a clean lift into
+  pure CSS." (PR #173 §"Why this rule first")
+- New shared helper `lib/css-hide-stylesheet.ts` "encapsulates the
+  inject-and-adopt pattern that `ads-hide` was previously doing inline." (PR
+  #173 §"Summary")
+- Stylesheet is also adopted into open shadow roots, satisfying ADR-0008's
+  shadow-DOM contract (PR #173 §"Summary").
+- "`cookie-banner-hide` and `newsletter-modal-hide` both depend on
+  `candidateFilter` (`isOverlay` checks computed position;
+  `looksLikeNewsletterModal` checks viewport area + text content + presence of
+  an `<input type='email'>`), so they stay on the JS path for now. A follow-up
+  could split their vendor-specific selectors out to CSS-first while keeping the
+  generic patterns on JS — but it's a per-selector judgment call worth its own
+  PR." (PR #173 §"Why this rule first")
+- Counting trade-off: `placeholder-count` previously queried
+  `.placeholder-class, [data-abs-hidden]`; CSS-first hides set neither. PR #173
+  added `registerCssFirstSelectors(union)` so CSS-first hides are counted via
+  "one extra `querySelectorAll(union).length` per 250ms throttle window, added
+  to the count. Marginal cost, badge stays accurate." (PR #173 §"Counting
+  trade-off")
+- EasyList (in `ads-hide`) "remains uncounted — that's the existing behavior and
+  unchanged here; lifting its 13k selectors into the badge total would be a
+  separate decision (the count would dwarf everything else)." (PR #173
+  §"Counting trade-off")
+
+### Consequences
+
+- Good, because lazily-injected vendor widgets are hidden at parse time, without
+  an observer/QSA cycle (PR #173 §"Perf characteristics").
+- Good, because the helper consolidates an inject-and-adopt pattern that
+  previously lived inline in `ads-hide` (PR #173 §"Summary").
+- Neutral, because the toolbar-badge count is preserved via an added
+  union-selector QSA per throttle window (PR #173 §"Counting trade-off").
+- Neutral, because future rule lifts to CSS-first are a per-rule judgment: only
+  static-selector `removeEntirely` rules qualify; rules with runtime
+  `candidateFilter` stay on the JS path until their vendor-specific selectors
+  can be split out (PR #173 §"Why this rule first").
+
+### Confirmation
+
+- "Existing `chat-widget-hide.test.ts` rewritten to assert via
+  `getComputedStyle().display === 'none'` (and stylesheet injection presence)
+  instead of `HIDDEN_ATTR` / inline `display`" (PR #173 §"Test plan").
+- Stylesheet adoption into open shadow roots is exercised by the shadow-aware
+  subtree watcher's tests (ADR-0008; PR #165 §"What changed").
+
+## Pros and Cons of the Options
+
+### Keep all selector-hide rules on the JS path
+
+- Bad, because each chat widget injection re-enters the observer → QSA → filter
+  → marker-write pipeline (PR #173 §"Perf characteristics").
+
+### Lift every selector-hide rule to CSS at once
+
+- Bad, because rules with runtime `candidateFilter` (e.g., `isOverlay`,
+  `looksLikeNewsletterModal`) can't be encoded in pure CSS (PR #173 §"Why this
+  rule first").
+
+### Lift selector-only rules; keep filtered rules on JS
+
+- Good, because the lift is per-rule and reversible: static selectors get the
+  CSS path, filtered ones stay on JS (PR #173 §"Why this rule first").
+
+## More Information
+
+- Issue
+  [#150 — Perf: speed up rule application during fast infinite scroll and SPA route transitions](https://github.com/pixiebrix/agent-browser-shield/issues/150)
+  — Tier 2 idea #13 "CSS-first hiding for static selectors"
+- PR
+  [#173 — Perf: CSS-first hide for chat-widget-hide (#150 Tier 2 #13)](https://github.com/pixiebrix/agent-browser-shield/pull/173)
+- Source: `extension/src/lib/css-hide-stylesheet.ts`

--- a/decisions/0015-calver-workflow-driven-release.md
+++ b/decisions/0015-calver-workflow-driven-release.md
@@ -1,0 +1,102 @@
+---
+status: accepted
+date: 2026-05-30
+---
+
+# CalVer + `workflow_dispatch`-driven extension release
+
+## Context and Problem Statement
+
+The extension manifest's `version` is consumed by Chrome's update logic. The
+release workflow originally fired on `release: published`, which meant the human
+had to bump `manifest.json` first. PR #17 switched to a workflow that computes
+the version itself and creates the release, keeping a permanent dev placeholder
+on the source manifest.
+
+## Decision Drivers
+
+- "Chrome compares `manifest.version` numerically segment-by-segment with a
+  4-segment max." (PR #17 §"Why CalVer + run_number")
+- "`github.run_number` is monotonic per-repo and never resets, so every release
+  is guaranteed to look newer than the previous one — including multiple
+  same-day releases." (PR #17 §"Why CalVer + run_number")
+- Run numbers are "only knowable at workflow time, which is why the workflow has
+  to create the release rather than react to a hand-cut tag." (PR #17 §"Why
+  CalVer + run_number")
+- No manual `manifest.json` version bump should be needed to cut a release (PR
+  #17 §"Summary").
+
+## Considered Options
+
+- Build-on-tag (the previous `release: published` trigger).
+- `workflow_dispatch` that computes `YYYY.M.D.${{ github.run_number }}`, patches
+  the manifest, builds, uploads, and creates the release itself.
+
+## Decision Outcome
+
+Chosen option: **`workflow_dispatch` that computes
+`YYYY.M.D.${{ github.run_number }}`, patches the manifest, and creates the
+release.**
+
+- "Switches `.github/workflows/release-extension.yml` from `release: published`
+  (build-on-tag) to `workflow_dispatch` (workflow creates the release). CI
+  computes `version = YYYY.M.D.${{ github.run_number }}`, `jq`-patches
+  `extension/src/manifest.json` in the runner, builds, uploads to S3, and calls
+  `gh release create` itself." (PR #17 §"Summary")
+- "The source `extension/src/manifest.json` `version` (`0.1.0`) is now a
+  permanent dev placeholder for unpacked loads — CI overwrites it. No manual
+  version bump is needed to cut a release." (PR #17 §"Summary")
+- "Adds `scripts/cut-release.sh` for dispatching the workflow from a clean
+  `main` (preflights gh auth, branch, dirty tree, sync with origin; `--watch`
+  tails the run)." (PR #17 §"Summary")
+
+### Consequences
+
+- Good, because Chrome's "`2026.6.1 > 2026.5.31` and
+  `2026.5.30.43 > 2026.5.30.42` both hold" — the version ordering is correct
+  across day boundaries and within a single day (PR #17 §"Why CalVer +
+  run_number").
+- Good, because the source `manifest.json` no longer needs to be bumped by hand
+  (PR #17 §"Summary").
+- Neutral, because the workflow has to compute the version at runtime rather
+  than relying on a tag — `cut-release.sh` is the supported trigger (PR #17
+  §"Summary").
+
+### Confirmation
+
+- "Computes a version of the form `YYYY.M.D.<run_number>` and the matching `v…`
+  tag." (PR #17 §"Test plan")
+- "Patches `extension/src/manifest.json` (visible in the 'Patch manifest
+  version' step log via the trailing `jq '{version, name}'`)." (PR #17 §"Test
+  plan")
+- "Re-run `scripts/cut-release.sh` immediately and confirm the second release
+  gets a higher `run_number` segment, and Chrome treats it as an update." (PR
+  #17 §"Test plan")
+- A `skills/agent-browser-shield-release/SKILL.md` captures the version format,
+  the cut-release flow, and rollback (PR #17 §"Summary").
+
+## Pros and Cons of the Options
+
+### Build-on-tag (`release: published`)
+
+- Bad, because cutting a release requires a hand-bump of `manifest.json` (PR #17
+  §"Summary").
+- Bad, because hand-cut tags can't encode the `github.run_number`-monotonicity
+  guarantee for same-day releases (PR #17 §"Why CalVer + run_number").
+
+### `workflow_dispatch` + CalVer + run_number
+
+- Good, because version ordering is mechanically correct across day boundaries
+  and within a single day (PR #17 §"Why CalVer + run_number").
+- Good, because the workflow can guarantee invariants (clean tree, auth, branch)
+  before dispatching (PR #17 §"Summary": `cut-release.sh` "preflights gh auth,
+  branch, dirty tree, sync with origin").
+- Neutral, because the source manifest carries a permanent dev placeholder;
+  readers have to know CI overwrites it (PR #17 §"Summary").
+
+## More Information
+
+- PR
+  [#17 — ci: workflow-driven CalVer release for the extension](https://github.com/pixiebrix/agent-browser-shield/pull/17)
+- `skills/agent-browser-shield-release/SKILL.md`
+- Source: `.github/workflows/release-extension.yml`, `scripts/cut-release.sh`

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -1,0 +1,38 @@
+# Architecture Decision Records
+
+This directory holds Architecture Decision Records (ADRs) for
+`agent-browser-shield`, written in the [MADR 3.0](https://adr.github.io/madr/)
+format.
+
+The records are a back-fill of load-bearing decisions reconstructed from merged
+pull requests, issues, and the user-facing docs. Each ADR cites its primary
+sources inline so readers can trace any claim back to a PR description, review
+thread, issue body, or doc passage. No pro/con or motivation appears in an ADR
+that is not supported by one of those citations.
+
+## Index
+
+| #                                                           | Title                                                                                         | Status                                            |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| [0001](./0001-source-available-license-and-cla.md)          | Source-available PolyForm Shield 1.0.0 license + CLA                                          | Accepted                                          |
+| [0002](./0002-rule-id-naming-taxonomy.md)                   | Rule ID naming taxonomy (`<target>-<verb>`, five verbs)                                       | Accepted                                          |
+| [0003](./0003-run-rule-engine-in-all-frames.md)             | Run rule engine in all frames                                                                 | Accepted                                          |
+| [0004](./0004-centralize-dom-markers.md)                    | Centralize `data-abs-*` DOM markers in `lib/dom-markers.ts`                                   | Accepted                                          |
+| [0005](./0005-lib-rules-import-boundary.md)                 | Enforce `lib/` ↔ `rules/` import boundary via ESLint                                          | Accepted                                          |
+| [0006](./0006-re-scan-spa-mutations.md)                     | Re-scan SPA-mutated subtrees via a shared subtree watcher                                     | Accepted                                          |
+| [0007](./0007-scrub-instead-of-detach-for-framework-dom.md) | Scrub data carrier, do not detach framework-rendered DOM                                      | Accepted                                          |
+| [0008](./0008-shadow-dom-coverage.md)                       | Pierce open shadow roots; document closed roots as out-of-scope                               | Accepted                                          |
+| [0009](./0009-rule-defaults-and-build-time-overrides.md)    | Rule defaults centralized in `rule-metadata.ts` + build-time override flag                    | Accepted (supersedes earlier JSON+codegen design) |
+| [0010](./0010-no-telemetry.md)                              | No telemetry; opt-in LLM rule is the only outbound call                                       | Accepted                                          |
+| [0011](./0011-build-time-decoded-injection-patterns.md)     | Encode prompt-injection patterns in YAML, decode at build time                                | Accepted                                          |
+| [0012](./0012-biome-plus-eslint-split.md)                   | Biome + ESLint split with project-specific custom rules                                       | Accepted                                          |
+| [0013](./0013-background-worker-purity-canary.md)           | Keep rule files out of the background service worker; enforce with a build-time purity canary | Accepted                                          |
+| [0014](./0014-css-first-hide-for-selector-only-rules.md)    | CSS-first hide for selector-only `removeEntirely` rules                                       | Accepted                                          |
+| [0015](./0015-calver-workflow-driven-release.md)            | CalVer + `workflow_dispatch`-driven extension release                                         | Accepted                                          |
+
+## Conventions
+
+- File names use `NNNN-kebab-case-title.md`.
+- Status values: `Proposed`, `Accepted`, `Superseded by ADR-NNNN`, `Deprecated`.
+- "More Information" sections list the primary sources used to write the ADR.
+  When a citation gives a date, it is the merge date of the cited PR.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -1,7 +1,7 @@
 # Architecture Decision Records
 
 This directory holds Architecture Decision Records (ADRs) for
-`agent-browser-shield`, written in the [MADR 3.0](https://adr.github.io/madr/)
+`agent-browser-shield`, written in the [MADR 4.0](https://adr.github.io/madr/)
 format.
 
 The records are a back-fill of load-bearing decisions reconstructed from merged


### PR DESCRIPTION
## Summary

Backfills a `decisions/` tree of [MADR 4.0](https://adr.github.io/madr/) ADRs
covering 15 load-bearing decisions reconstructed from merged PRs, issues, and
the user-facing docs.

Each ADR cites its primary source inline (PR description, review thread,
issue body, or doc passage); none of the pros/cons or motivations are
invented. Where one PR superseded another (PR #221 supersedes PR #61's
JSON+codegen pipeline for rule defaults), the supersession is captured in
the relevant ADR's status + Consequences.

### Decisions captured

| # | Title | Primary source |
|---|-------|----------------|
| 0001 | Source-available PolyForm Shield 1.0.0 + CLA | `LICENSING.md`, `LICENSE`, `.github/CLA.md` |
| 0002 | Rule ID naming taxonomy (`<target>-<verb>`, five verbs) | PR #105 |
| 0003 | Run rule engine in all frames | PR #4 |
| 0004 | Centralize `data-abs-*` DOM markers in `lib/dom-markers.ts` | PR #95 |
| 0005 | Enforce `lib/` ↔ `rules/` import boundary via ESLint | PR #85 |
| 0006 | Re-scan SPA-mutated subtrees via shared subtree watcher | PR #87, `AGENTS.md` |
| 0007 | Scrub data carrier; don't detach framework-rendered DOM | PR #176 |
| 0008 | Pierce open shadow roots; document closed roots as out of scope | Issue #164, PRs #165–#169 |
| 0009 | Rule defaults in `rule-metadata.ts` + build-time override flag | PR #61, PR #221 |
| 0010 | No telemetry; opt-in LLM rule is the only outbound call | PR #134 |
| 0011 | Encode prompt-injection patterns in YAML, decode at build time | PR #5 |
| 0012 | Biome + ESLint split with project-specific custom rules | PR #29 |
| 0013 | Background-worker purity canary | PR #130 |
| 0014 | CSS-first hide for selector-only `removeEntirely` rules | Issue #150 Tier 2 #13, PR #173 |
| 0015 | CalVer + `workflow_dispatch`-driven extension release | PR #17 |

### Conventions

- Files named `NNNN-kebab-case-title.md` under `decisions/`.
- MADR 4.0 format with YAML frontmatter (`status`, `date`). The
  `decision-makers` / `consulted` / `informed` fields are intentionally
  omitted — this is a small project with a single primary maintainer.
- A `decisions/README.md` indexes every ADR with a one-line description and
  status.

## Test plan

- [x] `pre-commit run --files decisions/*.md` — mdformat + markdownlint clean.
- [ ] Reviewer spot-checks 2–3 ADRs against their cited PRs to confirm no
      invented motivations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)