### PR TITLE
Docs: add specs/ — golden specs for current functional and non-functional behavior

### DIFF
--- a/specs/0001-extension-distribution.md
+++ b/specs/0001-extension-distribution.md
@@ -11,6 +11,16 @@ How `agent-browser-shield` reaches end users and agent runtimes — the shipping
 formats, supported browser, and licensing posture that gate use. Covers Chrome
 Web Store install, prebuilt ZIP, and build-from-source paths.
 
+## Problem
+
+Users and agent runtimes need a low-friction, deterministic way to get the
+shield onto a browser at the moment defenses matter most — when an agent is
+already attached and acting. Without an auto-updating store install for humans,
+a pinnable prebuilt ZIP for CI/Browserbase, and a clear license posture for
+commercial embedders, the shield becomes hard to adopt: humans skip it because
+loading-unpacked is fiddly, harness operators can't pin to a known build, and
+commercial users won't ship code they can't reason about legally.
+
 ## User stories
 
 ### Human users

--- a/specs/0001-extension-distribution.md
+++ b/specs/0001-extension-distribution.md
@@ -37,8 +37,10 @@ Web Store install, prebuilt ZIP, and build-from-source paths.
 
 - **FR-1.** A published build is available on the Chrome Web Store under
   extension ID `gnejacdioaelglahihpagpfjpddpnamd`.
-- **FR-2.** The extension targets **Chromium 148+** (any Chromium-based browser:
-  Chrome, Edge, Brave, Arc, Opera).
+- **FR-2.** The extension targets the **latest stable Chromium** release (any
+  Chromium-based browser: Chrome, Edge, Brave, Arc, Opera). The current
+  `minimum_chrome_version` in `extension/src/manifest.json` tracks that baseline
+  and is bumped as the stable channel advances.
 - **FR-3.** Every GitHub Release attaches a prebuilt ZIP at the conventional URL
   `https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`.
   `manifest.json` sits at the ZIP root; the archive can be uploaded to
@@ -69,7 +71,8 @@ Web Store install, prebuilt ZIP, and build-from-source paths.
 
 ## Current implementation
 
-- FR-1, FR-2: `extension/src/manifest.json` (`minimum_chrome_version: 148`).
+- FR-1, FR-2: `extension/src/manifest.json` (`minimum_chrome_version` tracks the
+  latest stable Chromium release at the time of the build).
 - FR-3: GitHub Releases workflow; see
   [ADR-0015](../decisions/0015-calver-workflow-driven-release.md).
 - FR-4, FR-5: `extension/package.json` scripts (`build`, `package`, `watch`),

--- a/specs/0001-extension-distribution.md
+++ b/specs/0001-extension-distribution.md
@@ -1,0 +1,93 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Extension distribution
+
+## Purpose
+
+How `agent-browser-shield` reaches end users and agent runtimes — the shipping
+formats, supported browser, and licensing posture that gate use. Covers Chrome
+Web Store install, prebuilt ZIP, and build-from-source paths.
+
+## User stories
+
+### Human users
+
+- As a **person who wants the shield on my own browser**, I want a one-click
+  Chrome Web Store install that auto-updates, so that I don't have to track
+  releases manually.
+- As a **person evaluating the extension on a managed profile**, I want a
+  prebuilt ZIP I can load unpacked, so that I can run a specific release without
+  going through the store.
+- As a **person iterating on rules**, I want to build from source and
+  hot-reload, so that I can test a change in minutes.
+
+### AI agents
+
+- As a **CDP/Browserbase harness operator**, I want a ZIP whose `manifest.json`
+  sits at the archive root, so that I can upload directly to the Browserbase
+  extensions API.
+- As an **agent runtime that attaches via existing session (OpenClaw)**, I want
+  the extension to install normally into a real Chromium profile, so that
+  attaching over CDP inherits the loaded extension.
+
+## Functional requirements
+
+- **FR-1.** A published build is available on the Chrome Web Store under
+  extension ID `gnejacdioaelglahihpagpfjpddpnamd`.
+- **FR-2.** The extension targets **Chromium 148+** (any Chromium-based browser:
+  Chrome, Edge, Brave, Arc, Opera).
+- **FR-3.** Every GitHub Release attaches a prebuilt ZIP at the conventional URL
+  `https://github.com/pixiebrix/agent-browser-shield/releases/latest/download/agent-browser-shield-extension.zip`.
+  `manifest.json` sits at the ZIP root; the archive can be uploaded to
+  Browserbase as-is or unzipped and loaded unpacked.
+- **FR-4.** `bun run build` in `extension/` produces an unpacked build at
+  `extension/dist/`; `bun run package` writes a ZIP to
+  `output/agent-browser-shield-extension.zip`.
+- **FR-5.** `bun run watch` rebuilds `extension/dist/` on source changes,
+  supporting hot-reload via `chrome://extensions`.
+- **FR-6.** The extension is licensed under [PolyForm Shield 1.0.0](../LICENSE).
+  Use is permitted for any purpose including commercial use, with a single
+  carve-out: building a product that competes with `agent-browser-shield` or
+  with a PixieBrix product built on it requires a commercial license.
+- **FR-7.** Contributors sign a CLA on their first PR; this preserves
+  contributor copyright while granting PixieBrix the relicensing right needed to
+  sell commercial licenses.
+- **FR-8.** Releases follow CalVer and are cut via `workflow_dispatch`.
+
+## Non-functional requirements
+
+- **NFR-M-1.** The published Chrome Web Store build must be reproducible from
+  the tagged commit (no proprietary build steps).
+- **NFR-S-1.** Releases must not bundle obfuscated code; build-time decoding
+  (e.g. injection patterns) emits plaintext sources before bundling. See
+  [ADR-0011](../decisions/0011-build-time-decoded-injection-patterns.md).
+- **NFR-U-1.** A first-time installer should be able to go from "want this" to
+  "extension active" in under three clicks via the Chrome Web Store.
+
+## Current implementation
+
+- FR-1, FR-2: `extension/src/manifest.json` (`minimum_chrome_version: 148`).
+- FR-3: GitHub Releases workflow; see
+  [ADR-0015](../decisions/0015-calver-workflow-driven-release.md).
+- FR-4, FR-5: `extension/package.json` scripts (`build`, `package`, `watch`),
+  `extension/build.ts`.
+- FR-6: [`LICENSE`](../LICENSE), [`LICENSING.md`](../LICENSING.md).
+- FR-7: [`CONTRIBUTING.md`](../CONTRIBUTING.md) §"Legal: license and CLA",
+  [`.github/CLA.md`](../.github/CLA.md).
+- FR-8: [ADR-0015](../decisions/0015-calver-workflow-driven-release.md).
+
+## Future work
+
+- Edge add-ons store / Firefox add-ons listing — neither shipped today; Firefox
+  would require a separate MV3 build path and is out of scope.
+
+## Related
+
+- ADRs: [ADR-0001](../decisions/0001-source-available-license-and-cla.md),
+  [ADR-0015](../decisions/0015-calver-workflow-driven-release.md).
+- Docs:
+  [`docs/src/content/docs/install.md`](../docs/src/content/docs/install.md).
+- Specs: [0011](./0011-build-time-customization.md).

--- a/specs/0002-rule-engine.md
+++ b/specs/0002-rule-engine.md
@@ -1,0 +1,211 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Rule engine
+
+## Purpose
+
+The runtime that decides which rules apply, where they apply, and how the
+extension keeps page mutations in sync with user toggles, availability, and SPA
+navigation. The engine is the substrate every defense rule plugs into.
+
+## User stories
+
+### Human users
+
+- As a **person who toggles a rule off**, I want previously hidden content to
+  reveal and the rule's machinery to stop running, so that disabling actually
+  disables.
+- As a **person browsing a single-page app**, I want late-mounted content (route
+  changes, lazy lists) to be scanned the same way the initial DOM is, so that
+  protection doesn't degrade after the first navigation.
+
+### AI agents
+
+- As a **browser-use agent reading the page**, I want a consistent set of rules
+  applied across every frame I read, so that defenses don't have an
+  iframe-shaped hole.
+- As a **browser-use agent acting on placeholders**, I want a stable
+  click-to-reveal affordance with rule attribution, so that I can decide whether
+  to expose redacted content per case.
+
+## Functional requirements
+
+### Rule shape and catalog
+
+- **FR-1.** Every rule conforms to the `Rule` interface (`id`, `label`,
+  `description`, optional `available` / `unavailableReason` / `topFrameOnly`,
+  `apply(root)`, optional `teardown()`).
+- **FR-2.** The rule catalog (`extension/src/rules/index.ts`) and the
+  ID-and-defaults registry (`extension/src/rules/rule-metadata.ts`) are kept in
+  sync: each rule ID appears in both exactly once. The `catalog.test.ts`
+  invariant suite enforces this and the related field guarantees (`label`
+  non-empty, `apply` is a function, `available: false` pairs with
+  `unavailableReason`, etc.).
+- **FR-3.** Rule IDs follow the `<target>-<verb>` taxonomy with five canonical
+  verbs (`annotate`, `hide`, `redact`, `sanitize`, `strip`). `-helper` is
+  reserved for non-defensive agent affordances. See
+  [ADR-0002](../decisions/0002-rule-id-naming-taxonomy.md).
+
+### Frame coverage
+
+- **FR-4.** The content script runs in **every frame** (`all_frames: true`,
+  `match_origin_as_fallback: true`) at `document_idle`. Each frame independently
+  applies frame-appropriate rules. See
+  [ADR-0003](../decisions/0003-run-rule-engine-in-all-frames.md).
+- **FR-5.** Rules with `topFrameOnly: true` are applied only in the top browsing
+  context (cookie/newsletter overlays, footer, URL recipes, roach-motel
+  landmark). Subframes skip them entirely.
+- **FR-6.** The engine no-ops gracefully when `document.body` is missing (some
+  `about:blank` / `about:srcdoc` iframes at `document_idle`).
+
+### SPA mutation handling
+
+- **FR-7.** A shared `subtree-watcher` re-scans subtrees on DOM mutations and
+  route changes; rules subscribe rather than each running its own
+  MutationObserver. The watcher coalesces bursts and immediately flushes beyond
+  a configurable burst threshold (currently 512 pending roots). See
+  [ADR-0006](../decisions/0006-re-scan-spa-mutations.md).
+- **FR-8.** Watchers respect `skipPlaceholderSubtrees` so a rule's own
+  placeholder insertions don't drive re-triggering loops.
+- **FR-9.** By default, the shared watcher pauses when the tab is hidden
+  (`document.visibilityState !== "visible"`). Operators can override this via
+  the `runOnInactiveTabs` build-time default (spec 0011) or the options page
+  toggle.
+
+### Mutation strategy
+
+- **FR-10.** Strip and sanitize rules **scrub the data carrier** rather than
+  detach framework-rendered nodes — they blank attribute values, text node data,
+  or comment data while leaving the node attached. This preserves framework
+  reconciliation (React 19 metadata, Vue Teleport, Astro view transitions,
+  htmx). The single documented exception is `svg-sprite-strip`, which detaches
+  hidden sprite containers the page framework does not own. See
+  [ADR-0007](../decisions/0007-scrub-instead-of-detach-for-framework-dom.md).
+- **FR-11.** For selector-only `removeEntirely` rules, hiding uses a single CSS
+  stylesheet (`display: none`) rather than per-element DOM mutation. See
+  [ADR-0014](../decisions/0014-css-first-hide-for-selector-only-rules.md).
+- **FR-12.** Every `data-abs-*` attribute the engine or any rule writes is
+  declared in `extension/src/lib/dom-markers.ts` and imported by name; an ESLint
+  rule blocks raw `"data-abs-…"` literals outside the registry. See
+  [ADR-0004](../decisions/0004-centralize-dom-markers.md).
+
+### Reconciliation
+
+- **FR-13.** When a rule transitions from disabled to enabled, the engine calls
+  `rule.apply(document.body)`. When a rule transitions from enabled to disabled,
+  the engine calls `revealAll(ruleId)` to restore originals behind placeholders,
+  then `rule.teardown?.()`.
+- **FR-14.** Enforcement is a global kill-switch. With enforcement off, the
+  effective state is "all rules disabled" and the engine reveals everything
+  (per-rule selections are preserved in storage for restore on toggle-on).
+- **FR-15.** Rule availability is a separate axis from enabled/disabled. A rule
+  reporting `available: false` (or a reactive availability accessor returning
+  `{available: false}`) is gated off by the engine even when the user's stored
+  toggle is on. The user-facing toggle preference is preserved so the rule
+  re-engages the moment availability flips.
+
+### Placeholders
+
+- **FR-16.** Click-to-reveal placeholders share a single stylesheet injected
+  once into `document.documentElement` and adopted into every open shadow root
+  via `adoptedStyleSheets`. Each placeholder carries `data-abs-rule="<id>"` for
+  attribution.
+- **FR-17.** Inline placeholders are `<button>` elements; block placeholders use
+  a `<div>` container with a `<button class="abs-placeholder__label">` so the
+  reveal control is keyboard-and-screen-reader actionable. Both surface in the
+  accessibility tree as actionable.
+- **FR-18.** Two display modes ship: `inline`/`block` markup, and a per-mode CSS
+  toggle (icon-only vs label). The display mode is persisted in `chrome.storage`
+  and scoped via the `data-abs-placeholder-mode` attribute.
+
+### Open-shadow-root coverage
+
+- **FR-19.** The engine reaches every **open** shadow root the page builds —
+  imperative `attachShadow({mode: "open"})`, declarative shadow DOM at parse
+  time (`<template shadowrootmode="open">`), and post-parse
+  `Element.setHTMLUnsafe` / `ShadowRoot.setHTMLUnsafe`. Closed shadow roots are
+  explicitly out of scope. See
+  [ADR-0008](../decisions/0008-shadow-dom-coverage.md) and spec
+  [0008](./0008-cross-origin-and-shadow-dom.md).
+
+### Background-worker purity
+
+- **FR-20.** Rule files are forbidden from being pulled into the background
+  service-worker bundle (they touch DOM at module scope, which would crash the
+  worker). `lib/storage.ts` imports IDs from `rule-metadata.ts` (pure data)
+  rather than the catalog. A post-build canary
+  (`scripts/check-background-purity.ts`) blocks regressions. See
+  [ADR-0013](../decisions/0013-background-worker-purity-canary.md).
+
+## Non-functional requirements
+
+- **NFR-P-1.** Initial application runs once per frame at `document_idle`;
+  per-rule cost is bounded by the rule's own DOM walk. SPA re-scans are
+  coalesced through the shared watcher (one MutationObserver per observed root,
+  fanned out to all subscribers).
+- **NFR-O-1.** The engine logs initial application with the enabled rule list,
+  per-rule log channels (`createRuleLogger(ruleId)`), and rule enable/disable
+  transitions. See spec [0014](./0014-non-functional-requirements.md) for the
+  leveled-logging story.
+- **NFR-M-1.** Adding a rule requires appending exactly two entries
+  (`rules/index.ts` + `rule-metadata.ts`); `catalog.test.ts` fails the build if
+  they drift. Rules under `extension/src/rules/` must not import from
+  `extension/src/lib/`'s SPA-specific helpers across the documented import
+  boundary. See [ADR-0005](../decisions/0005-lib-rules-import-boundary.md).
+
+## Current implementation
+
+- FR-1, FR-2, FR-3: `extension/src/rules/types.ts`,
+  `extension/src/rules/index.ts`, `extension/src/rules/rule-metadata.ts`,
+  `extension/src/rules/__tests__/catalog.test.ts`.
+- FR-4, FR-5, FR-6: `extension/src/manifest.json`, `extension/src/content.ts`,
+  `extension/src/lib/rule-engine.ts`, `extension/src/lib/frame.ts`.
+- FR-7, FR-8, FR-9: `extension/src/lib/subtree-watcher.ts`,
+  `extension/src/lib/run-on-inactive-tabs.ts`.
+- FR-10, FR-11: `extension/src/lib/placeholder.ts`,
+  `extension/src/lib/selector-hide-rule.ts`,
+  `extension/src/lib/css-hide-stylesheet.ts`.
+- FR-12: `extension/src/lib/dom-markers.ts`,
+  `extension/eslint-rules/no-data-abs-literal.js`, `extension/eslint.config.js`.
+- FR-13, FR-14, FR-15: `extension/src/lib/rule-engine.ts`,
+  `extension/src/lib/enforcement.ts`, `extension/src/lib/availability.ts`.
+- FR-16, FR-17, FR-18: `extension/src/lib/placeholder.ts`,
+  `extension/src/lib/placeholder-display.ts`,
+  `extension/src/lib/shadow-stylesheets.ts`.
+- FR-19: `extension/src/lib/shadow-roots.ts`,
+  `extension/src/lib/shadow-root-probe-source.ts`.
+- FR-20: `extension/scripts/check-background-purity.ts`,
+  `extension/src/rules/rule-metadata.ts`.
+
+## Future work
+
+- Closed shadow root coverage — structurally precluded by the Web Components
+  spec; the optional
+  [`closed-shadow-root-annotate`](./0008-cross-origin-and-shadow-dom.md) rule is
+  the only mitigation. See [ADR-0008](../decisions/0008-shadow-dom-coverage.md).
+- Closed declarative shadow DOM detection — neither the page-world
+  `attachShadow` probe nor the structural heuristic catches DSD with
+  `shadowrootmode="closed"`. Documented in
+  [`docs/src/content/docs/rules.md`](../docs/src/content/docs/rules.md) under
+  *Flag Closed Shadow Roots*.
+
+## Related
+
+- ADRs: [ADR-0002](../decisions/0002-rule-id-naming-taxonomy.md),
+  [ADR-0003](../decisions/0003-run-rule-engine-in-all-frames.md),
+  [ADR-0004](../decisions/0004-centralize-dom-markers.md),
+  [ADR-0005](../decisions/0005-lib-rules-import-boundary.md),
+  [ADR-0006](../decisions/0006-re-scan-spa-mutations.md),
+  [ADR-0007](../decisions/0007-scrub-instead-of-detach-for-framework-dom.md),
+  [ADR-0008](../decisions/0008-shadow-dom-coverage.md),
+  [ADR-0013](../decisions/0013-background-worker-purity-canary.md),
+  [ADR-0014](../decisions/0014-css-first-hide-for-selector-only-rules.md).
+- Docs: [`docs/src/content/docs/rules.md`](../docs/src/content/docs/rules.md)
+  §"Coverage scope".
+- Specs: [0008](./0008-cross-origin-and-shadow-dom.md),
+  [0010](./0010-extension-ui-and-controls.md),
+  [0011](./0011-build-time-customization.md),
+  [0014](./0014-non-functional-requirements.md).

--- a/specs/0002-rule-engine.md
+++ b/specs/0002-rule-engine.md
@@ -11,6 +11,16 @@ The runtime that decides which rules apply, where they apply, and how the
 extension keeps page mutations in sync with user toggles, availability, and SPA
 navigation. The engine is the substrate every defense rule plugs into.
 
+## Problem
+
+Defenses must stay in sync with what the page renders and what the user has
+enabled — across every frame, through SPA route changes, and under bursts of DOM
+mutations. Without a shared runtime, individual rules duplicate MutationObserver
+wiring, leak listeners, drift in how they respond to toggles, and silently
+regress on late-mounted content. Each drift is a coverage hole the user can't
+see: a rule that fires on first paint but not after a React route change leaves
+the second page unprotected with no warning.
+
 ## User stories
 
 ### Human users

--- a/specs/0003-prompt-injection-defense.md
+++ b/specs/0003-prompt-injection-defense.md
@@ -1,0 +1,208 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Prompt-injection defense
+
+## Purpose
+
+Remove or neutralize content on a page that could carry attacker-controlled
+instructions to a browser-use agent. The threat model is **indirect prompt
+injection** — attacker text reaches the model via the page the agent reads, not
+via the user's prompt — generalized to LLM-driven web agents. Coverage spans
+rendered content, non-rendered DOM, page metadata, HTML attributes, and
+structured-data surfaces.
+
+## User stories
+
+### Human users
+
+- As a **person using a browser-use agent on real websites**, I want
+  user-generated content (comments, reviews, embedded social posts) hidden from
+  the agent by default, so that hostile commenters can't redirect the agent away
+  from my task.
+- As a **person who occasionally needs to see hidden content**, I want
+  click-to-reveal placeholders, so that I can opt back into individual
+  redactions without disabling the whole rule.
+
+### AI agents
+
+- As a **browser-use agent reading the page**, I want known prompt-injection
+  phrasings removed from the rendered text, the accessibility tree, and the
+  non-rendered DOM (HTML comments, hidden text, `<noscript>`, `<meta>` content,
+  `aria-*`, JSON-LD), so that I don't ingest hostile instructions disguised as
+  content.
+- As a **browser-use agent that summarizes the page**, I want
+  `<meta name="description">`, OpenGraph, and JSON-LD `Article.description`
+  scrubbed when they carry instruction-shaped text, so that "what is this page
+  about" answers aren't poisoned by metadata I can't see in the rendered view.
+- As a **browser-use agent that walks accessibility names and descriptions**, I
+  want `aria-label`, `alt`, `title`, `placeholder`, SVG
+  `<title>`/`<desc>`/`<text>`, and Unicode-tag-block payloads scrubbed, so that
+  the accessibility-tree surface isn't a hidden channel into my context.
+
+## Functional requirements
+
+### Pattern set
+
+- **FR-1.** The prompt-injection pattern set is defined in
+  `extension/data/injection-patterns.yaml`, base64-encoded at rest, and decoded
+  at build time into `extension/src/rules/injection-patterns.generated.ts`. The
+  shipped bundle contains plaintext `RegExp` literals — no runtime `atob` of
+  obfuscated strings. See
+  [ADR-0011](../decisions/0011-build-time-decoded-injection-patterns.md).
+- **FR-2.** The same pattern bundle backs `prompt-injection-redact`,
+  `meta-injection-strip`, `attribute-injection-sanitize`, `json-ld-sanitize`,
+  `html-comment-strip`, and `svg-text-strip`. Coverage gaps in the bundle
+  propagate to all six rules.
+- **FR-3.** The bundle is a finite curated catalog of phrasings observed in the
+  literature and fixtures. Payloads outside the catalog pass through; this gap
+  is intentional and documented.
+
+### Rendered text and user-generated content
+
+- **FR-4.** `prompt-injection-redact` (default **on**) hides page sections
+  matching the pattern set; a click-to-reveal placeholder is left behind.
+- **FR-5.** `encoded-payload-redact` (default **on**) redacts long base64, hex,
+  or percent-encoded runs whose decoded bytes are mostly printable ASCII. JWTs
+  are left for `secrets-redact`. Length floors sit above SHA-256/SHA-512/Git
+  commit SHA sizes.
+- **FR-6.** `comments-redact` (default **on**) hides user-generated comment
+  threads on Disqus, Facebook, Reddit, YouTube, and Hacker News.
+- **FR-7.** `reviews-redact` (default **on**) hides user-generated review text
+  on schema.org `Review` microdata and supported sites (Amazon, Walmart).
+  Aggregate star ratings stay visible.
+- **FR-8.** `social-embed-redact` (default **on**) replaces embedded
+  social-media widgets (Twitter/X, YouTube, Facebook, Instagram, TikTok,
+  LinkedIn, Reddit, Spotify, SoundCloud) with a placeholder. Skipped on the
+  embed provider's own domain.
+
+### Non-rendered DOM
+
+- **FR-9.** `html-comment-strip` (default **on**) walks every HTML comment and
+  **blanks its data** when it matches the pattern set, leaving the Comment node
+  attached so SPA hydration markers reconcile. Comments inside `<script>` /
+  `<style>` / `<noscript>` are preserved verbatim; framework Suspense/hydration
+  boundary comments are left alone.
+- **FR-10.** `noscript-strip` (default **on**) blanks every `<noscript>`
+  element's children, leaving the element attached. Reasoning: a browser-use
+  agent runs in a browser at all because the site requires JS, so `<noscript>`
+  content is by definition never rendered to a human.
+- **FR-11.** `hidden-text-strip` (default **on**) blanks text-node content
+  inside elements matching a hidden-CSS trigger (foreground=background,
+  `visibility:hidden`, `opacity:0`, `font-size:0`, off-screen positioning,
+  zero-area clipping). The element and descendant element nodes stay attached.
+  Screen-reader-only text (`.sr-only`, `.visually-hidden`, `.a-offscreen`,
+  `.aok-offscreen`, MUI `visuallyHidden`, 1×1 + `overflow:hidden` +
+  `position:absolute`) is preserved. `display:none` is left alone.
+- **FR-12.** `unicode-invisibles-strip` (default **on**) removes Unicode
+  invisibles with no visible glyph from text nodes and attribute values: Unicode
+  Tags block (`U+E0000–U+E007F`), bidi override and isolate characters
+  (`U+202A–U+202E`, `U+2066–U+2069`), and zero-width chars (`U+200B`,
+  `U+2060–U+2064`, `U+FEFF`, `U+180E`). Script-shaping codepoints (ZWJ `U+200D`,
+  ZWNJ `U+200C`, LRM/RLM `U+200E`/`U+200F`) are preserved.
+
+### HTML metadata and attributes
+
+- **FR-13.** `meta-injection-strip` (default **on**) walks every `<meta>` with a
+  `content` attribute and every `<title>`; on pattern match it blanks the
+  `content` attribute (or title text). Both elements stay attached. The rule
+  scans `document.head` in addition to the engine's apply root so SPA route
+  changes that mutate `<head>` are covered. The rule does not gate on specific
+  `name=` / `property=` values — any meta whose content carries
+  instruction-shaped text is scrubbed.
+- **FR-14.** `attribute-injection-sanitize` (default **on**) removes a matching
+  attribute (rather than blanking it) on a fixed allowlist: `aria-label`,
+  `aria-description`, `aria-roledescription`, `aria-placeholder`,
+  `aria-valuetext`, `aria-keyshortcuts`, `alt`, `title`, `placeholder`,
+  `data-tooltip`, and `value` on disabled / hidden `<input>` elements.
+  Attributes outside the allowlist are not inspected.
+
+### Structured data
+
+- **FR-15.** `json-ld-sanitize` (default **on**) parses every
+  `<script type="application/ld+json">`, recursively replaces matching string
+  fields with `""`, and re-serializes. Structural fields useful to the agent
+  (`price`, `priceCurrency`, `availability`, `sku`, `identifier`, `ratingValue`,
+  `reviewCount`, `position`) are preserved exactly. Malformed JSON-LD is left
+  alone.
+- **FR-16.** `svg-text-strip` (default **on**) blanks `<title>`, `<desc>`, and
+  `<text>` content inside an `<svg>` when it matches the pattern set. The
+  element shell is preserved so accessibility-tree mappings and rendered
+  geometry stay intact.
+
+## Non-functional requirements
+
+- **NFR-S-1.** No file under `extension/src/` may reproduce the literal
+  injection phrasings in plaintext source. The base64-encoded YAML
+  - build-time decode (FR-1) is the only path; user-facing docs and marketing
+    must keep example phrasings abstract.
+- **NFR-S-2.** **Remove over annotate** for adversarial content — strip or
+  redact carriers rather than label them. Annotations are reserved for
+  capability signals (closed shadow roots, webdriver-probe reads, link spoofs)
+  where the page itself is the artifact under inspection.
+- **NFR-O-1.** Each rule reports its per-frame mutation count via the standard
+  rule-count reporter (spec 0010), so operators can see how often each carrier
+  triggers in real traffic.
+- **NFR-M-1.** New patterns flow through the YAML → codegen pipeline; no rule
+  file imports the YAML directly.
+
+## Current implementation
+
+- FR-1, FR-2, FR-3: `extension/data/injection-patterns.yaml`,
+  `extension/scripts/build-injection-patterns.ts`,
+  `extension/src/rules/injection-patterns.generated.ts`.
+- FR-4: `extension/src/rules/prompt-injection-redact.ts`,
+  `extension/src/rules/__tests__/prompt-injection-redact.test.ts`.
+- FR-5: `extension/src/rules/encoded-payload-redact.ts`,
+  `extension/src/rules/__tests__/encoded-payload-redact.test.ts`,
+  `extension/src/rules/__tests__/encoded-payload-redact.property.test.ts`.
+- FR-6: `extension/src/rules/comments-redact.ts`,
+  `extension/src/rules/__tests__/comments-redact.test.ts`.
+- FR-7: `extension/src/rules/reviews-redact.ts`,
+  `extension/src/rules/__tests__/reviews-redact.*.test.ts`.
+- FR-8: `extension/src/rules/social-embed-redact.ts`,
+  `extension/src/rules/__tests__/social-embed-redact.test.ts`,
+  `extension/src/rules/__tests__/social-embed-redact.owner-host.test.ts`.
+- FR-9: `extension/src/rules/html-comment-strip.ts`,
+  `extension/src/rules/__tests__/html-comment-strip.test.ts`,
+  `extension/src/rules/__tests__/html-comment-strip.property.test.ts`.
+- FR-10: `extension/src/rules/noscript-strip.ts`,
+  `extension/src/rules/__tests__/noscript-strip.test.ts`.
+- FR-11: `extension/src/rules/hidden-text-strip.ts`,
+  `extension/src/rules/__tests__/hidden-text-strip.test.ts`,
+  `extension/src/rules/__tests__/hidden-text-strip.property.test.ts`.
+- FR-12: `extension/src/rules/unicode-invisibles-strip.ts`,
+  `extension/src/rules/__tests__/unicode-invisibles-strip.test.ts`.
+- FR-13: `extension/src/rules/meta-injection-strip.ts`,
+  `extension/src/rules/__tests__/meta-injection-strip.test.ts`,
+  `extension/src/rules/__tests__/meta-injection-strip.property.test.ts`.
+- FR-14: `extension/src/rules/attribute-injection-sanitize.ts`,
+  `extension/src/rules/__tests__/attribute-injection-sanitize.test.ts`,
+  `extension/src/rules/__tests__/attribute-injection-sanitize.property.test.ts`.
+- FR-15: `extension/src/rules/json-ld-sanitize.ts`,
+  `extension/src/rules/__tests__/json-ld-sanitize.test.ts`.
+- FR-16: `extension/src/rules/svg-text-strip.ts`,
+  `extension/src/rules/__tests__/svg-text-strip.test.ts`.
+
+## Future work
+
+- Novel-payload coverage — the bundle is a curated catalog (FR-3). Expanding to
+  non-catalog phrasings, role markers from new agent APIs, and multilingual
+  variants is ongoing PR-by-PR; there is no in-extension generic classifier
+  today.
+- Localized confirmshame phrasings — `confirmshame-sanitize` is English-only by
+  design (see spec 0005); the same constraint applies to pattern-set phrasings
+  that ship in English.
+
+## Related
+
+- ADRs:
+  [ADR-0007](../decisions/0007-scrub-instead-of-detach-for-framework-dom.md),
+  [ADR-0011](../decisions/0011-build-time-decoded-injection-patterns.md).
+- Docs: [`docs/src/content/docs/rules.md`](../docs/src/content/docs/rules.md)
+  §"Indirect prompt injection".
+- Specs: [0002](./0002-rule-engine.md),
+  [0007](./0007-visual-identity-and-trust.md),
+  [0008](./0008-cross-origin-and-shadow-dom.md).

--- a/specs/0003-prompt-injection-defense.md
+++ b/specs/0003-prompt-injection-defense.md
@@ -14,6 +14,16 @@ via the user's prompt — generalized to LLM-driven web agents. Coverage spans
 rendered content, non-rendered DOM, page metadata, HTML attributes, and
 structured-data surfaces.
 
+## Problem
+
+A browser-use agent treats the page it reads as authoritative. Anyone who can
+get text onto that page — review fields, comment threads, profile bios, metadata
+tags, hidden inputs, encoded payloads — can issue instructions the agent will
+execute on the user's behalf. The instruction never crosses the user's prompt,
+so prompt-layer filtering never sees it. Without a defense layer between the
+page and the model, the user's threat surface for agentic browsing is every text
+input on every page the agent ever reads.
+
 ## User stories
 
 ### Human users

--- a/specs/0004-sensitive-data-masking.md
+++ b/specs/0004-sensitive-data-masking.md
@@ -11,6 +11,16 @@ Replace credentials and personal identifiers with click-to-reveal placeholders
 before they reach a browser-use agent. The masking is in-place on text nodes —
 the page still renders normally for a human.
 
+## Problem
+
+Confirmation screens, account dashboards, billing pages, and developer consoles
+routinely render credit-card numbers, phone numbers, SSNs, API keys, JWTs, and
+OAuth tokens that a browser-use agent will faithfully copy into model context
+and downstream tool calls. The user doesn't see the leak — the page looks normal
+— but the agent has shipped PII or credentials into systems the user never
+named, with no audit trail at the point of exposure. A defense positioned at the
+agent's read path catches the leak before it leaves the browser.
+
 ## User stories
 
 ### Human users

--- a/specs/0004-sensitive-data-masking.md
+++ b/specs/0004-sensitive-data-masking.md
@@ -28,9 +28,9 @@ the page still renders normally for a human.
   credentials masked at read-time, so that I don't carry them into model context
   or downstream tool calls.
 - As a **browser-use agent that may decide to reveal a value**, I want per-value
-  placeholders labeled with the masked kind (e.g. "credit card"), so that I can
-  reason about whether to act on the redaction rather than guessing what was
-  hidden.
+  placeholders labeled with the masked kind (e.g. `[card hidden]`,
+  `[secret hidden]`), so that I can reason about whether to act on the redaction
+  rather than guessing what was hidden.
 
 ## Functional requirements
 
@@ -41,9 +41,11 @@ the page still renders normally for a human.
   JWTs, private-key blocks, and other high-entropy credential shapes in
   text-node content.
 - **FR-3.** Each masked value is replaced with an inline placeholder carrying
-  the masked kind in its label (e.g. *credit card*, *secret*). The placeholder
-  is a `<button>` element so screen readers and browser-use agents see it as
-  actionable in the accessibility tree.
+  the masked kind in its label, formatted `[<kind> hidden]` (e.g.
+  `[card hidden]`, `[ssn hidden]`, `[phone hidden]`, `[jwt hidden]`,
+  `[aws key hidden]`, `[secret hidden]`). The placeholder is a `<button>`
+  element so screen readers and browser-use agents see it as actionable in the
+  accessibility tree.
 - **FR-4.** A click (or programmatic equivalent issued by the agent on the
   button) reveals the original text node in place and stamps
   `data-abs-revealed="<rule-id>"` on the restored node so a subsequent

--- a/specs/0004-sensitive-data-masking.md
+++ b/specs/0004-sensitive-data-masking.md
@@ -1,0 +1,108 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Sensitive-data masking
+
+## Purpose
+
+Replace credentials and personal identifiers with click-to-reveal placeholders
+before they reach a browser-use agent. The masking is in-place on text nodes —
+the page still renders normally for a human.
+
+## User stories
+
+### Human users
+
+- As a **person whose page contains my name, phone number, or credit card on a
+  confirmation screen**, I want those values hidden from the agent by default,
+  so that a routine task can't ship PII to the model unnoticed.
+- As a **person who needs the agent to read a specific masked value**, I want a
+  click-to-reveal placeholder, so that I can opt into per-value exposure rather
+  than disabling the whole rule.
+
+### AI agents
+
+- As a **browser-use agent reading the page**, I want PII and high-entropy
+  credentials masked at read-time, so that I don't carry them into model context
+  or downstream tool calls.
+- As a **browser-use agent that may decide to reveal a value**, I want per-value
+  placeholders labeled with the masked kind (e.g. "credit card"), so that I can
+  reason about whether to act on the redaction rather than guessing what was
+  hidden.
+
+## Functional requirements
+
+- **FR-1.** `pii-redact` (default **on**) masks credit-card numbers
+  (Luhn-validated), phone numbers, and US Social Security numbers in text-node
+  content.
+- **FR-2.** `secrets-redact` (default **on**) masks API keys, OAuth tokens,
+  JWTs, private-key blocks, and other high-entropy credential shapes in
+  text-node content.
+- **FR-3.** Each masked value is replaced with an inline placeholder carrying
+  the masked kind in its label (e.g. *credit card*, *secret*). The placeholder
+  is a `<button>` element so screen readers and browser-use agents see it as
+  actionable in the accessibility tree.
+- **FR-4.** A click (or programmatic equivalent issued by the agent on the
+  button) reveals the original text node in place and stamps
+  `data-abs-revealed="<rule-id>"` on the restored node so a subsequent
+  subtree-watcher scan doesn't immediately re-mask it.
+- **FR-5.** Both rules re-scan late-inserted subtrees via the shared
+  subtree-watcher (skipPlaceholderSubtrees: true) so credentials and PII
+  arriving via SPA route changes, AJAX, or lazy lists are masked the same way as
+  initial content.
+- **FR-6.** Masking is text-node only. Both rules walk text content; element
+  attributes are handled separately by
+  [`attribute-injection-sanitize`](./0003-prompt-injection-defense.md) (against
+  prompt-injection patterns, not credentials).
+- **FR-7.** `secrets-redact` defers to itself rather than to `pii-redact` for
+  JWTs — JWTs are excluded from `encoded-payload-redact` so the more specific
+  secret label applies.
+
+## Non-functional requirements
+
+- **NFR-P-1.** Walks use the yielding text-walk helper
+  (`lib/yielding-text-walk.ts`) so a large document doesn't block the main
+  thread on a single scan.
+- **NFR-S-1.** Masking is destructive at the carrier level (the placeholder
+  replaces the text content). Originals live on the placeholder node for
+  click-to-reveal but are otherwise not retained.
+- **NFR-S-2.** The masking patterns are heuristic, not authoritative. Rules err
+  on the side of false positives within the documented carrier shapes; full
+  coverage of every PII format is explicitly out of scope (e.g. international
+  phone formats, non-US national IDs).
+- **NFR-O-1.** Per-frame mutation counts surface in the popup and badge so
+  operators can see how often a page triggers masking.
+
+## Current implementation
+
+- FR-1: `extension/src/rules/pii-redact.ts`, tested in
+  `extension/src/rules/__tests__/pii-redact.test.ts` and the property test
+  `extension/src/rules/__tests__/pii-redact.property.test.ts`.
+- FR-2: `extension/src/rules/secrets-redact.ts`,
+  `extension/src/rules/__tests__/secrets-redact.test.ts`.
+- FR-3, FR-4: `extension/src/lib/inline-text-redact.ts`,
+  `extension/src/lib/placeholder.ts`.
+- FR-5: `extension/src/lib/subtree-watcher.ts` shared subscription.
+- FR-7: `extension/src/rules/encoded-payload-redact.ts` (JWT exclusion),
+  `extension/src/rules/secrets-redact.ts` (JWT inclusion).
+
+## Future work
+
+- International phone and non-US national-ID coverage — out of scope today; no
+  tracking issue.
+- Email-address masking — not a current rule. The `attribute-injection-sanitize`
+  rule covers `placeholder=…` text on hidden/disabled inputs against injection
+  phrasings, but emails in rendered text pass through.
+- Document-scoped redaction (e.g. driver license, passport number) — not
+  shipped.
+
+## Related
+
+- ADRs: [ADR-0002](../decisions/0002-rule-id-naming-taxonomy.md) (rule-naming),
+  [ADR-0010](../decisions/0010-no-telemetry.md) (no values exfiltrated).
+- Docs: [`docs/src/content/docs/rules.md`](../docs/src/content/docs/rules.md)
+  §"Sensitive-data masking".
+- Specs: [0003](./0003-prompt-injection-defense.md) (overlapping carriers),
+  [0013](./0013-privacy-and-egress.md).

--- a/specs/0005-dark-pattern-defense.md
+++ b/specs/0005-dark-pattern-defense.md
@@ -12,6 +12,18 @@ browser-use agents — scarcity, urgency, sneaking, preselection, confirmshaming
 roach-motel signup flows, and nagging. Rules act on the DOM the agent reads
 rather than running a heuristic over the rendered pixels.
 
+## Problem
+
+Dark patterns are engineered to push humans into worse decisions, and
+browser-use agents inherit those decisions while skipping the human reaction
+that sometimes catches the trick — agents don't notice that the "decline" button
+changed wording, don't pause at a fake countdown, and don't recognize a
+preselected upsell. Without targeted defenses, an agent silently inherits
+pre-checked add-ons, agrees to roach-motel subscriptions during a signup, and
+completes checkouts with drip-pricing fees the user never approved. The
+asymmetry favors the attacker: one bad pattern × thousands of agent runs × no
+human-in-the-loop friction.
+
 ## User stories
 
 ### Human users

--- a/specs/0005-dark-pattern-defense.md
+++ b/specs/0005-dark-pattern-defense.md
@@ -1,0 +1,207 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Dark-pattern defense
+
+## Purpose
+
+Block manipulative UI patterns that mislead humans and (sometimes more acutely)
+browser-use agents — scarcity, urgency, sneaking, preselection, confirmshaming,
+roach-motel signup flows, and nagging. Rules act on the DOM the agent reads
+rather than running a heuristic over the rendered pixels.
+
+## User stories
+
+### Human users
+
+- As a **person delegating checkout to an agent**, I want pre-checked add-ons
+  cleared, sneaky cart line items flagged, and pre-populated form fields
+  surfaced, so that the agent doesn't silently inherit choices I never made.
+- As a **person whose subscription is hard to cancel**, I want the agent warned
+  at signup time, so that I find out the cancellation path *before* I commit.
+- As a **person who clicks decline on a confirmshame button**, I want the agent
+  to do the same without being pushed away by guilt-tripping copy.
+
+### AI agents
+
+- As a **browser-use agent on a checkout flow**, I want a `[abs: …]` chip
+  appended to add-on line items and drip-pricing fees, so that I can reason
+  about which lines to remove rather than treating every chip as legitimate.
+- As a **browser-use agent on a signup or subscription page**, I want a
+  screen-reader-only landmark carrying a normalized cancellation-difficulty
+  grade and the cancel URL, so that I can warn the user before completing
+  signup.
+- As a **browser-use agent reading scarcity or countdown text**, I want the
+  manipulative claim hidden behind a placeholder, so that I'm not pressured into
+  faster or worse decisions by fabricated time pressure.
+- As a **browser-use agent reading a decline button**, I want the guilt-tripping
+  label rewritten to a neutral "No thanks", so that the accessibility-tree
+  representation reflects the actual action.
+
+## Functional requirements
+
+### Urgency
+
+- **FR-1.** `countdown-timer-redact` (default **on**) hides running countdown
+  timers. Detection snapshots timer-shaped text and confirms the value strictly
+  decreased after 1.5s; re-scans on subtree mutations to catch lazy-loaded
+  sections. Timers that reset on each tick or render via `<canvas>`/WebGL are
+  not detected.
+
+### Scarcity
+
+- **FR-2.** `scarcity-redact` (default **on**) hides scarcity- and
+  activity-based urgency messages ("Only 3 left", "Selling fast", "12 viewing
+  now"). Out-of-stock indicators and bestseller badges are kept visible because
+  they convey real purchaseability or preference information.
+
+### Sneaking
+
+- **FR-3.** `cart-addon-annotate` (default **on**, top-frame only by effect of
+  checkout-URL gating) prepends a visible `[abs: likely cart add-on]` chip to
+  line items matching common sneak-into-basket patterns (protection plans,
+  extended warranties, AppleCare/SquareTrade/Asurion, insurance,
+  donation/round-up, gift wrap, carbon offset, shipping/package protection,
+  Route, Seel, Navidium, driver tips). The line item is **not** removed.
+- **FR-4.** `hidden-fee-annotate` (default **on**) prepends a visible
+  `[abs: drip-pricing fee]` chip to order-summary line items whose label matches
+  a curated mandatory-fee phrase set and that sit beside a currency amount.
+  Layered shape gates: whole-string regex on a small leaf-ish label,
+  order-summary ancestor (`<table>`, `[role="region"]` with order-summary
+  labeling, `<aside>`/`<section>` with cart-shaped class/id, or
+  `schema.org/Order` microdata), adjacent currency amount, and a
+  single-item-cart skip (utility-bill portals, court e-filing, DMV). The row is
+  **not** removed.
+- **FR-5.** `hidden-affiliate-sanitize` (default **on**) clears `value` on
+  `<input type="hidden">` whose `name` matches a curated affiliate/UTM/ referral
+  attribution allowlist (`utm_source`, `utm_medium`, `utm_campaign`, `aff`,
+  `aff_id`, `affiliate_id`, `ref`, `referral_code`, `source_id`, `campaign_id`,
+  `partner_code`, `click_id`, `gclid`, `fbclid`, `msclkid`). The input is
+  preserved; only the value is cleared.
+
+### Preselection
+
+- **FR-6.** `checkout-checkbox-sanitize` (default **on**) unchecks every
+  pre-checked `<input type="checkbox">` on checkout-like URLs (`/cart`,
+  `/checkout`, `/basket`, `/bag`, `/payment`, `/order`). The cleared state is
+  held against framework re-renders that would otherwise silently restore
+  pre-selected values from component state. A genuine user (or WebDriver-driven)
+  click releases the lock; programmatic re-checks from the page itself are
+  reverted. `role="checkbox"` widgets and radio groups are out of scope.
+- **FR-7.** `form-prefill-annotate` (default **on**) prepends a visible
+  `[abs: pre-populated …]` chip to form controls shipping with a server-rendered
+  default the agent might silently inherit: text / email / tel / number / url
+  inputs with a non-empty `value` attribute, `<select>` whose
+  explicitly-`selected` option is not the first one, and radio groups with an
+  initially-`checked` option. Layered FP gates: recognized autofill
+  `autocomplete` tokens skipped, geo `<select>` skipped, focused controls
+  skipped, disabled/readonly skipped, per-form chip cap. Required-selection
+  radio groups stay submittable. Hidden inputs are out of scope (FR-5 covers
+  them).
+
+### Confirmshaming
+
+- **FR-8.** `confirmshame-sanitize` (default **on**) rewrites guilt-tripping
+  decline labels to a neutral `No thanks` so the accessibility-tree
+  representation reflects the available action. The underlying control is
+  preserved; only the visible label and any matching `aria-label` / `title` are
+  rewritten. Coverage spans monetary, health and safety, loyalty-downgrade,
+  gamified progress-loss, imperative self-commands, sarcastic acceptance, and
+  reverse-positive ("Yes, … pay full price") framings. **English-only by
+  design.** Plain decline labels are left alone.
+
+### Roach motel
+
+- **FR-9.** `roach-motel-annotate` (default **on**, top-frame only) embeds a
+  screen-reader-only landmark on signup, subscription, and checkout pages of
+  sites documented to make cancellation difficult. The landmark carries a
+  normalized grade (`hard`, `very-hard`, `impossible`), the canonical
+  cancel/delete URL when known, and a short note. Two data sources back the
+  rule: a hand-curated list under `extension/data/sites/` (FTC-defendant and
+  well-documented friction cases) and a vendored JustDeleteMe snapshot
+  (`extension/src/rules/justdeleteme.generated.ts`, MIT, Robb Lewis &
+  contributors), filtered to `hard`/`impossible` entries and gated to
+  signup-shaped pathnames.
+
+### Nagging
+
+- **FR-10.** `newsletter-modal-hide` (default **on**, top-frame only) removes
+  interstitial newsletter signup modals that cover the page. Detects
+  fixed-position dialogs containing signup language and an email input. Standard
+  login modals, paywalls, and small toasts are kept visible.
+
+## Non-functional requirements
+
+- **NFR-S-1.** Annotate-don't-remove for visible content the user has a right to
+  see (sneaking, hidden fees, form prefills, roach-motel warnings). Remove only
+  when the carrier is itself the dark pattern (scarcity, countdown, newsletter
+  modals).
+- **NFR-S-2.** Hidden-affiliate sanitization preserves a hard
+  CSRF/session/cart/order/nonce/state/signature denylist (`csrf`, `nonce`,
+  `signature`, `hmac`, `secret`, `session`, `antiforgery`, etc.) — these win
+  over the affiliate allowlist by name shape, because a silently rejected submit
+  is strictly worse than the dark pattern. The input must live inside an
+  enclosing `<form>` (descendant or `form` attribute reference); free-floating
+  hidden inputs are JS-only data carriers we leave alone.
+- **NFR-S-3.** Promo/coupon/discount hidden inputs (`promo`, `coupon`,
+  `discount_code`, etc.) are intentionally **not** in the affiliate allowlist —
+  clearing them would silently strip a user-acquired discount.
+- **NFR-O-1.** `roach-motel-annotate` and `webdriver-probe-annotate` are
+  surfaced through the popup's *Heads up* card section (spec 0010) in addition
+  to the rule-count badge, since site-level context is worth reading per visit.
+- **NFR-M-1.** Per-host kill-switches exist for rules with higher false-positive
+  risk (`hidden-affiliate-sanitize`, `hidden-fee-annotate`) so a misfire can be
+  addressed by PR without a full rule disable.
+
+## Current implementation
+
+- FR-1: `extension/src/rules/countdown-timer-redact.ts`,
+  `extension/src/rules/__tests__/countdown-timer-redact.test.ts`.
+- FR-2: `extension/src/rules/scarcity-redact.ts`,
+  `extension/src/rules/__tests__/scarcity-redact.test.ts`.
+- FR-3: `extension/src/rules/cart-addon-annotate.ts`,
+  `extension/src/rules/__tests__/cart-addon-annotate.test.ts`.
+- FR-4: `extension/src/rules/hidden-fee-annotate.ts`,
+  `extension/src/rules/__tests__/hidden-fee-annotate.test.ts`,
+  `extension/src/rules/__tests__/hidden-fee-annotate.property.test.ts`.
+- FR-5: `extension/src/rules/hidden-affiliate-sanitize.ts`,
+  `extension/src/rules/__tests__/hidden-affiliate-sanitize.test.ts`,
+  `extension/src/rules/__tests__/hidden-affiliate-sanitize.property.test.ts`.
+- FR-6: `extension/src/rules/checkout-checkbox-sanitize.ts`,
+  `extension/src/lib/checkout-checkbox-defense-*.ts`,
+  `extension/src/rules/__tests__/checkout-checkbox-sanitize*.test.ts`.
+- FR-7: `extension/src/rules/form-prefill-annotate.ts`,
+  `extension/src/rules/__tests__/form-prefill-annotate*.test.ts`.
+- FR-8: `extension/src/rules/confirmshame-sanitize.ts`,
+  `extension/src/checkout-checkbox-defense.ts` (page-world wrap),
+  `extension/src/rules/__tests__/confirmshame-sanitize.test.ts`.
+- FR-9: `extension/src/rules/roach-motel-annotate.ts`,
+  `extension/data/sites/*.yaml`,
+  `extension/src/rules/justdeleteme.generated.ts`,
+  `extension/src/rules/__tests__/roach-motel-annotate.test.ts`.
+- FR-10: `extension/src/rules/newsletter-modal-hide.ts`,
+  `extension/src/rules/__tests__/newsletter-modal-hide.test.ts`.
+
+## Future work
+
+- `form-prefill-annotate` enhancements tracked in
+  [#121](https://github.com/pixiebrix/agent-browser-shield/issues/121):
+  optionally include the prefilled value in the chip; synthetic `blur`/`change`
+  after annotation; sanitize-mode toggle for `<select>` defaults on
+  sneaking-prone fields (shipping speed, tip percent, donation amount, insurance
+  plan).
+- Localized confirmshame phrasings — English-only today (FR-8); no tracking
+  issue.
+- Canvas/WebGL countdown timers — not detectable via DOM text snapshot (FR-1);
+  fundamental limitation.
+
+## Related
+
+- ADRs: [ADR-0002](../decisions/0002-rule-id-naming-taxonomy.md) (verb taxonomy
+  — sneaking uses annotate-not-remove deliberately).
+- Docs: [`docs/src/content/docs/rules.md`](../docs/src/content/docs/rules.md)
+  §"Dark patterns".
+- Specs: [0002](./0002-rule-engine.md),
+  [0010](./0010-extension-ui-and-controls.md) (popup *Heads up* section).

--- a/specs/0005-dark-pattern-defense.md
+++ b/specs/0005-dark-pattern-defense.md
@@ -60,20 +60,22 @@ rather than running a heuristic over the rendered pixels.
 ### Sneaking
 
 - **FR-3.** `cart-addon-annotate` (default **on**, top-frame only by effect of
-  checkout-URL gating) prepends a visible `[abs: likely cart add-on]` chip to
-  line items matching common sneak-into-basket patterns (protection plans,
+  checkout-URL gating) prepends a visible chip of the form
+  `[abs: likely cart add-on (<label>, matched "<phrase>") — verify you intended this charge before completing purchase]`
+  to line items matching common sneak-into-basket patterns (protection plans,
   extended warranties, AppleCare/SquareTrade/Asurion, insurance,
   donation/round-up, gift wrap, carbon offset, shipping/package protection,
   Route, Seel, Navidium, driver tips). The line item is **not** removed.
-- **FR-4.** `hidden-fee-annotate` (default **on**) prepends a visible
-  `[abs: drip-pricing fee]` chip to order-summary line items whose label matches
-  a curated mandatory-fee phrase set and that sit beside a currency amount.
-  Layered shape gates: whole-string regex on a small leaf-ish label,
-  order-summary ancestor (`<table>`, `[role="region"]` with order-summary
-  labeling, `<aside>`/`<section>` with cart-shaped class/id, or
-  `schema.org/Order` microdata), adjacent currency amount, and a
-  single-item-cart skip (utility-bill portals, court e-filing, DMV). The row is
-  **not** removed.
+- **FR-4.** `hidden-fee-annotate` (default **on**) prepends a visible chip of
+  the form
+  `[abs: drip-pricing fee (<phrase><amount-suffix>) — verify the total before completing checkout]`
+  to order-summary line items whose label matches a curated mandatory-fee phrase
+  set and that sit beside a currency amount. Layered shape gates: whole-string
+  regex on a small leaf-ish label, order-summary ancestor (`<table>`,
+  `[role="region"]` with order-summary labeling, `<aside>`/`<section>` with
+  cart-shaped class/id, or `schema.org/Order` microdata), adjacent currency
+  amount, and a single-item-cart skip (utility-bill portals, court e-filing,
+  DMV). The row is **not** removed.
 - **FR-5.** `hidden-affiliate-sanitize` (default **on**) clears `value` on
   `<input type="hidden">` whose `name` matches a curated affiliate/UTM/ referral
   attribution allowlist (`utm_source`, `utm_medium`, `utm_campaign`, `aff`,

--- a/specs/0006-context-pollution-reduction.md
+++ b/specs/0006-context-pollution-reduction.md
@@ -12,6 +12,17 @@ helping it complete the task — footers, cookie banners, chat widgets, ads,
 disguised native advertorials, dead SVG sprite definitions, and (opt-in)
 engagement rails identified by an LLM.
 
+## Problem
+
+Most of the bytes on a typical page — cookie banners, chat widgets, ads,
+footers, sidebar rails, dead SVG sprite definitions — aren't load-bearing for
+the task the agent was asked to do, but they all consume the agent's read
+budget. On a token-billed agent, a chrome-heavy page can burn through budget
+before the real content is reached; on a context-window-limited one, the actual
+task gets evicted to make room for cookie-policy boilerplate. Either way the
+agent gets dumber on pages the user picked precisely *because* the content was
+there.
+
 ## User stories
 
 ### Human users

--- a/specs/0006-context-pollution-reduction.md
+++ b/specs/0006-context-pollution-reduction.md
@@ -1,0 +1,132 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Context-pollution reduction
+
+## Purpose
+
+Strip page chrome and irrelevant regions that cost an agent tokens without
+helping it complete the task — footers, cookie banners, chat widgets, ads,
+disguised native advertorials, dead SVG sprite definitions, and (opt-in)
+engagement rails identified by an LLM.
+
+## User stories
+
+### Human users
+
+- As a **person using a token-billed agent**, I want the agent to spend its
+  budget on the actual page content, so that a task on a chrome-heavy site
+  doesn't burn tokens reading the footer five times.
+- As a **person on a site behind a cookie banner**, I want the banner gone by
+  default, so that the agent isn't blocked by an overlay before it can see the
+  page.
+
+### AI agents
+
+- As a **browser-use agent reading the page**, I want a smaller DOM with the
+  boilerplate regions stripped, so that my context window holds more of the
+  task-relevant content.
+- As a **browser-use agent that would otherwise interact with a chat widget**, I
+  want the floating bubble gone, so that it isn't a stray target competing with
+  the real call-to-action.
+- As a **browser-use agent on a publisher page**, I want native advertorials
+  with disclosure labels hidden, so that I don't treat paid placements as
+  editorial coverage.
+
+## Functional requirements
+
+- **FR-1.** `footer-redact` (default **on**) hides the page footer (legal links,
+  sitemap, social icons, marketing copy). Per-section footers inside articles or
+  asides are left visible.
+- **FR-2.** `cookie-banner-hide` (default **on**, top-frame only) removes
+  GDPR/CCPA cookie consent banners across OneTrust, Cookiebot, TrustArc,
+  Sourcepoint, Quantcast, Osano, Didomi, and generic patterns. Floating overlays
+  are removed entirely rather than placeholder-replaced.
+- **FR-3.** `chat-widget-hide` (default **on**, top-frame only) removes
+  live-chat widgets (Intercom, Drift, Zendesk, Crisp, Tawk.to, HubSpot, Olark,
+  LiveChat, Freshchat, Zopim). Removed entirely; no in-flow placeholder.
+- **FR-4.** `ads-hide` (default **on**) strips display ads and paid/sponsored
+  search results. Well-known surfaces (AdSense, GAM, Outbrain, Taboola,
+  Google/Bing/Amazon sponsored results) are stripped from the DOM. ~13k
+  additional EasyList generic element-hiding selectors are applied as a single
+  `display:none` stylesheet
+  (`extension/src/rules/easylist-generic.generated.ts`) — refreshed via
+  `bun run fetch-easylist` and committed to keep builds deterministic and
+  offline-capable.
+- **FR-5.** `disguised-ad-flag` (default **on**) hides article-shaped blocks
+  that carry a visible disclosure label — "Sponsored", "Promoted",
+  "Advertorial", "Paid Post", "Partner Content", "Featured Listing", "From our
+  Advertisers", "Marketing Partner", "In partnership with \<Brand>", or
+  bracketed variants (`[Ad]`, `(promoted)`, `(sponsored)`). The disclosure label
+  must sit inside an article-shaped container (heading carrier — `<h1>`–`<h6>`,
+  `[role="heading"]`, or `[class~="headline"]` — plus an image/outbound link and
+  body prose). A click-to-reveal placeholder is left in place.
+- **FR-6.** `svg-sprite-strip` (default **on**) removes hidden SVG sprite
+  containers (only `<symbol>`/`<defs>` definitions) when no `<use>` element on
+  the page references their symbols. Referenced sprites are preserved. Unlike
+  most strip rules, this one **detaches** the element outright because sprite
+  containers are not framework-owned (see
+  [ADR-0007](../decisions/0007-scrub-instead-of-detach-for-framework-dom.md)).
+- **FR-7.** `irrelevant-sections-redact` (default **off**, top-frame only,
+  requires an OpenAI API key) sends a compressed page tree with stable refs to a
+  small LLM to classify engagement/exploration rails (related products, "you
+  might also like", recommended articles, trending now). Identified rails are
+  replaced with click-to-reveal placeholders. Interactive elements (search,
+  cart, checkout, login) are labeled protected in the request payload. Re-scans
+  on scroll to catch lazy-loaded content. Unavailable until a key is configured
+  at build time via `OPENAI_API_KEY` or on the extension's options page.
+
+## Non-functional requirements
+
+- **NFR-P-1.** Selector-only hide rules (`ads-hide`'s EasyList portion,
+  `cookie-banner-hide`, `chat-widget-hide`) use a CSS `display:none` stylesheet
+  rather than per-element walks — one stylesheet append amortizes across
+  thousands of selectors. See
+  [ADR-0014](../decisions/0014-css-first-hide-for-selector-only-rules.md).
+- **NFR-S-1.** `irrelevant-sections-redact` is the only rule that performs
+  outbound network egress. It is off by default and gated on a user-supplied API
+  key. The compressed page tree is sent only when the rule is enabled and a key
+  is configured. See [ADR-0010](../decisions/0010-no-telemetry.md) and spec
+  [0013](./0013-privacy-and-egress.md).
+- **NFR-O-1.** EasyList refresh is a manual step (`bun run fetch-easylist`); the
+  generated file is committed. Build freshness is not automatically enforced —
+  operators decide cadence.
+
+## Current implementation
+
+- FR-1: `extension/src/rules/footer-redact.ts`,
+  `extension/src/rules/__tests__/footer-redact.test.ts`.
+- FR-2: `extension/src/rules/cookie-banner-hide.ts`,
+  `extension/src/rules/__tests__/cookie-banner-hide.test.ts`.
+- FR-3: `extension/src/rules/chat-widget-hide.ts`,
+  `extension/src/rules/__tests__/chat-widget-hide.test.ts`.
+- FR-4: `extension/src/rules/ads-hide.ts`,
+  `extension/src/rules/easylist-generic.generated.ts`,
+  `scripts/fetch_easylist.py`, `extension/src/rules/__tests__/ads-hide.test.ts`.
+- FR-5: `extension/src/rules/disguised-ad-flag.ts`,
+  `extension/src/rules/__tests__/disguised-ad-flag.test.ts`.
+- FR-6: `extension/src/rules/svg-sprite-strip.ts`,
+  `extension/src/rules/__tests__/svg-sprite-strip.test.ts`.
+- FR-7: `extension/src/rules/irrelevant-sections-redact.ts`,
+  `extension/src/lib/llm-client.ts`, `extension/src/lib/llm-background.ts`,
+  `extension/src/lib/page-tree.ts`, `extension/src/lib/api-key-storage.ts`,
+  `extension/src/rules/__tests__/irrelevant-sections-redact.test.ts`.
+
+## Future work
+
+- EasyList auto-refresh — manual today (NFR-O-1). No tracking issue yet.
+- Multi-provider LLM backend for `irrelevant-sections-redact` — OpenAI is the
+  only supported provider; local-model or alternate-vendor support is not on the
+  roadmap.
+- Per-host budget for `irrelevant-sections-redact` token spend — classification
+  cost is bounded by the compressed page tree size; no hard per-tab cap today.
+
+## Related
+
+- ADRs: [ADR-0010](../decisions/0010-no-telemetry.md),
+  [ADR-0014](../decisions/0014-css-first-hide-for-selector-only-rules.md).
+- Docs: [`docs/src/content/docs/rules.md`](../docs/src/content/docs/rules.md)
+  §"Context pollution".
+- Specs: [0002](./0002-rule-engine.md), [0013](./0013-privacy-and-egress.md).

--- a/specs/0007-visual-identity-and-trust.md
+++ b/specs/0007-visual-identity-and-trust.md
@@ -1,0 +1,149 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Visual identity and trust verification
+
+## Purpose
+
+Flag visual-identity spoofs and unverifiable trust claims that depend on the
+asymmetry between **rendered glyphs** (what humans and vision-based agents read)
+and **structured page data** (what DOM-walking agents read). The rules in this
+area annotate rather than remove, because the artifact itself is the thing under
+inspection.
+
+## User stories
+
+### Human users
+
+- As a **person reading a phishing-style page**, I want anchor text that
+  visually mimics a brand or whose domain differs from the `href` flagged with
+  an inline chip, so that I can see the asymmetry without having to hover-check
+  every link.
+- As a **person on a page covered in "trusted" badges**, I want unverifiable
+  third-party endorsements (Norton Secured, McAfee SECURE, BBB Accredited,
+  TrustPilot, "Verified Seller") flagged, so that I don't weight them as if the
+  chrome TLS UI backed them.
+
+### AI agents
+
+- As a **vision-based browser-use agent**, I want a visible chip acknowledging
+  the rendered-glyph-vs-href asymmetry, so that I see the same signal the
+  sighted user sees rather than ingesting the spoofed domain as fact.
+- As a **DOM-walking browser-use agent reading structured data**, I want
+  schema.org `Organization` impersonation flagged (blanked) when the publisher
+  claim resolves to a different registrable domain, so that I don't cite
+  borrowed authority as the page's own.
+
+## Functional requirements
+
+### Visual identity spoofing
+
+- **FR-1.** `link-spoof-annotate` (default **on**) annotates `<a>` elements
+  whose visible text is visually spoofed relative to the link's actual
+  destination. Three checks signal with a visible inline chip:
+  1. **Mixed-script word.** A word mixes Latin letters with letters from Greek
+     (`U+0370–03FF`), Cyrillic (`U+0400–04FF`), Armenian (`U+0530–058F`), or
+     Cherokee (`U+13A0–13FF`) — the script blocks supplying Latin confusables. A
+     pure-Cyrillic word adjacent to a pure-Latin word does not match; this test
+     requires within-word script mixing.
+  2. **Single-script homograph.** The visible text contains a domain whose
+     letters are drawn entirely from one non-Latin script but whose visual
+     skeleton — via a curated subset of the Unicode TR39 confusables table —
+     collapses to a pure-Latin string. The chip surfaces the Latin form the
+     domain mimics.
+  3. **Visible-text / href domain mismatch.** A fully-formed domain in the
+     visible text whose registrable identity (PSL, ICANN section) doesn't match
+     the link's actual host. Both visible candidate and `href` are normalized to
+     punycode before comparison, so legitimate IDN links don't surface while
+     attacker-redirect cases do. Gated to `http(s):` hrefs.
+- **FR-2.** The `link-spoof-annotate` chip renders as visible markup (not just a
+  `data-*` attribute) because the rule's threat model is the asymmetry where
+  vision-based agents and sighted users read the rendered glyphs but the
+  navigation target lives in the unrendered `href`.
+
+### Trust-badge claims
+
+- **FR-3.** `trust-badge-annotate` (default **off**, experimental) annotates
+  image-shaped trust badges — Norton Secured, McAfee SECURE, BBB Accredited,
+  TrustPilot, Verified Seller, and similar — whose accessible name asserts
+  third-party endorsement that no content-script-accessible signal backs. The
+  badge itself is left in place; the chip notes the claim is not verifiable from
+  page content.
+- **FR-4.** `trust-badge-annotate` detection is intentionally narrow. Only
+  `<img>`, `<svg>`, and elements with `role="img"` are considered (plain text
+  labels like "Verified Purchase" on a review are out of scope). The accessible
+  name is read in standard precedence (`aria-label` → `aria-labelledby` → SVG
+  `<title>` → `alt` → `title`), capped at a short length, matched against a
+  curated phrase set with word boundaries. Bare single words like "verified" or
+  "trusted" do not match. Badges on the issuer's own registrable domain (a
+  Norton page showing its own logo, BBB.org showing its accreditation seal) are
+  exempted as first-party.
+
+### Structured-data trust
+
+- **FR-5.** `schema-trust-sanitize` (default **off**, experimental) walks
+  JSON-LD blocks and microdata items for schema.org `Organization`-typed claims
+  (`Article.publisher`, `Article.sourceOrganization`, `ClaimReview.author`,
+  top-level brand assertions) and blanks `name`, `url`, and `@id` when the
+  claim's `url` resolves to a different registrable domain than the page
+  asserting it. Structural fields (`@type`, `logo`, `datePublished`, `price`,
+  `ratingValue`) are preserved exactly. Name-only claims with no `url` to anchor
+  against are left alone.
+- **FR-6.** The rule short-circuits on known syndicators (Google News, Yahoo
+  News, MSN, Apple News, Flipboard, SmartNews, Feedly, Pocket), web archives,
+  AMP cache, and Google Translate proxies, where mismatched publisher claims are
+  expected.
+- **FR-7.** `Person`-typed claims get a weaker treatment: when a `Person` is
+  nested under an authority-context property (`author`, `editor`, `publisher`,
+  `creator`, `contributor`, `reviewedBy`, `funder`, `sponsor`, similar) and its
+  `url` is on a different registrable domain than the page, the rule annotates
+  with `abs:unverified-authority: true` (JSON-LD) or
+  `data-abs-schema-trust-unverified="true"` (microdata) rather than blanking.
+  Standalone `@type: Person` (a personal homepage) is left alone regardless of
+  URL. Reasoning: blanking legitimate guest-author and academic bylines, which
+  routinely link off-domain, would erase real metadata.
+
+## Non-functional requirements
+
+- **NFR-S-1.** `link-spoof-annotate` and `trust-badge-annotate` preserve the
+  underlying control — the link still navigates, the badge still renders.
+  Annotation surfaces a signal alongside; it does not remove agency.
+- **NFR-S-2.** `schema-trust-sanitize` blanks identity strings only; structural
+  fields the agent needs to read the page's content are preserved exactly
+  (FR-5).
+- **NFR-U-1.** `link-spoof-annotate` chips are visible to humans precisely
+  because the threat model includes sighted users acting on the rendered glyphs.
+  They are not screen-reader-only.
+
+## Current implementation
+
+- FR-1, FR-2: `extension/src/rules/link-spoof-annotate.ts`,
+  `extension/src/lib/confusables.ts`,
+  `extension/src/rules/__tests__/link-spoof-annotate.test.ts`,
+  `extension/src/rules/__tests__/link-spoof-annotate.property.test.ts`.
+- FR-3, FR-4: `extension/src/rules/trust-badge-annotate.ts`,
+  `extension/src/rules/__tests__/trust-badge-annotate.test.ts`.
+- FR-5, FR-6, FR-7: `extension/src/rules/schema-trust-sanitize.ts`,
+  `extension/src/lib/schema-trust.ts`, `extension/src/lib/domain-trust.ts`,
+  `extension/src/rules/__tests__/schema-trust-sanitize.test.ts`,
+  `extension/src/rules/__tests__/schema-trust-sanitize-skip.test.ts`.
+
+## Future work
+
+- Move `trust-badge-annotate` and `schema-trust-sanitize` from experimental
+  (off-by-default) to default-on once the false-positive rate is characterized
+  in real traffic.
+- Native (non-image) text-only trust assertions ("100% Money Back Guarantee",
+  "Industry-Leading Security") — out of scope for `trust-badge-annotate` today;
+  would need a different shape gate than `<img>`/`<svg>`/`role="img"`.
+
+## Related
+
+- ADRs: [ADR-0002](../decisions/0002-rule-id-naming-taxonomy.md) (annotate verb
+  is reserved for capability signals like this).
+- Docs: [`docs/src/content/docs/rules.md`](../docs/src/content/docs/rules.md)
+  §"Visual identity spoofing".
+- Specs: [0005](./0005-dark-pattern-defense.md) (related: `roach-motel-annotate`
+  uses similar annotation posture).

--- a/specs/0007-visual-identity-and-trust.md
+++ b/specs/0007-visual-identity-and-trust.md
@@ -13,6 +13,17 @@ and **structured page data** (what DOM-walking agents read). The rules in this
 area annotate rather than remove, because the artifact itself is the thing under
 inspection.
 
+## Problem
+
+Phishing and impersonation pages exploit the gap between what humans see (a
+glyph, a logo, a "Verified" badge) and what DOM-walking agents see (an `href`,
+an `alt` text, a microdata field). An anchor that *displays* `paypal.com` but
+*points* at `paypa1.com`; a "Verified by Trustpilot" badge that's a static PNG
+with no schema.org markup; a homoglyph URL in the address bar. A vision-only
+agent reads the glyph and trusts it; a DOM-only agent reads the href and trusts
+it. Either reader class alone misses half of the spoof. A defense layer has to
+name the asymmetry explicitly so neither reader gets bluffed.
+
 ## User stories
 
 ### Human users

--- a/specs/0008-cross-origin-and-shadow-dom.md
+++ b/specs/0008-cross-origin-and-shadow-dom.md
@@ -1,0 +1,194 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Cross-origin and shadow-DOM coverage
+
+## Purpose
+
+Establish where the rule engine can and cannot reach, and surface the gaps back
+to the agent so it isn't silently reading content the shield never saw. Covers
+shadow-DOM attachment paths (open vs closed), cross-origin embedded frames, and
+AI-targeted cloaking signals.
+
+## User stories
+
+### Human users
+
+- As a **person browsing a page with a closed-shadow-root chat widget**, I want
+  the agent warned that there's a blind spot, so that I don't assume the shield
+  covers the whole page when it can't.
+- As a **person on a page with cross-origin iframes (payment, video, third-party
+  comments)**, I want a way to keep the agent from ingesting embedded-origin
+  content, so that an attacker can't smuggle instructions in via an iframe the
+  parent page doesn't control.
+
+### AI agents
+
+- As a **browser-use agent reading the page**, I want every open shadow root
+  walked the same way the light DOM is, so that defenses apply regardless of
+  which framework's component model the page uses.
+- As a **browser-use agent reading the page**, I want a screen-reader-only
+  landmark when the page attaches closed shadow roots or reads
+  `navigator.webdriver`, so that I can warn the user that the shield has a known
+  coverage gap on this page or that the site can distinguish agent traffic from
+  human traffic.
+
+## Functional requirements
+
+### Open shadow-root coverage
+
+- **FR-1.** The engine walks every **open** shadow root the page builds. Three
+  attachment paths are covered:
+  1. Imperative — `element.attachShadow({ mode: "open" })`. Handles most chat
+     widgets, consent banners, ad SDKs, and custom elements.
+  2. Declarative shadow DOM at parse time — `<template shadowrootmode="open">`
+     in the initial HTML. The browser materializes the shadow before the content
+     script runs; the extension's startup walk finds it.
+  3. Declarative shadow DOM post-parse — `Element.setHTMLUnsafe` and
+     `ShadowRoot.setHTMLUnsafe`. The extension wraps both so a host that gains a
+     shadow via this path is added to the registry.
+- **FR-2.** Placeholder styling is adopted into every open shadow root via
+  `adoptedStyleSheets` so a placeholder rendered inside a web-component shadow
+  tree renders with the same stripes, border, and reveal-button chrome as the
+  light DOM. Document stylesheets don't cross shadow boundaries; the
+  `adoptedStyleSheets` primitive does.
+
+### Closed shadow-root posture
+
+- **FR-3.** **Closed** shadow roots (`{ mode: "closed" }`) are not reached,
+  regardless of attachment path. The Web Components spec makes closed mode opt
+  out of all external JS access (`host.shadowRoot` is `null`,
+  `document.adoptedStyleSheets` and `MutationObserver` do not cross the
+  boundary). Any content rendered inside a closed shadow root — ads, chat
+  widgets, hidden text, prompt-injection payloads — is invisible to every rule
+  and is passed through to the agent untouched. This is documented as a known
+  gap. See [ADR-0008](../decisions/0008-shadow-dom-coverage.md).
+- **FR-4.** `closed-shadow-root-annotate` (default **off**, experimental,
+  top-frame only) detects closed-shadow-root attachments and prepends a
+  screen-reader-only landmark noting that the extension cannot see inside. Two
+  detection paths feed the landmark:
+  1. **Main-world probe (primary).** A page-world wrap over
+     `Element.prototype.attachShadow` runs at `document_start`. Any call with
+     `mode: "closed"` dispatches a binary signal — no shadow contents are
+     exposed; only the binary "attachment happened" signal crosses worlds,
+     preserving the spec-mandated encapsulation of closed mode.
+  2. **Structural heuristic (fallback).** Looks for an upgraded custom element
+     (hyphenated tag name, defined in `customElements`) with no light-DOM
+     children, no `host.shadowRoot`, and a non-zero rendered box. Built-in
+     elements with UA shadow roots (`<input>`, `<details>`, `<video>`) are
+     filtered out — their tag names contain no hyphen.
+- **FR-5.** The heuristic path has a known false positive: a custom element that
+  renders via canvas, WebGL, or `::before` background-image with no actual
+  shadow root will trip it. The landmark text reads "may contain content ABS
+  cannot see," not "this is definitely a closed shadow root." The main-world
+  probe is definitive when both signals are available.
+- **FR-6.** Declarative shadow DOM with `shadowrootmode="closed"` is not
+  surfaced by either path — the parser materializes the shadow without going
+  through `attachShadow`, so the probe doesn't see it; and the materialized
+  closed root is indistinguishable from "no shadow" from outside JS.
+
+### Cross-origin frames
+
+- **FR-7.** `cross-origin-frame-redact` (default **off**, experimental) replaces
+  cross-origin embedded frame-like elements with a click-to-reveal placeholder
+  so the parent-page agent doesn't ingest embedded-origin content. Three
+  carriers are covered:
+  - `<iframe>` whose `src` resolves to a different web origin,
+  - `<object data="…">` and `<embed src="…">` pointing at a different web
+    origin.
+- **FR-8.** Same-origin iframes/objects/embeds, `srcdoc` iframes, and inert
+  `about:` / `javascript:` / `data:` / `blob:` resources are left alone. Each
+  frame in the page processes its own direct children, so a cross-origin frame
+  nested inside a same-origin frame is also caught (the same-origin parent's
+  content script handles the redact).
+
+### AI-targeted cloaking signal
+
+- **FR-9.** `webdriver-probe-annotate` (default **off**, experimental, top-frame
+  only) injects a main-world probe that wraps `navigator.webdriver`'s getter on
+  the top-level document and listens for reads. If the page reads the property,
+  the rule prepends a screen-reader-only landmark noting that the site can
+  distinguish AI-agent traffic from human traffic and may serve different
+  content to agents than to people.
+- **FR-10.** Two complementary delivery paths run the same wrap-and-dispatch
+  logic in the page world:
+  1. **Primary, document_start.** On toggle-on, the background service worker
+     registers a standalone main-world bundle (`webdriver-probe.js`) via
+     `chrome.scripting.registerContentScripts` with `world: "MAIN"` and
+     `runAt: "document_start"`. Subsequent navigations run the probe before the
+     page's first script.
+  2. **Fallback, document_idle.** The rule's own `apply` inline-injects the same
+     probe via `<script>` `textContent`. Covers the tab the user was already
+     viewing when they toggled the rule on. Misses early-parse reads on that tab
+     but catches `DOMContentLoaded` / `load` handlers, polled fingerprinters,
+     and interaction-driven checks. Pages with a strict `script-src` CSP block
+     the inline `<script>`; future navigations are still covered by the
+     registered bundle.
+- **FR-11.** The annotation flags **capability**, not measured cloaking — a
+  `navigator.webdriver` read by itself is consistent with legitimate anti-fraud
+  fingerprinting on banking, payments, and checkout flows. The landmark text
+  never uses the unqualified word "cloaking".
+
+### Extension presence is observable
+
+- **FR-12.** The rules leave rendered artifacts on the page — click-to-reveal
+  placeholders, screen-reader-only landmarks, inline annotation chips,
+  neutralized button labels. A sophisticated site that fingerprints for those
+  artifacts can detect ABS and serve a different DOM under that fingerprint. The
+  rule engine only sees what the page renders, so any content shaped by such
+  adaptation is read by the rules as legitimate page content. **Counter-cloaking
+  from a content script is structurally out of scope.**
+
+## Non-functional requirements
+
+- **NFR-S-1.** Main-world probes (`webdriver-probe`, `shadow-root-probe`,
+  `checkout-checkbox-defense`, `dump-trace-bridge`) are registered as standalone
+  bundles via `chrome.scripting.registerContentScripts` with `world: "MAIN"`,
+  scoped to the rule's effective state. Toggling the rule off unregisters the
+  script for future navigations; the wrap on already-loaded pages stays in place
+  for the document's lifetime.
+- **NFR-S-2.** No closed-shadow-root contents are exfiltrated by the detection
+  path (FR-4(1)) — only the binary attach event crosses worlds.
+- **NFR-O-1.** Roach-motel, webdriver-probe, and closed-shadow-root detections
+  surface in the popup's *Heads up* card section in addition to the per-rule
+  activity counts. See spec [0010](./0010-extension-ui-and-controls.md).
+
+## Current implementation
+
+- FR-1: `extension/src/lib/shadow-roots.ts`,
+  `extension/src/lib/shadow-root-probe-source.ts`,
+  `extension/src/lib/shadow-root-probe-registration.ts`,
+  `extension/src/shadow-root-probe.ts`.
+- FR-2: `extension/src/lib/shadow-stylesheets.ts`.
+- FR-3, FR-4, FR-5, FR-6: `extension/src/rules/closed-shadow-root-annotate.ts`,
+  `extension/src/rules/__tests__/closed-shadow-root-annotate.test.ts`.
+- FR-7, FR-8: `extension/src/rules/cross-origin-frame-redact.ts`,
+  `extension/src/rules/__tests__/cross-origin-frame-redact.test.ts`,
+  `extension/src/rules/__tests__/cross-origin-frame-redact.property.test.ts`.
+- FR-9, FR-10, FR-11: `extension/src/rules/webdriver-probe-annotate.ts`,
+  `extension/src/lib/webdriver-probe-source.ts`,
+  `extension/src/lib/webdriver-probe-registration.ts`,
+  `extension/src/webdriver-probe.ts`,
+  `extension/src/rules/__tests__/webdriver-probe-annotate.test.ts`.
+
+## Future work
+
+- Closed declarative shadow DOM detection — not surfaced by either path today
+  (FR-6); fundamental limitation given parser-materialized closed roots are
+  indistinguishable from "no shadow" from outside JS.
+- Cross-origin `<frame>` (legacy frameset) coverage —
+  `cross-origin-frame-redact` covers `<iframe>`/`<object>`/`<embed>` only.
+- Beyond `navigator.webdriver` — IP-based, UA-based, and other cloaking signals
+  are not detected client-side. Caspi & Tugendhaft document the full taxonomy;
+  this rule covers the JS-property arm only.
+
+## Related
+
+- ADRs: [ADR-0003](../decisions/0003-run-rule-engine-in-all-frames.md),
+  [ADR-0008](../decisions/0008-shadow-dom-coverage.md).
+- Docs: [`docs/src/content/docs/rules.md`](../docs/src/content/docs/rules.md)
+  §"Coverage scope", §"Cross-origin surface".
+- Specs: [0002](./0002-rule-engine.md),
+  [0010](./0010-extension-ui-and-controls.md).

--- a/specs/0008-cross-origin-and-shadow-dom.md
+++ b/specs/0008-cross-origin-and-shadow-dom.md
@@ -12,6 +12,16 @@ to the agent so it isn't silently reading content the shield never saw. Covers
 shadow-DOM attachment paths (open vs closed), cross-origin embedded frames, and
 AI-targeted cloaking signals.
 
+## Problem
+
+A defense system that silently doesn't cover part of a page is worse than no
+defense — the user assumes protection where there is none. Closed shadow roots,
+cross-origin iframes, declarative shadow DOM, and AI-targeted cloaking all
+surface content the rule engine cannot read or rewrite. Without explicit
+landmarks naming those blind spots, agents act on partial information believing
+the shield ran, and humans don't know to look closer at the regions the shield
+couldn't see.
+
 ## User stories
 
 ### Human users

--- a/specs/0008-cross-origin-and-shadow-dom.md
+++ b/specs/0008-cross-origin-and-shadow-dom.md
@@ -81,9 +81,12 @@ AI-targeted cloaking signals.
      filtered out — their tag names contain no hyphen.
 - **FR-5.** The heuristic path has a known false positive: a custom element that
   renders via canvas, WebGL, or `::before` background-image with no actual
-  shadow root will trip it. The landmark text reads "may contain content ABS
-  cannot see," not "this is definitely a closed shadow root." The main-world
-  probe is definitive when both signals are available.
+  shadow root will trip it. The landmark text is calibrated to that uncertainty
+  — it tells the reader that closed shadow content "is invisible to this
+  extension and may include text, controls, or instructions that are not
+  reflected in the rest of the page's accessible content," rather than asserting
+  a closed shadow root is definitely present. The main-world probe is definitive
+  when both signals are available.
 - **FR-6.** Declarative shadow DOM with `shadowrootmode="closed"` is not
   surfaced by either path — the parser materializes the shadow without going
   through `attachShadow`, so the probe doesn't see it; and the materialized

--- a/specs/0009-agent-shortcuts.md
+++ b/specs/0009-agent-shortcuts.md
@@ -12,6 +12,17 @@ the human-facing UI — currently URL recipes for searches, filters, sorts, and
 direct lookups on a curated set of hosts. The agent reads the hint from the
 accessibility tree and decides whether to use it.
 
+## Problem
+
+Agents waste tokens and reliability fumbling through complex per-site UIs:
+search inputs that reject paste, faceted filter panels that re-render on each
+click, sort menus hidden behind a hamburger, autocomplete dropdowns that close
+on focus loss. Most of those same sites already expose deterministic URL
+parameters that get the same result in a single navigation. Without an in-page
+hint pointing the agent at the URL recipe, every agent re-discovers the URL
+shape from scratch — or, worse, gives up on the URL and grinds through the
+brittle UI path while the user pays for the tokens.
+
 ## User stories
 
 ### Human users

--- a/specs/0009-agent-shortcuts.md
+++ b/specs/0009-agent-shortcuts.md
@@ -39,10 +39,10 @@ accessibility tree and decides whether to use it.
   screen-reader-only landmark at the top of the page describing how to run
   searches, filters, sorts, and direct lookups via URL on a curated set of
   hosts.
-- **FR-2.** Covered hosts ship today (current set authoritatively listed in
-  `extension/data/sites/*.yaml`): Amazon, Best Buy, Etsy, IKEA, Home Depot, REI,
-  GitHub, Wikipedia, Hacker News, MDN, npm, weather.gov, arXiv, Python docs,
-  BBC.
+- **FR-2.** Covered hosts span shopping, search, news, reference, dev tools,
+  travel, and government/civic destinations. The authoritative current set is
+  the YAML directory `extension/data/sites/*.yaml`; sites are added by dropping
+  in a new YAML, not by editing this spec.
 - **FR-3.** Per-host recipes live in `extension/data/sites/*.yaml`, validated at
   build time by the zod schema at `extension/data/site-rules.schema.ts`, and
   emitted into `extension/src/rules/site-data.generated.ts` via

--- a/specs/0009-agent-shortcuts.md
+++ b/specs/0009-agent-shortcuts.md
@@ -1,0 +1,106 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Agent shortcuts
+
+## Purpose
+
+Inject hints that let browser-use agents reach what they need without navigating
+the human-facing UI — currently URL recipes for searches, filters, sorts, and
+direct lookups on a curated set of hosts. The agent reads the hint from the
+accessibility tree and decides whether to use it.
+
+## User stories
+
+### Human users
+
+- As a **person watching an agent fumble through a search box on Amazon**, I
+  want the agent to navigate by URL instead, so that the task completes faster
+  and with fewer wrong clicks.
+- As a **sighted user**, I want the shortcut hint to be invisible to me, so that
+  it doesn't clutter the rendered page or compete with the site's UI.
+
+### AI agents
+
+- As a **browser-use agent landing on a covered host**, I want a
+  screen-reader-only landmark at the top of the page describing how to run
+  searches, filters, sorts, and direct lookups via URL, so that I can issue a
+  navigation instead of typing into search boxes.
+- As a **browser-use agent reading the landmark**, I want the URL templates to
+  be composable — every `{variable}` placeholder should be fillable from the
+  runtime intent, the page tree, or an inline vocabulary baked into the landmark
+  — so that I don't have to guess what value to interpolate.
+
+## Functional requirements
+
+- **FR-1.** `search-url-helper` (default **on**, top-frame only) embeds a
+  screen-reader-only landmark at the top of the page describing how to run
+  searches, filters, sorts, and direct lookups via URL on a curated set of
+  hosts.
+- **FR-2.** Covered hosts ship today (current set authoritatively listed in
+  `extension/data/sites/*.yaml`): Amazon, Best Buy, Etsy, IKEA, Home Depot, REI,
+  GitHub, Wikipedia, Hacker News, MDN, npm, weather.gov, arXiv, Python docs,
+  BBC.
+- **FR-3.** Per-host recipes live in `extension/data/sites/*.yaml`, validated at
+  build time by the zod schema at `extension/data/site-rules.schema.ts`, and
+  emitted into `extension/src/rules/site-data.generated.ts` via
+  `extension/scripts/build-site-data.ts`. Rule files import the generated TS;
+  the YAML is the editable source-of-truth.
+- **FR-4.** Recipe templates are **composable**: each `{variable}` placeholder
+  must be fillable from one of:
+  1. **runtime intent** — values the agent already has from the user's task,
+  2. **the page tree** — values present in the DOM the agent is reading (the
+     URL, breadcrumbs, visible labels), or
+  3. **an inline vocabulary** — an enumerated set baked into the landmark text
+     (e.g. allowed sort values).
+- **FR-5.** The landmark uses the standard screen-reader-only envelope. It is
+  preserved by `hidden-text-strip` via the `sr-only` class allowlist (spec
+  [0003](./0003-prompt-injection-defense.md), FR-11), so the shortcut and the
+  hidden-text defense don't fight each other.
+- **FR-6.** No visible affordance is rendered. The landmark surfaces in the
+  accessibility tree but not in the rendered layout.
+
+## Non-functional requirements
+
+- **NFR-M-1.** Templates must remain composable (FR-4). A `{variable}` derived
+  from benchmark task wording — not from intent, page tree, or inline vocabulary
+  — is not allowed.
+- **NFR-M-2.** Recipe changes flow through the YAML → codegen pipeline; rule
+  files don't inline per-host strings.
+- **NFR-O-1.** The rule reports per-frame mutation counts via the standard
+  rule-count reporter so operators see how often a covered host is visited and
+  the landmark fires.
+
+## Current implementation
+
+- FR-1, FR-2, FR-5, FR-6: `extension/src/rules/search-url-helper.ts`,
+  `extension/src/rules/__tests__/search-url-helper.test.ts`,
+  `extension/src/lib/sr-only.ts`.
+- FR-3: `extension/data/sites/*.yaml`, `extension/data/site-rules.schema.ts`,
+  `extension/scripts/build-site-data.ts`,
+  `extension/src/rules/site-data.generated.ts`,
+  `extension/src/rules/__tests__/site-data.test.ts`.
+- FR-4: enforced by code review; recipe authoring guidance lives in the
+  `agent-browser-shield-site-rules` skill at
+  `skills/agent-browser-shield-site-rules/SKILL.md`.
+
+## Future work
+
+- Beyond URL recipes: form-filling helpers (e.g. landmark surfacing the
+  canonical filter form's parameter names) — not shipped today; would use the
+  same composable-templates discipline.
+- Expanding host coverage — adding a host is one YAML file plus a test;
+  prioritized by real-world usage patterns observed in benchmark and user
+  feedback rather than predefined roadmap.
+
+## Related
+
+- ADRs: [ADR-0002](../decisions/0002-rule-id-naming-taxonomy.md) (`-helper`
+  reserved for non-defensive agent affordances).
+- Docs: [`docs/src/content/docs/rules.md`](../docs/src/content/docs/rules.md)
+  §"Agent shortcuts".
+- Skills:
+  [`skills/agent-browser-shield-site-rules/SKILL.md`](../skills/agent-browser-shield-site-rules/SKILL.md).
+- Specs: [0002](./0002-rule-engine.md).

--- a/specs/0010-extension-ui-and-controls.md
+++ b/specs/0010-extension-ui-and-controls.md
@@ -11,6 +11,16 @@ The user-facing surfaces of the extension: the toolbar action with its badge and
 popup, the Options page, the optional floating on-page options button, and the
 rule-state storage that backs them.
 
+## Problem
+
+A defensive extension has to be transparent and tunable, or it loses the user's
+trust the first time it gets in the way. Without a per-tab badge, users can't
+tell whether the shield is doing anything. Without a popup that lists which
+rules fired and how often, they can't reproduce a complaint to file a bug.
+Without fine-grained per-rule toggles backed by persistent storage, "the shield
+broke my page" turns into "I uninstalled the shield" — defenses are
+all-or-nothing, and users pick "nothing."
+
 ## User stories
 
 ### Human users

--- a/specs/0010-extension-ui-and-controls.md
+++ b/specs/0010-extension-ui-and-controls.md
@@ -1,0 +1,185 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Extension UI and controls
+
+## Purpose
+
+The user-facing surfaces of the extension: the toolbar action with its badge and
+popup, the Options page, the optional floating on-page options button, and the
+rule-state storage that backs them.
+
+## User stories
+
+### Human users
+
+- As a **person who wants to see what the shield did on this page**, I want a
+  badge with a per-tab activity count and a popup listing per-rule footprint, so
+  that I can verify protection is working at a glance.
+- As a **person hitting a false positive**, I want a one-click enforcement pause
+  that disables every rule for every tab without losing my per-rule selections,
+  so that I can finish my task and restore protection later.
+- As a **person tuning the rule set**, I want an Options page with each rule's
+  label, description, and a toggle, so that I can pick exactly the defenses I
+  want.
+- As a **person who needs to share configuration with a coworker**, I want to
+  export my rule states as JSON and import a JSON string, so that configuration
+  is portable across profiles.
+
+### AI agents
+
+- As a **browser-use agent that should not click the floating shield button by
+  mistake**, I want the on-page options button off by default on sparse pages,
+  so that it doesn't dominate the accessibility tree as a misleading target.
+- As a **browser-use agent reading a "Heads up" landmark**, I want site-level
+  detection context surfaced separately from per-rule activity counts, so that I
+  can act on roach-motel, webdriver-probe, and closed-shadow-root signals at
+  decision time.
+
+## Functional requirements
+
+### Toolbar action and badge
+
+- **FR-1.** The toolbar action shows a per-tab badge: a numeric count of the
+  cross-frame rule footprint on the active tab. Counts above 999 render as
+  `999+`.
+- **FR-2.** The badge color encodes detection state. Default blue (`#2563eb`)
+  means activity counts only; amber (`#f59e0b`) means the tab has a detection
+  worth opening the popup for (roach-motel-annotate, webdriver-probe-annotate,
+  closed-shadow-root-annotate). When a detection is present without an activity
+  count, the badge text falls back to `!` so the badge stays visible.
+- **FR-3.** Top-level navigation drops stale per-frame counts so the new
+  document starts from zero; content scripts in the new document report fresh
+  numbers as rules run.
+
+### Popup
+
+- **FR-4.** The popup renders a master **Enforcement** toggle, a **Configure
+  rules** button that opens the Options page, a **Heads up** detections section,
+  a **Per-rule activity** section, a **Debug trace** toggle, and an **Export**
+  button (visible when the debug-trace recorder is on).
+- **FR-5.** Toggling enforcement off pauses every rule for every tab. The
+  per-rule selection is preserved in `chrome.storage` and restored when
+  enforcement turns back on. The popup shows a hint when enforcement is off
+  explaining the behavior.
+- **FR-6.** The *Heads up* section renders one card per detection surfaced by
+  the background worker — roach-motel-annotate's grade and cancel URL,
+  webdriver-probe-annotate's capability note, closed-shadow-root-annotate's
+  blind-spot note. Detections are cleared when their producing rule is toggled
+  off mid-session.
+- **FR-7.** The *Per-rule activity* section lists rules whose footprint on the
+  active tab is non-zero, sorted by count descending and breaking ties by rule
+  ID for stable render across reopens. Rule labels are read from
+  `extension/src/popup/rule-labels.ts`, which is kept in lockstep with rule
+  labels by the `catalog.test.ts` invariant *"popup labels match each rule's own
+  label"*.
+
+### Options page
+
+- **FR-8.** The Options page renders all rules grouped by category (mirrors
+  `rule-groups.ts` and the `docs/src/content/docs/rules.md` taxonomy). Each rule
+  shows its label, description, and an enable/disable toggle. Unavailable rules
+  show as disabled with the rule's `unavailableReason` text.
+- **FR-9.** Per-rule toggles persist in `chrome.storage` under
+  `agent-browser-shield.rules`. Defaults come from
+  `extension/src/rules/rule-metadata.ts`, optionally layered with build-time
+  `EXTENSION_DEFAULT_OVERRIDES`. Build-time overrides only affect fresh
+  `chrome.storage`; existing user toggles persist on rebuild.
+- **FR-10.** The Options page exposes:
+  - **Apply configuration** — paste a JSON object mapping rule IDs to booleans;
+    click Apply.
+  - **Export configuration** — download the current rule states as
+    `agent-browser-shield-config.json`. Export shape matches the build-time
+    overrides format so the same JSON works in both places.
+  - **Placeholder display** — choose between label and icon-only modes for
+    click-to-reveal placeholders. Persisted in storage and applied via the
+    `data-abs-placeholder-mode` attribute on `<html>`.
+  - **On-page options button** — toggle the optional floating shield button.
+  - **Inactive tabs** — toggle whether the subtree-watcher keeps observing while
+    the tab is hidden.
+  - **OpenAI API key** — input for the key that backs
+    `irrelevant-sections-redact`. When a key is already bundled at build time
+    (`HAS_BUILT_IN_OPENAI_KEY`), the field acts as an override.
+
+### Floating on-page options button
+
+- **FR-11.** The on-page options button (default **off**) renders a floating
+  shield in the bottom-right corner of every page. Clicking it opens the
+  extension's options page. Default off because on sparse pages (JSON viewers,
+  error screens, interstitials) it dominates the accessibility tree and becomes
+  a misleading target for browser-use agents.
+
+### Inactive-tab observation
+
+- **FR-12.** `runOnInactiveTabs` (default **off**) controls whether the shared
+  subtree-watcher keeps observing while the tab is hidden. Off by default — a
+  hidden tab gets no observer callbacks, avoiding work the user can't see.
+  Operators flip it on when something else reads the page in the background
+  (chat copilots, accessibility-tree agents, sidebar extensions).
+
+### Rule storage and reconciliation
+
+- **FR-13.** Rule states are normalized on read: unknown keys are dropped,
+  missing keys default per `rule-metadata.ts` (with overrides layered). The
+  `chrome.storage.onChanged` listener fans changes to every subscribed surface —
+  the rule engine, the popup, the Options page — via `chrome-storage-value.ts`.
+- **FR-14.** The catalog test in `extension/src/rules/__tests__/catalog.test.ts`
+  enforces that every rule appears in exactly one group (FR-8 grouping is
+  exhaustive and non-overlapping), and that every rule has a popup label
+  matching its own `Rule.label`.
+
+## Non-functional requirements
+
+- **NFR-U-1.** The popup loads in under one frame on a warm storage read —
+  `useChromeStorageValue` reads synchronously from a cached value once the first
+  round-trip resolves. A "Loading…" state shows only on the cold first open.
+- **NFR-U-2.** The Options page is `open_in_tab: true` so users can keep it
+  pinned alongside the page being tuned.
+- **NFR-S-1.** The Options page's *Apply configuration* JSON input is parsed via
+  `parseConfig` (`extension/src/options/parse-config.ts`), which validates types
+  and rejects unknown keys with a user-visible message.
+
+## Current implementation
+
+- FR-1, FR-2, FR-3: `extension/src/background.ts` (`refreshBadge`,
+  `recordFrameRuleCounts`, `recordDetection`, `clearTab`).
+- FR-4, FR-5, FR-6, FR-7: `extension/src/popup/Popup.tsx`,
+  `extension/src/popup/PerRuleCountsSection.tsx`,
+  `extension/src/popup/DetectionsSection.tsx`,
+  `extension/src/popup/DebugTraceSection.tsx`,
+  `extension/src/popup/rule-labels.ts`,
+  `extension/src/popup/use-tab-detections.ts`.
+- FR-8, FR-9, FR-10: `extension/src/options/Options.tsx`,
+  `extension/src/options/Section.tsx`, `extension/src/options/parse-config.ts`,
+  `extension/src/lib/RuleList.tsx`, `extension/src/lib/storage.ts`,
+  `extension/src/lib/placeholder-display.ts`,
+  `extension/src/lib/api-key-storage.ts`, `extension/src/options/__tests__/`.
+- FR-11: `extension/src/lib/options-button-toggle.ts`,
+  `extension/src/lib/options-badge.ts`.
+- FR-12: `extension/src/lib/run-on-inactive-tabs.ts`,
+  `extension/src/lib/subtree-watcher.ts`.
+- FR-13, FR-14: `extension/src/lib/chrome-storage-value.ts`,
+  `extension/src/lib/rule-groups.ts`,
+  `extension/src/rules/__tests__/catalog.test.ts`.
+
+## Future work
+
+- Detection promotion: when a detection-producing rule is off, surface a hint
+  that turning it on would catch this kind of pattern. Not implemented;
+  detections only render when their producing rule is on.
+- Per-host enable/disable for specific rules from the popup — only per-host
+  kill-switches today are baked into rule files (`hidden-affiliate-sanitize`,
+  `hidden-fee-annotate`); no UI surface.
+
+## Related
+
+- ADRs: [ADR-0009](../decisions/0009-rule-defaults-and-build-time-overrides.md),
+  [ADR-0013](../decisions/0013-background-worker-purity-canary.md).
+- Docs:
+  [`docs/src/content/docs/install.md`](../docs/src/content/docs/install.md)
+  §"Customizing defaults at build time".
+- Specs: [0002](./0002-rule-engine.md),
+  [0008](./0008-cross-origin-and-shadow-dom.md),
+  [0011](./0011-build-time-customization.md), [0012](./0012-debug-trace.md).

--- a/specs/0011-build-time-customization.md
+++ b/specs/0011-build-time-customization.md
@@ -12,6 +12,16 @@ non-rule build-time toggles — without forking the repo or flipping toggles in
 the Options UI on every fresh session. Targets infra deployments (CDP,
 Browserbase, agent runtimes) where storage starts empty each session.
 
+## Problem
+
+Downstream embedders — PixieBrix, agent harness operators, CDP/Browserbase users
+— need different defaults than a human installer. Short-lived browser sessions
+start with empty storage every time, so any rule a harness wants on by default
+reverts to the ship state on every boot. Without build-time override hooks,
+every embedder forks the repo to flip defaults, or runs a brittle "set storage
+at startup" script before each session — and both strategies drift on every
+shield release.
+
 ## User stories
 
 ### Human users

--- a/specs/0011-build-time-customization.md
+++ b/specs/0011-build-time-customization.md
@@ -1,0 +1,120 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Build-time customization
+
+## Purpose
+
+Let operators ship a build with a custom default rule set — and a small set of
+non-rule build-time toggles — without forking the repo or flipping toggles in
+the Options UI on every fresh session. Targets infra deployments (CDP,
+Browserbase, agent runtimes) where storage starts empty each session.
+
+## User stories
+
+### Human users
+
+- As a **person running an agent in a short-lived browser instance**, I want the
+  shield to start configured the way my workflow needs, so that every session
+  doesn't reproduce the same setup clicks.
+- As a **person who already tuned the Options page**, I want a rebuild to
+  preserve my existing toggles, so that an infra default override doesn't blow
+  away the configuration I chose.
+
+### AI agents
+
+- As a **CDP harness operator**, I want `debugTrace: true` and any other
+  baseline I care about to be the build default, so that the recorder is on
+  every session without a human flipping the popup toggle.
+
+## Functional requirements
+
+- **FR-1.** `extension/build.ts` accepts a `--defaults <path>` CLI flag, or
+  `EXTENSION_DEFAULTS_FILE=<path>` environment variable, pointing at a JSON file
+  in the same shape as the Options-page export. Validated overrides are injected
+  into the bundle via the `process.env.EXTENSION_DEFAULT_OVERRIDES` define
+  substitution.
+- **FR-2.** The override file is a **flat JSON object**. Keys are either:
+  - a registered rule ID mapped to a boolean (same shape as the Options-page
+    export), or
+  - one of the reserved non-rule keys (FR-3).
+- **FR-3.** Reserved non-rule keys:
+  - `optionsButton` (boolean, default **off**) — start with the floating on-page
+    options button enabled.
+  - `runOnInactiveTabs` (boolean, default **off**) — start with the shared
+    subtree-watcher observing while the tab is hidden.
+  - `debugTrace` (boolean, default **off**) — start with the dev-mode
+    debug-trace recorder enabled, so the popup's Export button and the
+    `window.__abs_dumpTrace` bridge are available without a human flipping the
+    toggle.
+- **FR-4.** Unknown keys (neither a registered rule ID nor a reserved key) and
+  non-boolean values fail the build with a message naming them.
+- **FR-5.** The override file may be partial; rules not listed keep the
+  committed default from `extension/src/rules/rule-metadata.ts`.
+- **FR-6.** Build-time overrides only affect **fresh** `chrome.storage`. Users
+  who already toggled rules in the Options UI keep their preferences on rebuild.
+  Implementation: defaults are merged into the `defaultValue` of the storage
+  accessor; existing entries are read back as-is.
+- **FR-7.** The starting template is committed at
+  [`extension/data/defaults-overrides.example.json`](../extension/data/defaults-overrides.example.json).
+  The Options-page export shape matches the override-file shape — a JSON
+  exported from a tuned extension can be fed straight back into the next build.
+
+## Non-functional requirements
+
+- **NFR-S-1.** Built bundles must not contain obfuscated code. The
+  injection-pattern decode step (spec
+  [0003](./0003-prompt-injection-defense.md), FR-1) emits plaintext RegExp
+  literals at build time so the shipped JS contains no runtime `atob` of
+  obfuscated strings. See
+  [ADR-0011](../decisions/0011-build-time-decoded-injection-patterns.md).
+- **NFR-S-2.** The build-time `EXTENSION_DEFAULT_OVERRIDES` value is parsed at
+  content-script startup via `JSON.parse` and validated per-rule-ID; a malformed
+  value silently degrades to "no overrides" rather than crashing the engine.
+- **NFR-M-1.** Rule defaults and IDs live in a single hand-edited file
+  (`extension/src/rules/rule-metadata.ts`). The `catalog.test.ts` invariant
+  enforces parity with `rules/index.ts`. See
+  [ADR-0009](../decisions/0009-rule-defaults-and-build-time-overrides.md).
+- **NFR-O-1.** The build-time inputs that affect operator deployment (CLI flags,
+  env vars, `define:` substitutions) are documented in
+  [`docs/src/content/docs/install.md`](../docs/src/content/docs/install.md)
+  §"Customizing defaults at build time" and mirrored in
+  `skills/agent-browser-shield-install/SKILL.md` so the build-time customization
+  workflow stays accurate across surfaces.
+
+## Current implementation
+
+- FR-1, FR-4: `extension/build.ts` (`--defaults` flag, `EXTENSION_DEFAULTS_FILE`
+  env, validation).
+- FR-2, FR-3, FR-7: `extension/data/defaults-overrides.example.json`,
+  `extension/src/lib/options-button-toggle.ts`,
+  `extension/src/lib/run-on-inactive-tabs.ts`,
+  `extension/src/lib/debug-trace.ts`.
+- FR-5, FR-6: `extension/src/lib/storage.ts` (`parseOverrides`,
+  `DEFAULT_STATES`).
+- Default source-of-truth: `extension/src/rules/rule-metadata.ts`, validated by
+  `extension/src/rules/__tests__/catalog.test.ts`.
+
+## Future work
+
+- Per-host default overrides — today overrides are flat and global; no way to
+  ship "rule X off on host Y" as a build-time default.
+- Build-time API key bundling for `irrelevant-sections-redact` is supported via
+  `OPENAI_API_KEY` at build time (see `extension/src/lib/api-key-storage.ts`)
+  but is not part of the override file. Folding it into the same JSON shape
+  would be a natural cleanup; no tracking issue.
+
+## Related
+
+- ADRs: [ADR-0009](../decisions/0009-rule-defaults-and-build-time-overrides.md),
+  [ADR-0011](../decisions/0011-build-time-decoded-injection-patterns.md),
+  [ADR-0013](../decisions/0013-background-worker-purity-canary.md).
+- Docs:
+  [`docs/src/content/docs/install.md`](../docs/src/content/docs/install.md)
+  §"Customizing defaults at build time".
+- Skills:
+  [`skills/agent-browser-shield-install/SKILL.md`](../skills/agent-browser-shield-install/SKILL.md).
+- Specs: [0010](./0010-extension-ui-and-controls.md),
+  [0012](./0012-debug-trace.md).

--- a/specs/0012-debug-trace.md
+++ b/specs/0012-debug-trace.md
@@ -1,0 +1,156 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Debug trace
+
+## Purpose
+
+A dev-mode recorder that captures every rule-driven mutation (selector, kind,
+before/after `outerHTML`, segment id) and persists it to IndexedDB so operators
+and rule authors can investigate **false positives** — "the shield hid, masked,
+or rewrote something it shouldn't have." Off by default; retrieved via the
+popup's *Export* button or, for CDP-driven harnesses, via
+`window.__abs_dumpTrace()`.
+
+## User stories
+
+### Human users
+
+- As a **person who reported "the page looks broken"**, I want to dump a JSONL
+  trace and replay the recorded `outerHTML` before/after pair on a clean page,
+  so that the false positive is reproducible without me needing to re-stage the
+  bug.
+- As a **rule author tuning a new pattern**, I want a footprint report of every
+  selector match the rule made on a page, so that I can decide whether the
+  rule's scope is right before merging.
+
+### AI agents
+
+- As a **CDP-driven harness operator (Browserbase, Hermes, browser-use,
+  OpenClaw)**, I want a build-time-default option for `debugTrace: true`, so
+  that every session ships with the recorder on without a human flipping a
+  per-session toggle.
+- As a **Playwright or raw-CDP client**, I want to retrieve the trace mid-flow
+  via `Runtime.evaluate("(async () => await window.__abs_dumpTrace())()")`, so
+  that I can pull the record without driving the popup UI.
+
+## Functional requirements
+
+### Recorder
+
+- **FR-1.** The recorder is **off by default**. Three paths turn it on for the
+  lifetime of `chrome.storage`:
+  1. Build-time default `debugTrace: true` in an overrides file (spec
+     [0011](./0011-build-time-customization.md), FR-3).
+  2. Popup toggle in the *Debug trace* section.
+  3. Programmatic `chrome.storage` write (used in tests).
+- **FR-2.** When the recorder is on, every rule-driven mutation is appended to
+  the IndexedDB store via the background worker. Each record carries the `tabId`
+  and `frameId` it was recorded against.
+- **FR-3.** The store caps each tab at **2000 events**; older events are dropped
+  first.
+
+### Event schema
+
+- **FR-4.** Each record matches the schema at
+  [`extension/data/debug-trace.schema.json`](../extension/data/debug-trace.schema.json).
+  The `type` discriminator picks one of three shapes:
+  - **`segment`** — bookkeeping marker emitted at initial load, route changes,
+    modal opens, and large mutation bursts. Subsequent rule-application entries
+    carry the active segment id so consumers can group events by user-visible
+    phase.
+  - **`rule-application`** — a single rule-driven mutation. Carries the rule ID,
+    mutation kind (`hide` / `mask` / `strip` / `sanitize` / `flag` / `embed`),
+    the matched selector, and `outerHTML` before/after the mutation. CSS-only
+    matches (a rule installed a stylesheet but didn't write to the element) set
+    `cssOnly: true` and have identical before/after HTML.
+  - **`navigation`** — emitted by the background service worker on every
+    top-level loading transition. Lets a single trace span multiple page loads
+    in the same tab.
+
+### Retrieval — popup Export
+
+- **FR-5.** When the recorder is on, the popup shows an **Export** button in the
+  *Debug trace* section. Clicking it downloads a JSONL file with one stored
+  event per line, ordered chronologically across all frames for the active tab.
+
+### Retrieval — CDP bridge
+
+- **FR-6.** When the recorder is on and the background worker has registered the
+  page-world bundle, `window.__abs_dumpTrace()` is exposed on the **top frame's
+  MAIN world**. The async function returns the same stored-event shape as the
+  JSONL export, scoped to the calling tab.
+- **FR-7.** The bridge is exposed only on the top frame; the response includes
+  events from every frame on the tab (each carries its `frameId`), so a CDP
+  caller asking from the top frame sees the full picture across subframes.
+- **FR-8.** Pages already open when the popup toggle flips need a reload before
+  the `window.__abs_dumpTrace()` bridge appears — the dynamic content-script
+  registration only takes effect on subsequent navigations. Builds with
+  `debugTrace: true` register the bundle at startup so this caveat doesn't
+  apply.
+
+### Lifecycle
+
+- **FR-9.** Navigation does **not** clear the trace; instead a `navigation`
+  event is appended so a single export can span multiple page loads in the same
+  tab. Navigation entries are gated on the same recorder toggle that gates
+  content-script emission.
+- **FR-10.** Closing a tab clears its trace data from IndexedDB.
+
+## Non-functional requirements
+
+- **NFR-P-1.** When the recorder is off, the per-mutation cost is zero —
+  emission paths are gated on the `debugTraceStorage` toggle before any
+  `outerHTML` serialization runs. When on, the recorder visibly slows chatty
+  SPAs that re-render constantly. The docs explicitly direct operators to leave
+  the recorder off in production.
+- **NFR-S-1.** The page can see `window.__abs_dumpTrace()` when the bridge is
+  installed — any page-world script in the tab can call it. Documented in
+  [`docs/src/content/docs/debug-trace.md`](../docs/src/content/docs/debug-trace.md)
+  §"Caveats" with the warning: don't enable the recorder on a CWS profile used
+  for browsing untrusted sites.
+- **NFR-O-1.** The export schema is versioned via
+  `extension/data/debug-trace.schema.json` and is the public wire contract for
+  both the JSONL export and the CDP bridge response. Internal IDB bookkeeping
+  fields (`addedAt`) are stripped before export.
+
+## Current implementation
+
+- FR-1: `extension/src/lib/debug-trace.ts` (`debugTraceStorage`),
+  `extension/src/popup/DebugTraceSection.tsx`.
+- FR-2, FR-3: `extension/src/lib/debug-trace-store.ts` (`appendEvent`,
+  `clearTab`), background message handlers in `extension/src/background.ts`.
+- FR-4: `extension/data/debug-trace.schema.json`,
+  `extension/src/lib/debug-trace.ts`, `extension/src/lib/debug-trace-export.ts`,
+  `extension/src/lib/detection-messages.ts`,
+  `extension/src/lib/segment-tracker.ts`, `extension/src/lib/trace-mutation.ts`.
+- FR-5: `extension/src/popup/DebugTraceSection.tsx`,
+  `extension/src/popup/use-tab-debug-trace.ts`.
+- FR-6, FR-7, FR-8: `extension/src/dump-trace-bridge.ts`,
+  `extension/src/lib/dump-trace-bridge-source.ts`,
+  `extension/src/lib/dump-trace-bridge-registration.ts`,
+  `extension/src/lib/dump-trace-content-bridge.ts`.
+- FR-9, FR-10: `extension/src/background.ts` (`chrome.tabs.onUpdated` and
+  `chrome.tabs.onRemoved` handlers).
+
+## Future work
+
+- Compaction strategy beyond the 2000-event cap — older events are dropped first
+  today; a sampling or rule-id-aware retention policy could keep coverage for
+  low-frequency rules longer. No tracking issue.
+- Streaming export for very chatty pages — JSONL export today buffers in memory
+  before download.
+
+## Related
+
+- ADRs: [ADR-0009](../decisions/0009-rule-defaults-and-build-time-overrides.md)
+  (`debugTrace` reserved key).
+- Docs:
+  [`docs/src/content/docs/debug-trace.md`](../docs/src/content/docs/debug-trace.md),
+  [`docs/src/content/docs/install.md`](../docs/src/content/docs/install.md).
+- Skills:
+  [`skills/agent-browser-shield-diagnose/SKILL.md`](../skills/agent-browser-shield-diagnose/SKILL.md).
+- Specs: [0010](./0010-extension-ui-and-controls.md),
+  [0011](./0011-build-time-customization.md).

--- a/specs/0012-debug-trace.md
+++ b/specs/0012-debug-trace.md
@@ -14,6 +14,17 @@ or rewrote something it shouldn't have." Off by default; retrieved via the
 popup's *Export* button or, for CDP-driven harnesses, via
 `window.__abs_dumpTrace()`.
 
+## Problem
+
+Rules that hide, mask, or rewrite page content fail in two directions: they can
+cross-fire on legitimate content (false positive — the user notices something
+missing), or they can miss real injections (false negative — the agent quietly
+follows attacker text). Without a per-rule trace of "what selector matched, on
+which element, with what text before and after," neither failure mode is
+actionable: users can't reproduce reports beyond "the shield ate my form," and
+rule authors can't tell a tunable heuristic from a hard bug. The trace turns
+vague reports into evidence.
+
 ## User stories
 
 ### Human users

--- a/specs/0013-privacy-and-egress.md
+++ b/specs/0013-privacy-and-egress.md
@@ -48,9 +48,10 @@ conditions.
   they're not flagged for redaction. The exact payload shape lives in
   `extension/src/lib/page-tree.ts`.
 - **FR-4.** The API key is stored in `chrome.storage` under
-  `agent-browser-shield.api-key`. The Options page reads and writes it via the
-  `apiKeyStorage` accessor. A build-time bundled key (`HAS_BUILT_IN_OPENAI_KEY`)
-  is treated as a fallback the user can override via the Options page.
+  `agent-browser-shield.openai-api-key`. The Options page reads and writes it
+  via the `apiKeyStorage` accessor. A build-time bundled key
+  (`HAS_BUILT_IN_OPENAI_KEY`) is treated as a fallback the user can override via
+  the Options page.
 - **FR-5.** Per-tab rule footprint counts and detection payloads (roach-motel,
   webdriver-probe, closed-shadow-root) are held in background-worker memory only
   and cleared on tab close, top-level navigation, and enforcement-off

--- a/specs/0013-privacy-and-egress.md
+++ b/specs/0013-privacy-and-egress.md
@@ -12,6 +12,17 @@ call, and per-storage discipline that keeps user data on the device. This spec
 is the authoritative statement of what leaves the browser and under what
 conditions.
 
+## Problem
+
+A defensive extension installed to keep data away from agents must not itself
+become an exfiltration channel. The extension runs a `<all_urls>` content script
+that sees every page, holds API keys and per-tab detection state, and could
+plausibly phone home for "analytics" or "model improvement." Without a hard,
+inspectable zero-telemetry posture — written into the README, the docs, the
+Chrome Web Store listing, and the code — users have no way to verify the shield
+doesn't trade their data for the same reason they installed it. The bar is high
+precisely because the access is total.
+
 ## User stories
 
 ### Human users

--- a/specs/0013-privacy-and-egress.md
+++ b/specs/0013-privacy-and-egress.md
@@ -1,0 +1,110 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Privacy and network egress
+
+## Purpose
+
+The extension's privacy posture: zero telemetry, one explicitly opt-in outbound
+call, and per-storage discipline that keeps user data on the device. This spec
+is the authoritative statement of what leaves the browser and under what
+conditions.
+
+## User stories
+
+### Human users
+
+- As a **person installing the extension**, I want to confirm that no analytics,
+  usage telemetry, or page content is sent off-device by default, so that I can
+  use the shield on whatever pages I browse without a separate privacy review.
+- As a **person who wants the LLM-driven rule**, I want to provide my own OpenAI
+  API key explicitly, so that I'm in control of the outbound call and can revoke
+  or change the key at any time.
+
+### AI agents
+
+- As a **CDP harness operator**, I want a single documented endpoint
+  (`api.openai.com`) for the only outbound call the extension can make, so that
+  network egress allowlists are easy to scope.
+
+## Functional requirements
+
+- **FR-1.** The extension does not collect, store, or send any telemetry,
+  analytics, or usage data. Rule processing runs locally in the browser; nothing
+  is reported back to PixieBrix or any other server.
+- **FR-2.** The single exception is the optional `irrelevant-sections-redact`
+  rule (default **off**), which sends a compressed page tree to OpenAI's API for
+  classification when:
+  1. the rule is enabled, **and**
+  2. an OpenAI API key is configured (either bundled at build time via
+     `OPENAI_API_KEY` or saved on the extension's options page). Until both
+     conditions hold, the rule shows as Unavailable on the Options page and
+     makes no network calls.
+- **FR-3.** The compressed page tree sent to OpenAI carries DOM structure with
+  stable refs (so the LLM can choose the right granularity for redaction) and
+  labels interactive elements (search, cart, checkout, login) as protected so
+  they're not flagged for redaction. The exact payload shape lives in
+  `extension/src/lib/page-tree.ts`.
+- **FR-4.** The API key is stored in `chrome.storage` under
+  `agent-browser-shield.api-key`. The Options page reads and writes it via the
+  `apiKeyStorage` accessor. A build-time bundled key (`HAS_BUILT_IN_OPENAI_KEY`)
+  is treated as a fallback the user can override via the Options page.
+- **FR-5.** Per-tab rule footprint counts and detection payloads (roach-motel,
+  webdriver-probe, closed-shadow-root) are held in background-worker memory only
+  and cleared on tab close, top-level navigation, and enforcement-off
+  transitions. They are not persisted beyond the service-worker process
+  lifetime.
+- **FR-6.** Per-tab debug-trace records live in IndexedDB at the extension
+  origin (spec [0012](./0012-debug-trace.md)). They are not network-exposed;
+  export is user-driven (popup *Export* button or the `window.__abs_dumpTrace()`
+  bridge the page can call when the recorder is on).
+- **FR-7.** The per-rule activity counts the background worker aggregates are
+  sanitized at receipt — unknown rule IDs and non-positive counts are dropped,
+  so a misbehaving content script can't poison the popup or badge.
+
+## Non-functional requirements
+
+- **NFR-S-1.** The privacy statement is reproduced verbatim in
+  [`README.md`](../README.md) §"Privacy" and
+  [`docs/src/content/docs/index.mdx`](../docs/src/content/docs/index.mdx). Drift
+  between the two is caught by review. See
+  [ADR-0010](../decisions/0010-no-telemetry.md).
+- **NFR-S-2.** The Chrome Web Store listing must reflect the no-telemetry
+  posture; no analytics SDKs may be added to the extension without updating both
+  the docs and the listing.
+- **NFR-S-3.** The `irrelevant-sections-redact` rule does not log the raw page
+  content or model response to any persistent store beyond the debug-trace
+  recorder (when on), and the trace is local to the user's browser.
+- **NFR-O-1.** The extension's `host_permissions: ["<all_urls>"]` is needed
+  because the content script runs on every page. The background worker uses no
+  other permissions beyond `storage` and `scripting`.
+
+## Current implementation
+
+- FR-1, FR-2: `extension/src/rules/irrelevant-sections-redact.ts`,
+  `extension/src/lib/llm-background.ts`, `extension/src/lib/llm-client.ts`.
+- FR-3: `extension/src/lib/page-tree.ts`.
+- FR-4: `extension/src/lib/api-key-storage.ts`,
+  `extension/src/options/Options.tsx`.
+- FR-5: `extension/src/background.ts` (`tabRuleCounts`, `tabDetections`,
+  `clearTab`, `chrome.tabs.onRemoved`, `chrome.tabs.onUpdated`).
+- FR-6: `extension/src/lib/debug-trace-store.ts` (IndexedDB).
+- FR-7: `extension/src/background.ts` (sanitization in the `rule-count` message
+  handler).
+
+## Future work
+
+- Multi-provider LLM backend so users can keep the LLM rule on without involving
+  OpenAI specifically — out of scope today; OpenAI is the only supported
+  provider.
+
+## Related
+
+- ADRs: [ADR-0010](../decisions/0010-no-telemetry.md).
+- Docs: [`README.md`](../README.md) §"Privacy",
+  [`docs/src/content/docs/index.mdx`](../docs/src/content/docs/index.mdx).
+- Specs: [0006](./0006-context-pollution-reduction.md) (FR-7,
+  `irrelevant-sections-redact`), [0010](./0010-extension-ui-and-controls.md),
+  [0012](./0012-debug-trace.md).

--- a/specs/0014-non-functional-requirements.md
+++ b/specs/0014-non-functional-requirements.md
@@ -1,0 +1,184 @@
+---
+status: Current
+last_reviewed: 2026-06-09
+---
+
+# Non-functional requirements
+
+## Purpose
+
+Cross-cutting quality bars that apply across the system. Capability-specific
+NFRs live in their own specs; this one names the standing requirements every
+spec inherits unless explicitly weakened.
+
+This spec has no user stories — non-functional bars are not user-facing
+behavior. They constrain how every functional requirement must be met.
+
+## Performance
+
+- **NFR-P-1. Initial application is bounded by `document_idle`.** The content
+  script runs once at `document_idle` per frame. Per-rule cost must fit within
+  the budget of one event-loop turn for a typical page (~1k DOM elements). Rules
+  that walk the entire document use the yielding text-walk helper
+  (`extension/src/lib/yielding-text-walk.ts`) to avoid blocking the main thread.
+- **NFR-P-2. SPA re-scans use the shared subtree watcher.** Rules must not run
+  their own MutationObserver against `document.body`. The shared watcher
+  coalesces a burst of additions into a single throttled callback and
+  immediately flushes beyond a documented burst threshold (currently 512 pending
+  roots). See [ADR-0006](../decisions/0006-re-scan-spa-mutations.md).
+- **NFR-P-3. Selector-only hides are CSS-first.** Rules whose only action is
+  "hide elements matching a selector list" install a single `display:none`
+  stylesheet rather than walking the DOM. See
+  [ADR-0014](../decisions/0014-css-first-hide-for-selector-only-rules.md).
+- **NFR-P-4. Hidden tabs do no work by default.** The shared watcher pauses
+  while the tab is hidden. Operators can override via `runOnInactiveTabs` (spec
+  [0011](./0011-build-time-customization.md), FR-3).
+- **NFR-P-5. Debug trace is zero-cost when off.** Trace emission paths are gated
+  on `debugTraceStorage` before any `outerHTML` serialization runs.
+
+## Security and trust
+
+- **NFR-S-1. Strip carrier, don't detach framework-owned nodes.** Strip and
+  sanitize rules blank the data carrier (attribute value, text node, comment
+  data) rather than detach the node. Detaching framework-rendered DOM (React,
+  Vue, Svelte, Astro, htmx) breaks reconciliation on route change. See
+  [ADR-0007](../decisions/0007-scrub-instead-of-detach-for-framework-dom.md).
+  Documented exception: `svg-sprite-strip` detaches sprite containers, which are
+  not framework-owned.
+- **NFR-S-2. Remove over annotate for adversarial content.** Defenses against
+  prompt injection and cross-origin trickery strip the content; they do not just
+  label it as suspicious. Annotate is reserved for capability signals (closed
+  shadow roots, webdriver-probe reads, link spoofs) where the page itself is the
+  artifact under inspection.
+- **NFR-S-3. No prompt-injection phrasing in plaintext source.** Injection
+  patterns are base64-encoded in `extension/data/injection-patterns.yaml` and
+  decoded at build time into the generated file. User-facing docs and marketing
+  keep example phrasings abstract. See
+  [ADR-0011](../decisions/0011-build-time-decoded-injection-patterns.md).
+- **NFR-S-4. No obfuscated code in shipped bundles.** Build-time decoding emits
+  plaintext sources; the runtime contains no `atob` of obfuscated strings.
+  Chrome Web Store review treats runtime-decoded strings as obfuscated code.
+- **NFR-S-5. Centralized DOM markers.** Every `data-abs-*` attribute the engine
+  or any rule writes is declared in `extension/src/lib/dom-markers.ts`. An
+  ESLint `no-restricted-syntax` rule blocks raw `"data-abs-…"` literals outside
+  the registry. See [ADR-0004](../decisions/0004-centralize-dom-markers.md).
+- **NFR-S-6. Background-worker purity.** Rule files are excluded from the
+  background service-worker bundle (they touch DOM at module scope, which would
+  crash the worker). A post-build canary
+  (`extension/scripts/check-background-purity.ts`) enforces this. See
+  [ADR-0013](../decisions/0013-background-worker-purity-canary.md).
+- **NFR-S-7. Zero telemetry by default.** The extension does not collect, store,
+  or send any telemetry, analytics, or usage data. The optional
+  `irrelevant-sections-redact` rule is the only outbound call; off by default
+  and gated on a user-supplied API key. See
+  [ADR-0010](../decisions/0010-no-telemetry.md) and spec
+  [0013](./0013-privacy-and-egress.md).
+- **NFR-S-8. Extension presence is observable.** A sophisticated site can
+  fingerprint the rendered artifacts (placeholders, landmarks, chips,
+  neutralized labels) and serve a different DOM under that fingerprint.
+  Counter-cloaking from a content script is structurally out of scope.
+
+## Observability
+
+- **NFR-O-1. Leveled logging.** The rule engine and per-rule logs use
+  `extension/src/lib/log.ts` with leveled channels (`createRuleLogger(ruleId)`).
+  Production builds log INFO and above by default.
+- **NFR-O-2. Per-frame rule footprint counts.** Each content script reports its
+  own frame's tally per rule ID; the background worker aggregates and surfaces
+  the totals via the toolbar badge and the popup's per-rule activity list. Spec
+  [0010](./0010-extension-ui-and-controls.md) FR-1, FR-7.
+- **NFR-O-3. Debug-trace JSONL export.** The schema lives at
+  [`extension/data/debug-trace.schema.json`](../extension/data/debug-trace.schema.json)
+  and is the wire contract for the popup *Export* button and the
+  `window.__abs_dumpTrace` CDP bridge. Spec [0012](./0012-debug-trace.md).
+
+## Usability
+
+- **NFR-U-1. Reveal preserves agency.** Every placeholder is a `<button>` so
+  screen readers and accessibility-tree consumers see it as actionable. Clicking
+  restores the original carrier and stamps `data-abs-revealed="<rule-id>"` so
+  subtree watchers don't immediately re-hide. Spec
+  [0002](./0002-rule-engine.md), FR-16, FR-17.
+- **NFR-U-2. Visible chips for human-targeted asymmetries.**
+  `link-spoof-annotate` and `trust-badge-annotate` render visible chips because
+  the threat model includes the sighted human acting on rendered glyphs. Spec
+  [0007](./0007-visual-identity-and-trust.md).
+- **NFR-U-3. Screen-reader-only landmarks for agent-targeted asymmetries.**
+  `roach-motel-annotate`, `webdriver-probe-annotate`,
+  `closed-shadow-root-annotate`, and `search-url-helper` surface in the
+  accessibility tree without affecting the rendered layout. Spec
+  [0005](./0005-dark-pattern-defense.md),
+  [0008](./0008-cross-origin-and-shadow-dom.md),
+  [0009](./0009-agent-shortcuts.md).
+- **NFR-U-4. Per-rule preferences survive enforcement-off.** The master
+  enforcement kill-switch pauses every rule without losing per-rule selections.
+  Spec [0010](./0010-extension-ui-and-controls.md), FR-5.
+
+## Maintainability
+
+- **NFR-M-1. `lib/` ↔ `rules/` import boundary.** Files under
+  `extension/src/rules/` may import from `extension/src/lib/`, but `lib/` files
+  may not import from `rules/`. Enforced by ESLint. See
+  [ADR-0005](../decisions/0005-lib-rules-import-boundary.md).
+- **NFR-M-2. Rule defaults are hand-edited in one file.** Adding a rule is one
+  entry in `extension/src/rules/rule-metadata.ts` and one in
+  `extension/src/rules/index.ts`. The
+  `extension/src/rules/__tests__/catalog.test.ts` invariant suite catches drift.
+  See [ADR-0009](../decisions/0009-rule-defaults-and-build-time-overrides.md).
+- **NFR-M-3. Site data lives in YAML, not inline.** Per-host selectors and URL
+  recipes live in `extension/data/sites/*.yaml`, validated against the zod
+  schema at `extension/data/site-rules.schema.ts`, and emitted into
+  `extension/src/rules/site-data.generated.ts`. The generated file is committed;
+  rules import the TS.
+- **NFR-M-4. Property tests for new rule matchers.** New rules ship with a
+  `.property.test.ts` alongside the example test, using `fast-check`. Already a
+  dep; pattern visible in `extension/src/rules/__tests__/*.property.test.ts`.
+- **NFR-M-5. Docs reflect current behavior only.** User-facing docs describe
+  shipped rules and behavior; planned rules, roadmap items, and aspirational
+  behavior live in issues — not in `docs/src/content/docs/`. (Specs explicitly
+  do call out future work in a dedicated section, with each item tied to an
+  issue or ADR.)
+- **NFR-M-6. Skills stay in lockstep with capabilities.** When a rule is added,
+  removed, or renamed, update `skills/agent-browser-shield-config/SKILL.md`.
+  When DOM markers or required agent behavior change, also update
+  `skills/agent-browser-shield/SKILL.md`. When trace bundle layout changes,
+  update `skills/agent-browser-shield-diagnose/SKILL.md`. When the site-rule
+  schema or Playwright MCP setup changes, update
+  `skills/agent-browser-shield-site-rules/SKILL.md`. When build-time inputs in
+  `extension/build.ts` change, update
+  `skills/agent-browser-shield-install/SKILL.md` and
+  `docs/src/content/docs/install.md`. See [`AGENTS.md`](../AGENTS.md) §"Skills".
+
+## Toolchain
+
+- **NFR-T-1. Pre-push parity with CI.** `bun run check` in `extension/` runs
+  Biome + ESLint; this matches what CI runs. (The `lint` alias skips the Biome
+  formatter and does **not** match CI; prefer `check`.)
+- **NFR-T-2. Markdown preflight.** `pre-commit run` runs `mdformat` with the
+  wrap width and table padding the CI Pre-commit hooks job expects.
+  `bun run check` does not cover markdown.
+- **NFR-T-3. Biome + ESLint split.** Biome owns formatting plus its recommended
+  rule set; ESLint runs only rules Biome doesn't have. The split is mechanical —
+  rules are never duplicated between them. Custom project-specific rules live in
+  `extension/eslint-rules/*.js`. See
+  [ADR-0012](../decisions/0012-biome-plus-eslint-split.md).
+- **NFR-T-4. CalVer release via `workflow_dispatch`.** Releases follow CalVer
+  and are cut from a GitHub Actions `workflow_dispatch` job. See
+  [ADR-0015](../decisions/0015-calver-workflow-driven-release.md).
+
+## Future work
+
+- A budget-style CI check that flags PRs whose bundled extension size grew
+  beyond a threshold — not implemented today; the EasyList snapshot is the
+  largest contributor and is gated only by manual refresh cadence.
+- A canary for `chrome.storage` schema migrations — today, the `normalize`
+  function in `extension/src/lib/storage.ts` silently drops unknown keys. An
+  additive-only invariant is not enforced.
+
+## Related
+
+- ADRs: every accepted ADR backs at least one NFR here; see the inline
+  citations.
+- Docs: [`AGENTS.md`](../AGENTS.md), [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+- Specs: every other spec inherits the bars in this file unless it explicitly
+  weakens one.

--- a/specs/0014-non-functional-requirements.md
+++ b/specs/0014-non-functional-requirements.md
@@ -11,6 +11,17 @@ Cross-cutting quality bars that apply across the system. Capability-specific
 NFRs live in their own specs; this one names the standing requirements every
 spec inherits unless explicitly weakened.
 
+## Problem
+
+Quality bars that span the whole system — performance, privacy, observability,
+maintainability — drift fast when each capability's spec restates them in its
+own words. One spec relaxes the `document_idle` deadline because "it's a quick
+walk anyway," another adopts its own MutationObserver to "keep things simple,"
+and a third loosens the no-telemetry posture for a "small debug ping." A single
+cross-cutting spec is the source of truth other specs cite — "I inherit the
+rule-engine perf bar at NFR-P-1" — so when a bar tightens or loosens, one file
+changes and every capability inherits the change with one review pass.
+
 This spec has no user stories — non-functional bars are not user-facing
 behavior. They constrain how every functional requirement must be met.
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -8,12 +8,17 @@ called out under **Future work**.
 
 Specs are distinct from [Architecture Decision Records](../decisions/README.md):
 
-| Specs (this directory)                         | ADRs (`decisions/`)                                |
-| ---------------------------------------------- | -------------------------------------------------- |
-| **What** the system does today                 | **Why** we chose a particular path                 |
-| Updated as behavior changes                    | Immutable once accepted (or marked superseded)     |
-| User stories + acceptance criteria             | Context, drivers, considered options, consequences |
-| Forward-pointing: "future work" calls out gaps | Backward-looking: cites PRs, issues, doc passages  |
+| Specs (this directory)                               | ADRs (`decisions/`)                                |
+| ---------------------------------------------------- | -------------------------------------------------- |
+| **What** the system does and **why each one exists** | **Why** we chose a particular implementation path  |
+| Updated as behavior changes                          | Immutable once accepted (or marked superseded)     |
+| Problem + user stories + acceptance criteria         | Context, drivers, considered options, consequences |
+| Forward-pointing: "future work" calls out gaps       | Backward-looking: cites PRs, issues, doc passages  |
+
+Both kinds of doc carry a "why" — specs name the **product** why (the problem
+solved), ADRs name the **implementation** why (the path chosen). A spec
+shouldn't litigate alternative architectures; an ADR shouldn't restate the
+problem at user-story granularity.
 
 When a spec changes, check whether the change implies a new decision worth
 recording as an ADR.
@@ -59,22 +64,25 @@ A spec carries one of:
 
 Every spec follows the template at [`_template.md`](./_template.md):
 
-1. **Purpose** — one paragraph: what this spec is about and why it exists.
-2. **User stories** — separated into **Human users** and **AI agents** (the two
+1. **Purpose** — one paragraph: what this capability is and where it sits.
+2. **Problem** — the harm, friction, or risk this capability addresses. Phrased
+   so a reader can answer "what would go wrong without it?" The **product** why;
+   implementation choices belong in an ADR.
+3. **User stories** — separated into **Human users** and **AI agents** (the two
    reader classes the extension serves). Stories follow
    `As a … I want … so that …`.
-3. **Functional requirements** — numbered acceptance criteria. Each is a
+4. **Functional requirements** — numbered acceptance criteria. Each is a
    verifiable statement about current behavior (FR-1, FR-2, …).
-4. **Non-functional requirements** — qualities the capability holds itself to
+5. **Non-functional requirements** — qualities the capability holds itself to
    (NFR-P/S/O/U/M for performance, security, observability, usability,
    maintainability). Defer to [0014](./0014-non-functional-requirements.md) for
    cross-cutting bars.
-5. **Current implementation** — file pointers into the repo that back each
+6. **Current implementation** — file pointers into the repo that back each
    requirement.
-6. **Future work** — concrete gaps in current behavior, each tied to a tracking
+7. **Future work** — concrete gaps in current behavior, each tied to a tracking
    issue or a documented decision to defer. **No aspirational features without a
    tracking link.**
-7. **Related** — links to ADRs, docs, and other specs.
+8. **Related** — links to ADRs, docs, and other specs.
 
 ### Citation discipline
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,109 @@
+# Specifications
+
+This directory holds the **golden specs** for `agent-browser-shield` — living
+descriptions of what the system does today. They are organized by capability
+area and kept in lockstep with the shipped behavior: every functional
+requirement here is backed by code, tests, or user-facing docs; every gap is
+called out under **Future work**.
+
+Specs are distinct from [Architecture Decision Records](../decisions/README.md):
+
+| Specs (this directory)                         | ADRs (`decisions/`)                                |
+| ---------------------------------------------- | -------------------------------------------------- |
+| **What** the system does today                 | **Why** we chose a particular path                 |
+| Updated as behavior changes                    | Immutable once accepted (or marked superseded)     |
+| User stories + acceptance criteria             | Context, drivers, considered options, consequences |
+| Forward-pointing: "future work" calls out gaps | Backward-looking: cites PRs, issues, doc passages  |
+
+When a spec changes, check whether the change implies a new decision worth
+recording as an ADR.
+
+## Index
+
+| #                                             | Title                                  | Status  |
+| --------------------------------------------- | -------------------------------------- | ------- |
+| [0001](./0001-extension-distribution.md)      | Extension distribution                 | Current |
+| [0002](./0002-rule-engine.md)                 | Rule engine                            | Current |
+| [0003](./0003-prompt-injection-defense.md)    | Prompt-injection defense               | Current |
+| [0004](./0004-sensitive-data-masking.md)      | Sensitive-data masking                 | Current |
+| [0005](./0005-dark-pattern-defense.md)        | Dark-pattern defense                   | Current |
+| [0006](./0006-context-pollution-reduction.md) | Context-pollution reduction            | Current |
+| [0007](./0007-visual-identity-and-trust.md)   | Visual identity and trust verification | Current |
+| [0008](./0008-cross-origin-and-shadow-dom.md) | Cross-origin and shadow-DOM coverage   | Current |
+| [0009](./0009-agent-shortcuts.md)             | Agent shortcuts                        | Current |
+| [0010](./0010-extension-ui-and-controls.md)   | Extension UI and controls              | Current |
+| [0011](./0011-build-time-customization.md)    | Build-time customization               | Current |
+| [0012](./0012-debug-trace.md)                 | Debug trace                            | Current |
+| [0013](./0013-privacy-and-egress.md)          | Privacy and network egress             | Current |
+| [0014](./0014-non-functional-requirements.md) | Non-functional requirements            | Current |
+
+## Conventions
+
+### File naming
+
+`NNNN-kebab-case-title.md`. Numbers are stable; new specs append at the end of
+the index.
+
+### Status
+
+A spec carries one of:
+
+- **Current** — describes the shipped behavior. Default.
+- **Draft** — proposed capability not yet shipped. Use sparingly; prefer
+  recording the proposal as an issue and adding the spec on merge.
+- **Superseded by spec-NNNN** — split, merged, or replaced.
+- **Deprecated** — capability still present but planned for removal; pairs with
+  a future-work entry pointing at the tracking issue.
+
+### Section order
+
+Every spec follows the template at [`_template.md`](./_template.md):
+
+1. **Purpose** — one paragraph: what this spec is about and why it exists.
+2. **User stories** — separated into **Human users** and **AI agents** (the two
+   reader classes the extension serves). Stories follow
+   `As a … I want … so that …`.
+3. **Functional requirements** — numbered acceptance criteria. Each is a
+   verifiable statement about current behavior (FR-1, FR-2, …).
+4. **Non-functional requirements** — qualities the capability holds itself to
+   (NFR-P/S/O/U/M for performance, security, observability, usability,
+   maintainability). Defer to [0014](./0014-non-functional-requirements.md) for
+   cross-cutting bars.
+5. **Current implementation** — file pointers into the repo that back each
+   requirement.
+6. **Future work** — concrete gaps in current behavior, each tied to a tracking
+   issue or a documented decision to defer. **No aspirational features without a
+   tracking link.**
+7. **Related** — links to ADRs, docs, and other specs.
+
+### Citation discipline
+
+Every functional requirement must be traceable to **one of**:
+
+- a file in the repo (rule module, library file, schema),
+- a test in `extension/src/**/__tests__/`,
+- a passage in `docs/src/content/docs/**.md` or the README/AGENTS.md.
+
+If none of those back a claim, the claim does not belong in a spec — file an
+issue first.
+
+### User-story discipline
+
+The "AI agent" story isn't a polite second copy of the human story. It names
+**what an agent reading the page or accessibility tree gets** that it wouldn't
+get without this capability — fewer poisoned tokens, a placeholder it can act
+on, a landmark surfacing a known blind spot, etc. If the agent story collapses
+to "an agent benefits the same way a human does," the capability is probably
+agent-incidental and doesn't need its own story.
+
+### Future-work discipline
+
+A bullet under **Future work** must either:
+
+- link to a GitHub issue with the work scoped (e.g.
+  [#121](https://github.com/pixiebrix/agent-browser-shield/issues/121) for
+  `form-prefill-annotate` enhancements), or
+- cite an ADR section that records the deliberate scope cut (e.g. closed shadow
+  roots in [ADR-0008](../decisions/0008-shadow-dom-coverage.md)).
+
+This keeps the section from drifting into vague roadmap material.

--- a/specs/_template.md
+++ b/specs/_template.md
@@ -1,0 +1,70 @@
+---
+status: Current
+last_reviewed: YYYY-MM-DD
+---
+
+# {Capability name}
+
+## Purpose
+
+One paragraph. What this capability is, who it serves, and where it sits in the
+overall threat model or value proposition. No marketing copy — name the concrete
+user surface (a rule group, a UI control, a build flag).
+
+## User stories
+
+### Human users
+
+- As a **person installing the extension on my own browser**, I want …, so that
+  ….
+- As a **person tuning the extension for my workflow**, I want …, so that ….
+
+### AI agents
+
+- As a **browser-use agent reading the page**, I want …, so that ….
+- As a **browser-use agent acting on the page**, I want …, so that ….
+
+Drop a class of story if it doesn't apply (e.g. a build-time-only capability has
+no agent-runtime story).
+
+## Functional requirements
+
+- **FR-1.** {testable statement of current behavior}.
+- **FR-2.** {…}.
+
+Each FR is a single verifiable claim. When the claim depends on a list (covered
+hosts, blocked attributes, etc.), reference the source-of-truth file instead of
+duplicating the list inline.
+
+## Non-functional requirements
+
+Cite the cross-cutting bars in [0014](./0014-non-functional-requirements.md)
+where applicable; only list capability-specific ones here.
+
+- **NFR-P-1.** Performance: ….
+- **NFR-S-1.** Security: ….
+- **NFR-O-1.** Observability: ….
+- **NFR-U-1.** Usability: ….
+- **NFR-M-1.** Maintainability: ….
+
+## Current implementation
+
+Point each FR at the file(s) and test(s) that back it. Avoid restating the
+behavior — just name the location.
+
+- FR-1: `extension/src/…`, tested in `extension/src/…/__tests__/…`.
+- FR-2: ….
+
+## Future work
+
+Bullets only. Each one links to an issue or cites an ADR that records the
+deliberate deferral.
+
+- {gap} — [#NNN](https://github.com/pixiebrix/agent-browser-shield/issues/NNN).
+- {scope cut} — see [ADR-NNNN](../decisions/NNNN-%E2%80%A6.md) §"…".
+
+## Related
+
+- ADRs: [ADR-NNNN](../decisions/NNNN-%E2%80%A6.md).
+- Docs: [`docs/src/content/docs/…`](../docs/src/content/docs/%E2%80%A6).
+- Specs: [NNNN](./NNNN-%E2%80%A6.md).

--- a/specs/_template.md
+++ b/specs/_template.md
@@ -11,6 +11,13 @@ One paragraph. What this capability is, who it serves, and where it sits in the
 overall threat model or value proposition. No marketing copy — name the concrete
 user surface (a rule group, a UI control, a build flag).
 
+## Problem
+
+One paragraph (or 2–4 bullets). The harm, friction, or risk this capability
+exists to address — phrased so a reader can answer "what would go wrong without
+it?" Architectural rationale ("why we chose React over Lit") belongs in an ADR,
+not here; this section is the **product** why, not the **implementation** why.
+
 ## User stories
 
 ### Human users


### PR DESCRIPTION
## Summary

- Backfill 14 golden specs (plus `README.md` and `_template.md`) under a new top-level `specs/` directory describing what the system does today. Paired with the existing `decisions/` ADRs that explain *why we chose a particular implementation path*.
- Each spec follows a fixed shape: **Purpose**, **Problem** (the product why — what would go wrong without this capability), **User stories** (human + AI agent), numbered **Functional requirements** (FR-N), **Non-functional requirements** (NFR-P/S/O/U/M-N), **Current implementation** with file pointers into the repo, **Future work** tied to a tracking issue or ADR, and **Related** cross-links.
- Citation discipline mirrors the ADR backfill: every FR is grounded in code, tests, or user-facing docs; future-work bullets either link to a GitHub issue or cite an ADR's scope-cut.

### Specs added

| #    | Title                                  |
| ---- | -------------------------------------- |
| 0001 | Extension distribution                 |
| 0002 | Rule engine                            |
| 0003 | Prompt-injection defense               |
| 0004 | Sensitive-data masking                 |
| 0005 | Dark-pattern defense                   |
| 0006 | Context-pollution reduction            |
| 0007 | Visual identity and trust verification |
| 0008 | Cross-origin and shadow-DOM coverage   |
| 0009 | Agent shortcuts                        |
| 0010 | Extension UI and controls              |
| 0011 | Build-time customization               |
| 0012 | Debug trace                            |
| 0013 | Privacy and network egress             |
| 0014 | Non-functional requirements            |

### Notes for review

- Both kinds of doc carry a "why" — **specs name the product why** (the problem each capability exists to solve), **ADRs name the implementation why** (the path chosen over alternatives). `specs/README.md` documents the split.
- Specs are forward-pointing: future-work calls out gaps and points at tracking issues or ADR scope-cuts. ADRs remain immutable historical records.
- The agent-side user stories are intentionally distinct from the human-side ones: they name what an agent reading the page or accessibility tree gets, not a polite copy of the human story.
- No `docs/`, `extension/`, `decisions/`, or `skills/` files are touched — this PR is doc-only and adds one new top-level directory.

## Test plan

- [ ] Skim `specs/README.md` to confirm the index, status legend, spec-vs-ADR table, and citation rules read cleanly.
- [ ] Spot-check 2–3 specs against the cited code (e.g. 0002 FR-1 ↔ \`extension/src/rules/types.ts\`; 0011 FR-3 ↔ \`extension/data/defaults-overrides.example.json\`; 0013 FR-2 ↔ \`extension/src/lib/llm-client.ts\` / \`extension/src/lib/api-key-storage.ts\`) to confirm grounding holds.
- [ ] Read 2–3 **Problem** sections (e.g. 0003 prompt-injection, 0006 context pollution, 0013 privacy) to confirm they capture the user/agent harm the capability is solving, distinct from architecture choices.
- [ ] Verify \`pre-commit run --files specs/*.md specs/README.md\` is clean locally (it was at commit time — mdformat reflowed paragraph wrap widths only).
- [ ] CI Pre-commit hooks job passes on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)