### PR TITLE
Fix: disguised-ad-flag skips single card with content wrapper (#228 follow-up)

### DIFF
--- a/extension/src/rules/__tests__/disguised-ad-flag.property.test.ts
+++ b/extension/src/rules/__tests__/disguised-ad-flag.property.test.ts
@@ -119,6 +119,52 @@ describe("disguisedAdFlagRule feed-wrapper invariants (property)", () => {
     );
   });
 
+  it("a single card with N stacked wrapper divs is always hidden", () => {
+    // Regression for the follow-up to #228: stacking wrapper divs
+    // between the label and the heading+image+link content must not
+    // cause the rule to skip the card. The multi-card guard counts
+    // only outermost qualifying subtrees, so nested wrappers collapse
+    // to one and the card matches.
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 5 }),
+        fc.constantFrom(...LABEL_PHRASES),
+        (wrapperDepth, labelText) => {
+          document.body.innerHTML = "";
+          const card = document.createElement("article");
+          card.dataset.fixture = "card";
+          const label = document.createElement("span");
+          label.className = "label";
+          label.textContent = labelText;
+          card.append(label);
+          let cursor: HTMLElement = card;
+          for (let i = 0; i < wrapperDepth; i++) {
+            const wrapper = document.createElement("div");
+            wrapper.className = `wrapper-${i}`;
+            cursor.append(wrapper);
+            cursor = wrapper;
+          }
+          cursor.innerHTML = `
+            <h2><a href="/x">Title</a></h2>
+            <img alt="" src="/x.jpg" />
+            <p>Body copy that exceeds the eighty-character prose minimum the disguised-ad-flag rule applies to article-shape candidates.</p>
+          `;
+          document.body.append(card);
+
+          disguisedAdFlagRule.apply(document.body);
+
+          expect(document.querySelector('[data-fixture="card"]')).toBeNull();
+          expect(
+            document.querySelectorAll(`.${PLACEHOLDER_CLASS}`),
+          ).toHaveLength(1);
+
+          disguisedAdFlagRule.teardown();
+        },
+      ),
+      { numRuns: 30 },
+    );
+  });
+
   it("a role='feed' wrapper is never crossed by the walk-up", () => {
     fc.assert(
       fc.property(

--- a/extension/src/rules/__tests__/disguised-ad-flag.test.ts
+++ b/extension/src/rules/__tests__/disguised-ad-flag.test.ts
@@ -181,6 +181,29 @@ describe("disguisedAdFlagRule positive cases", () => {
     expect(document.querySelector('[data-fixture="editorial"]')).not.toBeNull();
   });
 
+  it("hides a single card whose content sits inside a wrapper div", () => {
+    // Regression for the follow-up to #228: with the original
+    // `hasOtherCardSubtree` guard, any descendant outside the label's
+    // chain with both an `<img>` and an `<a href>` made the rule reject
+    // the card. A common card layout puts the label as a sibling to a
+    // single content wrapper that holds the heading + image + link,
+    // which would trip that guard. The card must still be hidden.
+    document.body.innerHTML = `
+      <article class="post" data-fixture="wrapped-card">
+        <span class="label">Sponsored</span>
+        <div class="card-body">
+          <h2><a href="/ad">Acme energy drinks are the future of hydration</a></h2>
+          <img src="hero.jpg" alt="" />
+          <p>A long-form look at how Acme reformulated its flagship beverage to taste less metallic while keeping the same caffeine load and electrolyte balance.</p>
+        </div>
+      </article>
+    `;
+    disguisedAdFlagRule.apply(document.body);
+
+    expect(document.querySelector('[data-fixture="wrapped-card"]')).toBeNull();
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).not.toBeNull();
+  });
+
   it("dedupes when a card carries both a badge and a 'Paid for' caption", () => {
     document.body.innerHTML = `
       <article class="post" data-fixture="dual-label">

--- a/extension/src/rules/disguised-ad-flag.ts
+++ b/extension/src/rules/disguised-ad-flag.ts
@@ -212,23 +212,31 @@ function isPageBoundary(element: Element): boolean {
 const HEADING_SELECTOR =
   'h1, h2, h3, h4, h5, h6, [role="heading"], [class~="headline"]';
 
-// True if `element` contains a *sibling* card-shaped subtree — a
-// descendant outside `labelElement`'s ancestor chain that itself
-// carries both an image and an outgoing link. Used as the feed-wrapper
-// guard inside `isArticleShaped`: a single advertorial card has at
-// most one such subtree (its own); a feed wraps many. The image+link
-// pair is the cheapest stable signal for "card-ness" — every card-
-// shaped feed item in the wild carries a thumbnail and a click target,
-// and the pair is rare in non-card chrome.
-function hasOtherCardSubtree(element: Element, labelElement: Element): boolean {
+// True if `element` encloses two or more card-shaped subtrees — each
+// carrying both an image and an outgoing link. Used as the feed-
+// wrapper guard inside `isArticleShaped`: a single advertorial card
+// can legitimately stack wrapper `<div>`s between its label and its
+// content (one of which carries img+link), so any one such subtree
+// inside the candidate isn't enough to call it a wrapper. Two
+// non-overlapping subtrees — the label's own card boundary plus a
+// sibling card — is.
+//
+// Counts *outermost* qualifying subtrees: a nested wrapper inside an
+// already-counted candidate doesn't bump the count again, so
+// `<div><div><h2>` doesn't trip the guard by itself. The label's own
+// containing chain *is* counted: a feed wrapper where the label's
+// card is structurally complete still trips at count >= 2 because
+// the label's card plus a sibling card are two outermost subtrees.
+function hasMultipleCardSubtrees(
+  element: Element,
+  labelElement: Element,
+): boolean {
+  const matches: Element[] = [];
   for (const candidate of element.querySelectorAll("*")) {
     if (candidate === labelElement) {
       continue;
     }
     if (labelElement.contains(candidate)) {
-      continue;
-    }
-    if (candidate.contains(labelElement)) {
       continue;
     }
     if (candidate.querySelector("img, picture") === null) {
@@ -237,7 +245,13 @@ function hasOtherCardSubtree(element: Element, labelElement: Element): boolean {
     if (candidate.querySelector("a[href]") === null) {
       continue;
     }
-    return true;
+    if (matches.some((m) => m.contains(candidate))) {
+      continue;
+    }
+    matches.push(candidate);
+    if (matches.length >= 2) {
+      return true;
+    }
   }
   return false;
 }
@@ -246,20 +260,21 @@ function hasOtherCardSubtree(element: Element, labelElement: Element): boolean {
 // plus at least one of an image or an outgoing link, plus enough prose
 // text to be confusable with editorial. The label text itself and
 // headings are excluded from the prose count so a label-only row
-// doesn't qualify. The candidate must also not enclose a *second*
-// card-shaped subtree (see #228: when one ad post momentarily lacks
+// doesn't qualify. The candidate must also not enclose two or more
+// card-shaped subtrees (see #228: when one ad post momentarily lacks
 // its own heading — different ad creative, mid-hydration — the walk
 // reaches the surrounding feed; pre-guard the feed passed every check
 // because *sibling* cards carry headings/images/links, and the entire
-// feed got replaced with one placeholder). The sibling-card guard lets
+// feed got replaced with one placeholder). The multi-card guard lets
 // each card match on its own walk-up while keeping the feed wrapper
-// unmatched.
+// unmatched, and tolerates a single card whose content sits inside a
+// wrapper `<div>` (label as a sibling to one card-shaped subtree).
 function isArticleShaped(element: Element, labelElement: Element): boolean {
   const heading = element.querySelector(HEADING_SELECTOR);
   if (heading === null) {
     return false;
   }
-  if (hasOtherCardSubtree(element, labelElement)) {
+  if (hasMultipleCardSubtrees(element, labelElement)) {
     return false;
   }
   const hasImage = element.querySelector("img, picture") !== null;


### PR DESCRIPTION
## Summary

Follow-up to #230 (review feedback from Unblocked bot).

PR #230's `hasOtherCardSubtree` guard rejected any candidate enclosing a descendant outside the label's chain that carried both an image and an outgoing link. A common card layout — label as a sibling to a single content wrapper that holds heading + image + link — tripped the guard, and the legitimate ad card escaped detection entirely.

```html
<article>
  <span class="label">Sponsored</span>
  <div class="card-body">
    <h2><a href="/ad">Title</a></h2>
    <img src="ad.jpg" />
    <p>Long body text…</p>
  </div>
</article>
```

`div.card-body` is not the label, not contained by the label, and does not contain the label. It has both an `<img>` and an `<a href>` descendant → the pre-fix guard returned `true` → `isArticleShaped` returned `false` → the card was not hidden.

## Fix

Rename `hasOtherCardSubtree` → `hasMultipleCardSubtrees` and require **two or more** outermost non-overlapping qualifying subtrees before rejecting. The label's own containing chain *does* count toward the total (the `candidate.contains(labelElement)` skip is dropped), so a feed wrapper still trips at >= 2 (label's card + sibling cards), while a single card with one (or several stacked) content wrappers collapses to 1.

## Verifying #228 still holds

- Reddit `<shreddit-feed>` with 3 ad-post cards, one momentarily headless: walking from the headless card's label reaches the feed; the feed encloses 3 outermost card subtrees (each card has img+a) → count >= 2 → feed wrapper is rejected, individual headed cards still match on their own walk-up.
- 2-card feed with one headless: 2 outermost card subtrees → count = 2 → feed rejected.

## Test plan

- [x] `bun run check` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run knip` — clean
- [x] `./node_modules/.bin/jest` — 1918 tests passing, including:
  - new `hides a single card whose content sits inside a wrapper div` regression test in `disguised-ad-flag.test.ts`
  - new fast-check property in `disguised-ad-flag.property.test.ts` asserting that a single card with N stacked wrapper divs is always hidden (N ∈ [1, 5])
- [ ] Manual on `reddit.com` with the unpacked extension after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)