### PR TITLE
Add: per-site enforcement denylist authored from the popup (ADR-0018)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ keys:
   human flipping the toggle. Intended for automation builds (CDP, Browserbase).
   The export shape is documented in
   [`extension/data/debug-trace.schema.json`](./extension/data/debug-trace.schema.json).
+- `siteDenylist` (array of URL Pattern strings, default `[]`) — start with these
+  hosts already in the per-site enforcement denylist. When the active tab's
+  top-frame URL matches any entry, every rule is paused on that tab. Each entry
+  must satisfy `new URLPattern(entry)`; the build fails otherwise.
 
 See
 [`extension/data/defaults-overrides.example.json`](./extension/data/defaults-overrides.example.json)

--- a/decisions/0018-per-site-enforcement-denylist.md
+++ b/decisions/0018-per-site-enforcement-denylist.md
@@ -1,0 +1,265 @@
+---
+status: proposed
+date: 2026-06-09
+---
+
+# Per-site enforcement denylist authored from the popup; stored as URL Pattern strings
+
+## Context and Problem Statement
+
+Today the only enforcement scoping a user has is the global on/off toggle
+(`enforcement.ts`, spec 0010 FR-5). When a rule misfires on a specific site —
+breaks layout, hides content the user actually wants, blocks a workflow — the
+choices are:
+
+1. Turn off enforcement globally, lose protection on every other tab.
+2. Turn off the offending rule globally from the Options page, lose its
+   protection on every other site.
+3. Live with the misfire.
+
+Spec 0010 §"Future work" calls out the gap: *"Per-host enable/disable for
+specific rules from the popup — only per-host kill-switches today are baked into
+rule files."* Peer privacy extensions (uBlock Origin, Privacy Badger, Adblock
+Plus, DuckDuckGo Privacy Essentials, Ghostery) all converged on the same
+affordance: a one-click *"disable on this site"* toggle in the toolbar popup.
+None of them ask the user to author a match pattern; the pattern is inferred
+from the active tab's host.
+
+The two open shape questions:
+
+1. **Per-rule on a host, or all rules on a host?** uBO and ABP support per-rule
+   exceptions through their full filter syntax (authored in the dashboard, not
+   the popup); the popup itself is a single toggle. Privacy Badger and DDG skip
+   the per-rule axis entirely.
+2. **Storage syntax — URL Pattern, Chrome match-pattern, or hostname strings?**
+   The codebase already uses the URLPattern API (`urlpattern-polyfill`) inside
+   `lib/checkout-url.ts` and rule-file URL gating, so the same syntax in the
+   denylist keeps one matching primitive across the project.
+
+## Decision Drivers
+
+- The user surface that authors the denylist is the popup, not a config file.
+  Whatever syntax we store has to be derivable from the active tab URL with no
+  user editing on the hot path.
+- Power users will look at the Options page to audit what they've disabled and
+  occasionally edit a pattern (broaden a host wildcard, drop an entry). The
+  syntax must be human-readable when displayed flat.
+- The matching primitive should be the same one rule files already use, so there
+  is one place to learn URL matching for this codebase
+  (`extension/src/lib/checkout-url.ts` already imports `urlpattern-polyfill`).
+- The denylist's effective behaviour must compose cleanly with the existing
+  global enforcement toggle (spec 0002 FR-14): global-off remains the master
+  kill-switch; the denylist is a per-tab refinement evaluated only when global
+  enforcement is on.
+- Per-rule per-host control is **out of scope for this ADR**. Privacy Badger and
+  DDG ship without it; the popup affordance reduces to a single toggle and
+  storage stays one-dimensional. The "per-rule per-host" future work entry in
+  spec 0010 §"Future work" is preserved separately.
+
+## Considered Options
+
+- **A. URL Pattern strings in an array, popup writes `<scheme>://<host>/*`.**
+  Storage: `string[]`. Popup *"Disable on this site"* reads the active tab's
+  `URL`, writes the scheme-and-host pattern, and adds it to the array.
+  *"Re-enable on this site"* removes every pattern in the array that matches the
+  active URL.
+- **B. Chrome match patterns (`*://*.example.com/*`).** Same array shape, but
+  the matcher is the manifest match-pattern grammar (scheme wildcard built in).
+  Different syntax from rule files.
+- **C. Hostname strings only (`mail.google.com`).** Simplest authoring; cannot
+  scope by scheme or path. eTLD+1 vs full hostname becomes an extra question.
+- **D. Per-rule per-host map** — `Record<RuleId, string[]>` of patterns per
+  rule. Subsumes A but multiplies UI complexity in both popup and Options page.
+
+## Decision Outcome
+
+Chosen option: **A — URL Pattern strings in an array, popup writes
+`<scheme>://<host>/*`**.
+
+- Storage shape: `string[]`, persisted under
+  `agent-browser-shield.site-denylist` in `chrome.storage.local`. Each string is
+  a URL Pattern string accepted by `new URLPattern(string)`.
+- Popup affordance: *"Disable on this site"* button writes
+  `` `${activeUrl.protocol}//${activeUrl.host}/*` `` to the array — preserving
+  scheme and the host as it appears in the URL bar (no eTLD+1 inference, no port
+  stripping). Authoring is a single click; the resulting pattern is
+  human-readable in the Options-page list.
+- Re-enable affordance: when one or more patterns in the denylist match the
+  active tab's top-frame URL, the popup shows *"Re-enable on this site"*.
+  Clicking it removes **every** pattern from the array whose `URLPattern.test`
+  returns true for the active URL. The intent of the click is "I want rules to
+  run here"; partial removal would not achieve that. The full list remains
+  visible on the Options page for users who want finer control.
+- Effective enforcement is computed per tab as:
+  `globalEnforcement && !matchesAnyDenylistPattern(topFrameUrl)`. Global
+  enforcement (spec 0002 FR-14) remains the master kill-switch; toggling it off
+  pauses every tab regardless of the denylist. Toggling it back on restores both
+  the per-rule selection and any denylist scoping.
+- Matching is evaluated against the **top-frame** URL only. Subframes inherit
+  the tab's enforcement state from the background, so a denylisted top-frame
+  pauses every frame in the tab. Frame-by-frame matching would create surprising
+  splits (e.g., a cross-origin iframe escaping a top-frame denylist) that don't
+  match the user's "this site" mental model.
+- Validation: invalid patterns are dropped on read (parsed via
+  `new URLPattern(string)` in a try/catch), mirroring the silent-degrade
+  behaviour of `EXTENSION_DEFAULT_OVERRIDES` (ADR-0009). The popup's add path
+  can never produce an invalid pattern because it composes the string from a
+  parsed `URL`; the only way to get an invalid entry is hand-editing via the
+  export / import round-trip on the Options page, where loud failure is
+  appropriate.
+- The denylist applies **only to URL-scheme tabs** (http/https/file). For
+  `chrome://`, `about:`, `view-source:`, and other non-content tabs the popup
+  affordance is shown disabled with a hint; the content script doesn't run on
+  those pages anyway.
+- Build-time seeding: the build-time overrides file
+  ([spec 0011](../specs/0011-build-time-customization.md) FR-3) gains a reserved
+  `siteDenylist` key whose value is `string[]`. Each entry must parse via
+  `new URLPattern(entry)`; invalid entries fail the build with a path-qualified
+  message (spec 0011 FR-4 — loud-failure path). The validated list is injected
+  through a new `process.env.EXTENSION_DEFAULT_DENYLIST` define, parallel to
+  `EXTENSION_DEFAULT_OVERRIDES`. `site-denylist.ts` reads it at module init and
+  feeds it into `siteDenylistStorage`'s `defaultValue`, so it only affects fresh
+  `chrome.storage` (spec 0011 FR-6); a user with any entries already in their
+  denylist keeps theirs on rebuild. The same `siteDenylist` key round-trips
+  through the Options-page *Export configuration* / *Apply configuration* (spec
+  0010 FR-10b), so a JSON exported from a tuned extension can be fed straight
+  back into the next build.
+- Per-rule per-host control is **not** part of this decision. Adding it later
+  would change the storage shape to either (D) or a sidecar
+  `Record<RuleId, string[]>`; the migration is straightforward (the current
+  single-axis denylist becomes the `__all__` row of the per-rule map) and is not
+  a reason to over-design v1.
+
+### Consequences
+
+- Good, because the popup gets the affordance users expect from privacy
+  extensions: one click to scope an exception to the site they're on, one click
+  to undo it.
+- Good, because the URL Pattern matcher is already in the codebase
+  (`urlpattern-polyfill` in `package.json`, `lib/checkout-url.ts` uses it); no
+  new dependency, no new matching grammar to learn.
+- Good, because the Options-page surface (list of patterns with a remove button
+  each, optional add-by-pattern input for power users) is a straightforward
+  render of `string[]` plus an audit affordance — it surfaces exactly what is
+  enforced, no derived state to reconcile.
+- Good, because the denylist composes orthogonally with the existing global
+  enforcement toggle: global-off still wins, and the per-rule selection
+  preserved by spec 0002 FR-14 is untouched.
+- Neutral, because matching is host-and-scheme specific by default. A user who
+  disables on `https://mail.google.com/*` and then visits
+  `https://docs.google.com` is not covered — the popup will offer *"Disable on
+  this site"* again. This matches uBO's hostname-default; power users who want a
+  wildcard subdomain pattern (`https://*.google.com/*`) can author it in the
+  Options page.
+- Neutral, because the denylist applies to the whole rule set, not per rule. A
+  user with one specific rule misfiring on a site has to either accept the
+  trade-off (silence every rule there) or globally disable just that rule. The
+  per-rule-per-host gap remains as future work; this ADR addresses the
+  common-case "ABS is breaking this site, get it off this site only."
+- Bad, because http vs https are stored as separate entries when the user wants
+  both. The popup defaults to the scheme of the active tab; if the user needs
+  both they author the second entry by visiting the other-scheme URL once or
+  editing the pattern in Options. We chose this over Chrome match-pattern syntax
+  to stay consistent with the rest of the codebase (driver: same matching
+  primitive everywhere).
+- Bad, because re-enable removes *every* matching pattern. A user who has both
+  `https://*.example.com/*` and `https://mail.example.com/*` in the denylist,
+  viewing `https://mail.example.com`, will lose both when they click *"Re-enable
+  on this site"*. The Options-page list mitigates this: the user can see exactly
+  what they had and re-add what they want. The alternative (asking the user to
+  disambiguate) negates the one-click affordance the popup is built around.
+
+### Confirmation
+
+- A new `extension/src/lib/site-denylist.ts` exposes `siteDenylistStorage` (a
+  `chrome-storage-value` of `string[]`) plus `matchesDenylist(url, patterns)`
+  and `addHostPattern(url)` / `removeMatchingPatterns(url)` helpers. The
+  storage's `normalize` drops entries that fail `new URLPattern(entry)` so a
+  corrupted store can't crash consumers.
+- `extension/src/popup/Popup.tsx` gains a *"Disable on this site"* / *"Re-enable
+  on this site"* control that reads the active tab URL, calls `URLPattern` for
+  the current-tab match check, and toggles the storage. The control is disabled
+  (with a hint) on non-URL-scheme tabs.
+- `extension/src/options/Options.tsx` gains a *Sites with enforcement disabled*
+  section listing every pattern with a *Remove* button per entry and an *Add
+  pattern* input that validates against `new URLPattern(input)` before saving.
+- `extension/src/lib/rule-engine.ts` reads its effective enforcement state from
+  a per-tab derived signal (background-computed) instead of directly subscribing
+  to `enforcementStorage`. The background module `extension/src/background.ts`
+  subscribes to both `enforcementStorage` and `siteDenylistStorage`, recomputes
+  per-tab enforcement on `chrome.tabs.onUpdated`, and pushes the per-tab boolean
+  to content scripts via `chrome.tabs.sendMessage` or a per-tab session-storage
+  entry the content scripts subscribe to (implementation choice deferred to PR).
+- A property test (per the project's "include property tests for rule matchers"
+  guideline) exercises `matchesDenylist` against arbitrary URLs and patterns to
+  assert: a pattern derived from a URL via `addHostPattern` always matches that
+  URL; removing every matching pattern leaves no pattern matching the URL.
+- The build-time loader (`extension/scripts/load-default-overrides.ts`)
+  validates `siteDenylist` entries — every entry must parse via
+  `new URLPattern(entry)`; build fails with a path-qualified message otherwise.
+  Tested in `extension/scripts/__tests__/load-default-overrides.test.ts` with a
+  valid list, an invalid-pattern entry, and a non-array value.
+
+## Pros and Cons of the Options
+
+### A. URL Pattern strings, scheme-and-host inferred from active tab (chosen)
+
+- Good, because the matcher is already in the codebase; one matching primitive
+  across rule files, checkout-URL gating, and the denylist.
+- Good, because the storage shape is a flat array — trivially auditable on the
+  Options page, trivially export/importable.
+- Good, because the popup affordance is a single click; the user is never asked
+  to author a pattern.
+- Bad, because scheme-and-host specificity means http/https and
+  subdomain-vs-eTLD+1 expansions require power-user editing in Options.
+
+### B. Chrome match patterns
+
+- Good, because the `*://` scheme wildcard handles http+https in one entry,
+  closer to user intent.
+- Bad, because the codebase has no match-pattern matcher today — every other URL
+  gate uses URLPattern. Introducing a second grammar splits the mental model for
+  rule authors.
+- Bad, because match patterns have well-known asymmetries (`*` matches the whole
+  host, not a label; `*.example.com` doesn't match `example.com`) that generate
+  support questions. URLPattern's behaviour is closer to what users expect.
+
+### C. Hostname strings only
+
+- Good, because authoring is the simplest possible — a string the user can read
+  off the URL bar.
+- Bad, because there's no way to scope by path or scheme. A user who wants ABS
+  off on `example.com/admin` but on everywhere else can't express that even at
+  the Options-page level.
+- Bad, because it diverges from the matching primitive used elsewhere in the
+  codebase, forcing a parallel matcher.
+
+### D. Per-rule per-host map
+
+- Good, because it subsumes the v1 affordance and adds the per-rule axis uBO and
+  ABP support.
+- Bad, because the popup affordance grows from "one toggle" to "one toggle per
+  rule on this site" — a control surface the popup doesn't have room for, and
+  which peer extensions reserve for their full dashboard.
+- Bad, because most user reports of "ABS is breaking this site" want the whole
+  shield off here, not a rule-by-rule audit. Solving the common case first and
+  adding the per-rule axis later as additive future work is the right sequence.
+
+## More Information
+
+- Spec
+  [0010 — Extension UI and controls](../specs/0010-extension-ui-and-controls.md)
+  §"Future work" — the gap this ADR fills.
+- Spec [0002 — Rule engine](../specs/0002-rule-engine.md) FR-14 — the existing
+  global enforcement kill-switch the denylist composes with.
+- ADR-0009 — the build-time override loader's silent-degrade behaviour, which
+  `siteDenylistStorage.normalize` mirrors on read.
+- `extension/src/lib/checkout-url.ts` — existing URLPattern usage in the
+  codebase, demonstrating the matching primitive this ADR adopts.
+- `extension/src/lib/enforcement.ts` — the existing global enforcement storage;
+  the denylist is stored separately so toggling enforcement on/off doesn't churn
+  the denylist listener path (mirrors the same split between enforcement and
+  rule states).
+- Privacy Badger source (`pb-storage.ts`, `disabled-sites`) — the closest
+  peer-extension analogue: per-site list, host-keyed, single toggle in the
+  popup.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -31,6 +31,7 @@ that is not supported by one of those citations.
 | [0015](./0015-calver-workflow-driven-release.md)            | CalVer + `workflow_dispatch`-driven extension release                                         | Accepted                                          |
 | [0016](./0016-eslint-style-per-rule-options-shape.md)       | ESLint-style per-rule build-time options shape                                                | Accepted                                          |
 | [0017](./0017-numeric-thresholds-as-rule-options.md)        | Numeric thresholds exposed as per-sub-rule options                                            | Accepted                                          |
+| [0018](./0018-per-site-enforcement-denylist.md)             | Per-site enforcement denylist authored from the popup; stored as URL Pattern strings          | Proposed                                          |
 
 ## Conventions
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -123,6 +123,19 @@ set of reserved keys is also accepted for non-rule build-time toggles:
   display* section so humans can flip it without rebuilding. Enable for
   deployments on consistently dark UIs.
 
+- `siteDenylist` (array of URL Pattern strings, default `[]`) — start with these
+  hosts already in the per-site enforcement denylist. When the active tab's
+  top-frame URL matches any entry, every rule is paused on that tab; subframes
+  inherit the tab's state. Each entry must satisfy `new URLPattern(entry)` (the
+  build fails otherwise) and accepts the full URL Pattern syntax — including
+  subdomain wildcards (`https://*.example.com/*`) and path scopes
+  (`https://example.com/admin/*`). The same key round-trips through the
+  Options-page *Export configuration* / *Apply configuration* surface so a tuned
+  extension's exported JSON can be fed back into the next build. Users author
+  entries one-click from the toolbar popup ("Disable on this site") and can
+  audit / remove them on the Options page under *Sites with enforcement
+  disabled*.
+
 A handful of rules expose sub-rule options in addition to the plain on/off
 toggle. For those, a rule's value may be an ESLint-style object instead of a
 boolean:

--- a/extension/build.ts
+++ b/extension/build.ts
@@ -112,7 +112,8 @@ async function build(): Promise<void> {
       (overrides.optionsButton === undefined ? 0 : 1) +
       (overrides.runOnInactiveTabs === undefined ? 0 : 1) +
       (overrides.debugTrace === undefined ? 0 : 1) +
-      (overrides.placeholderAdaptivePalette === undefined ? 0 : 1);
+      (overrides.placeholderAdaptivePalette === undefined ? 0 : 1) +
+      (overrides.siteDenylist === undefined ? 0 : 1);
     console.log(
       `Applying ${changed} build-time default override(s) from ${defaultsPath}.`,
     );
@@ -199,6 +200,15 @@ async function build(): Promise<void> {
             ? ""
             : String(overrides.placeholderAdaptivePalette),
         ),
+      // Seed for `siteDenylistStorage`'s `defaultValue`. Encoded as a
+      // JSON-stringified array (then JSON.stringify'd again so the value
+      // lands as a string literal at the substitution site). Empty when
+      // no `siteDenylist` key is present in the overrides file.
+      "process.env.EXTENSION_DEFAULT_DENYLIST": JSON.stringify(
+        overrides.siteDenylist === undefined
+          ? ""
+          : JSON.stringify(overrides.siteDenylist),
+      ),
     },
   });
 

--- a/extension/data/defaults-overrides.example.json
+++ b/extension/data/defaults-overrides.example.json
@@ -15,5 +15,7 @@
   "optionsButton": true,
   "runOnInactiveTabs": false,
   "debugTrace": false,
-  "placeholderAdaptivePalette": false
+  "placeholderAdaptivePalette": false,
+
+  "siteDenylist": ["https://staging.internal.example/*"]
 }

--- a/extension/jest.config.cjs
+++ b/extension/jest.config.cjs
@@ -81,6 +81,7 @@ module.exports = {
     "!src/lib/wait-for-settle.ts",
     "!src/lib/automation-element-reference.ts",
     "!src/lib/enforcement.ts",
+    "!src/lib/effective-enforcement.ts",
     "!src/lib/frame.ts",
     // `webdriver-probe-source.ts` defines `installProbe`, which the rule
     // serializes via `Function.prototype.toString` and ships into the

--- a/extension/scripts/__tests__/load-default-overrides.test.ts
+++ b/extension/scripts/__tests__/load-default-overrides.test.ts
@@ -238,6 +238,71 @@ describe("loadDefaultOverrides", () => {
     );
   });
 
+  describe("siteDenylist reserved key", () => {
+    it("extracts a valid siteDenylist alongside rules", () => {
+      const file = writeFile(
+        "with-denylist.json",
+        JSON.stringify({
+          "pii-redact": true,
+          siteDenylist: ["https://example.test/*", "https://*.mail.test/*"],
+        }),
+      );
+      expect(
+        loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+      ).toEqual({
+        rules: { "pii-redact": true },
+        ruleOptions: {},
+        siteDenylist: ["https://example.test/*", "https://*.mail.test/*"],
+      });
+    });
+
+    it("accepts an empty siteDenylist", () => {
+      const file = writeFile(
+        "empty-denylist.json",
+        JSON.stringify({ siteDenylist: [] }),
+      );
+      expect(
+        loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+      ).toEqual({
+        rules: {},
+        ruleOptions: {},
+        siteDenylist: [],
+      });
+    });
+
+    it("rejects a non-array siteDenylist", () => {
+      const file = writeFile(
+        "non-array-denylist.json",
+        JSON.stringify({ siteDenylist: "https://example.test/*" }),
+      );
+      expect(() =>
+        loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+      ).toThrow(/siteDenylist: .*array/);
+    });
+
+    it("rejects an entry that is not a valid URL Pattern", () => {
+      const file = writeFile(
+        "bad-pattern.json",
+        JSON.stringify({
+          siteDenylist: ["https://example.test/*", "not-a-pattern!!! :::"],
+        }),
+      );
+      expect(() =>
+        loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+      ).toThrow(/siteDenylist\.1: .*URL Pattern/);
+    });
+
+    it("rejects a non-string entry", () => {
+      const file = writeFile(
+        "non-string-entry.json",
+        JSON.stringify({ siteDenylist: [42] }),
+      );
+      expect(() =>
+        loadDefaultOverrides({ path: file, knownRuleIds: KNOWN_IDS }),
+      ).toThrow(/siteDenylist\.0: .*string/);
+    });
+  });
+
   describe("per-rule options (ESLint-style object value)", () => {
     // Fixture covers both leaf shapes the validator now supports: bare
     // boolean (`base64`) and `{ enabled, ...thresholds }` per-sub-rule

--- a/extension/scripts/load-default-overrides.ts
+++ b/extension/scripts/load-default-overrides.ts
@@ -18,6 +18,7 @@
 // failures, not silent drift if a rule was renamed.
 
 import { readFileSync } from "node:fs";
+import { URLPattern } from "urlpattern-polyfill";
 import { z } from "zod";
 
 export interface LoadOverridesOptions {
@@ -42,19 +43,38 @@ export interface DefaultOverrides {
   runOnInactiveTabs?: boolean;
   debugTrace?: boolean;
   placeholderAdaptivePalette?: boolean;
+  // URL Pattern strings the per-site enforcement denylist (ADR-0018) is
+  // seeded with on fresh `chrome.storage`. Each entry must satisfy
+  // `new URLPattern(entry)`; the validator below fails the build loudly on
+  // a bad pattern (spec 0011 FR-4).
+  siteDenylist?: string[];
 }
 
-const RESERVED_KEYS = [
+const BOOLEAN_RESERVED_KEYS = [
   "optionsButton",
   "runOnInactiveTabs",
   "debugTrace",
   "placeholderAdaptivePalette",
 ] as const;
 
+const RESERVED_KEYS = [...BOOLEAN_RESERVED_KEYS, "siteDenylist"] as const;
+
 type ReservedKey = (typeof RESERVED_KEYS)[number];
 
 function isReservedKey(key: string): key is ReservedKey {
   return (RESERVED_KEYS as readonly string[]).includes(key);
+}
+
+// `new URLPattern(entry)` either parses or throws; zod's `.refine` only
+// accepts a predicate, so we wrap the throw in a boolean check here. Used
+// by the schema below for every `siteDenylist` entry.
+function isValidUrlPattern(entry: string): boolean {
+  try {
+    void new URLPattern(entry);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // Builds a zod schema for one position in the option-shape default tree.
@@ -115,9 +135,17 @@ function ruleValueSchema(
 function buildOverridesSchema(options: LoadOverridesOptions): z.ZodType {
   const { knownRuleIds, ruleOptionDefaults = {} } = options;
   const shape: Record<string, z.ZodType> = {};
-  for (const reserved of RESERVED_KEYS) {
+  for (const reserved of BOOLEAN_RESERVED_KEYS) {
     shape[reserved] = z.boolean().optional();
   }
+  shape.siteDenylist = z
+    .array(
+      z.string().refine(isValidUrlPattern, {
+        message:
+          "expected URL Pattern string accepted by new URLPattern(entry)",
+      }),
+    )
+    .optional();
   for (const id of knownRuleIds) {
     shape[id] = ruleValueSchema(
       ruleOptionDefaults[id] as Readonly<Record<string, unknown>> | undefined,
@@ -225,6 +253,10 @@ function splitOverrides(parsed: Record<string, unknown>): DefaultOverrides {
         }
         case "placeholderAdaptivePalette": {
           out.placeholderAdaptivePalette = value as boolean;
+          break;
+        }
+        case "siteDenylist": {
+          out.siteDenylist = value as string[];
           break;
         }
       }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -289,6 +289,19 @@ chrome.runtime.onMessage.addListener(
       return true;
     }
 
+    if (message.type === "get-tab-url") {
+      // Subframe content scripts ask this once at startup so they can
+      // evaluate the per-site denylist (ADR-0018) against the tab's
+      // top-frame URL instead of their own iframe URL. `sender.tab.url`
+      // requires host permission for the URL — we have <all_urls>, so
+      // this is just a property read. Frames inside a tab whose URL the
+      // background can't resolve get `{ url: null }` and the requesting
+      // content script falls back to "URL unknown → fail open."
+      const url = sender.tab?.url ?? null;
+      sendResponse({ url });
+      return undefined;
+    }
+
     if (message.type === "inject-webdriver-probe") {
       const tabId = sender.tab?.id;
       if (typeof tabId !== "number") {

--- a/extension/src/lib/__tests__/rule-engine.test.ts
+++ b/extension/src/lib/__tests__/rule-engine.test.ts
@@ -48,7 +48,6 @@ jest.mock("../frame", () => ({
 
 jest.mock("../effective-enforcement", () => ({
   initEffectiveEnforcement: jest.fn(() => Promise.resolve(true)),
-  getEffectiveEnforcement: jest.fn(() => true),
   subscribeEffectiveEnforcement: jest.fn(() => () => undefined),
 }));
 

--- a/extension/src/lib/__tests__/rule-engine.test.ts
+++ b/extension/src/lib/__tests__/rule-engine.test.ts
@@ -46,10 +46,10 @@ jest.mock("../frame", () => ({
   isTopFrame: jest.fn(),
 }));
 
-jest.mock("../enforcement", () => ({
-  getEnforcementEnabled: jest.fn(() => Promise.resolve(true)),
-  subscribeEnforcementEnabled: jest.fn(() => () => undefined),
-  ENFORCEMENT_ENABLED_DEFAULT: true,
+jest.mock("../effective-enforcement", () => ({
+  initEffectiveEnforcement: jest.fn(() => Promise.resolve(true)),
+  getEffectiveEnforcement: jest.fn(() => true),
+  subscribeEffectiveEnforcement: jest.fn(() => () => undefined),
 }));
 
 // Mock availability so tests can drive availability-flip reconciliation
@@ -76,7 +76,7 @@ import {
   getRuleAvailabilityStates,
   subscribeRuleAvailability,
 } from "../availability";
-import { subscribeEnforcementEnabled } from "../enforcement";
+import { subscribeEffectiveEnforcement } from "../effective-enforcement";
 import { isTopFrame } from "../frame";
 import { revealAll } from "../placeholder";
 import { start } from "../rule-engine";
@@ -91,8 +91,8 @@ const getAvailabilityMock = getRuleAvailabilityStates as jest.MockedFunction<
 >;
 const subscribeStorageMock = subscribe as jest.MockedFunction<typeof subscribe>;
 const subscribeEnforcementMock =
-  subscribeEnforcementEnabled as jest.MockedFunction<
-    typeof subscribeEnforcementEnabled
+  subscribeEffectiveEnforcement as jest.MockedFunction<
+    typeof subscribeEffectiveEnforcement
   >;
 const subscribeAvailabilityMock =
   subscribeRuleAvailability as jest.MockedFunction<

--- a/extension/src/lib/__tests__/site-denylist.property.test.ts
+++ b/extension/src/lib/__tests__/site-denylist.property.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Property tests for the site-denylist matcher round-trip. Two invariants
+// that example tests can't exhaust:
+//   - For any content-scheme URL, the pattern produced by `addHostPattern`
+//     subsequently matches that URL via `matchesDenylist`.
+//   - After `removeMatchingPatterns(url, ...)`, no remaining pattern matches
+//     `url` — even when the input list contained multiple overlapping
+//     entries (host-specific, subdomain wildcard, exact URL).
+
+import fc from "fast-check";
+
+import {
+  addHostPattern,
+  matchesDenylist,
+  removeMatchingPatterns,
+} from "../site-denylist";
+
+// Arbitrary content-scheme URLs the popup might encounter. Hostnames are
+// constrained to ASCII labels so URLPattern's hostname parser sees the
+// same shape browsers produce.
+const arbHost = fc
+  .array(fc.stringMatching(/^[a-z]([a-z0-9-]{0,30}[a-z0-9])?$/), {
+    minLength: 1,
+    maxLength: 3,
+  })
+  .filter((labels) => labels.length > 0)
+  .map((labels) => labels.join("."));
+
+const arbPath = fc
+  .array(fc.stringMatching(/^[a-zA-Z0-9_-]{1,20}$/), { maxLength: 4 })
+  .map((segments) => (segments.length === 0 ? "/" : `/${segments.join("/")}`));
+
+const arbContentUrl = fc
+  .tuple(fc.constantFrom("http:", "https:"), arbHost, arbPath)
+  .map(([scheme, host, path]) => `${scheme}//${host}${path}`);
+
+describe("site-denylist matcher round-trip", () => {
+  it("addHostPattern produces a pattern that subsequently matches the URL", () => {
+    fc.assert(
+      fc.property(arbContentUrl, (url) => {
+        const { patterns, added } = addHostPattern(url, []);
+        expect(added).not.toBeNull();
+        expect(matchesDenylist(url, patterns)).toBe(true);
+      }),
+    );
+  });
+
+  it("removeMatchingPatterns leaves no pattern matching the URL", () => {
+    // Builds a list of patterns guaranteed to include at least one match:
+    // the host pattern from `url`, plus optional additional patterns from
+    // other arbitrary URLs (some of which may also coincidentally match).
+    fc.assert(
+      fc.property(
+        arbContentUrl,
+        fc.array(arbContentUrl, { maxLength: 5 }),
+        (url, others) => {
+          const seedPatterns: string[] = [];
+          for (const other of [url, ...others]) {
+            const { added } = addHostPattern(other, seedPatterns);
+            if (added) {
+              seedPatterns.push(added);
+            }
+          }
+          // Sanity: at least the URL's own host pattern is in there.
+          expect(matchesDenylist(url, seedPatterns)).toBe(true);
+
+          const { patterns } = removeMatchingPatterns(url, seedPatterns);
+          expect(matchesDenylist(url, patterns)).toBe(false);
+        },
+      ),
+    );
+  });
+});

--- a/extension/src/lib/__tests__/site-denylist.test.ts
+++ b/extension/src/lib/__tests__/site-denylist.test.ts
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import {
+  addHostPattern,
+  findMatchingPatterns,
+  hostPatternFor,
+  isContentSchemeUrl,
+  isValidPattern,
+  matchesDenylist,
+  removeMatchingPatterns,
+} from "../site-denylist";
+
+describe("hostPatternFor", () => {
+  it("returns scheme+host+/* for an https URL", () => {
+    expect(hostPatternFor("https://mail.google.com/u/0/inbox")).toBe(
+      "https://mail.google.com/*",
+    );
+  });
+
+  it("preserves the scheme for http", () => {
+    expect(hostPatternFor("http://example.test/path")).toBe(
+      "http://example.test/*",
+    );
+  });
+
+  it("preserves port when present in the host", () => {
+    expect(hostPatternFor("http://localhost:8080/")).toBe(
+      "http://localhost:8080/*",
+    );
+  });
+
+  it("returns null for chrome:// URLs", () => {
+    expect(hostPatternFor("chrome://extensions")).toBeNull();
+  });
+
+  it("returns null for about:blank", () => {
+    expect(hostPatternFor("about:blank")).toBeNull();
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(hostPatternFor("not a url")).toBeNull();
+  });
+});
+
+describe("isContentSchemeUrl", () => {
+  it.each([
+    ["https://example.test/", true],
+    ["http://example.test/", true],
+    ["file:///home/user/file.html", true],
+    ["chrome://flags/", false],
+    ["about:blank", false],
+    ["view-source:https://example.test/", false],
+    ["", false],
+    ["javascript:void(0)", false],
+  ])("isContentSchemeUrl(%s) = %s", (url, expected) => {
+    expect(isContentSchemeUrl(url)).toBe(expected);
+  });
+});
+
+describe("matchesDenylist", () => {
+  it("returns false for an empty pattern list", () => {
+    expect(matchesDenylist("https://example.test/", [])).toBe(false);
+  });
+
+  it("matches a host-scoped pattern", () => {
+    expect(
+      matchesDenylist("https://example.test/anything?x=1", [
+        "https://example.test/*",
+      ]),
+    ).toBe(true);
+  });
+
+  it("differentiates http from https by default", () => {
+    expect(
+      matchesDenylist("http://example.test/foo", ["https://example.test/*"]),
+    ).toBe(false);
+  });
+
+  it("differentiates host vs subdomain", () => {
+    expect(
+      matchesDenylist("https://example.test/", ["https://mail.example.test/*"]),
+    ).toBe(false);
+  });
+
+  it("supports subdomain wildcards in URL Pattern syntax", () => {
+    // URLPattern wildcards apply within a component — `{*.}?example.test`
+    // means "optionally any subdomain". The plain `*` form below is the
+    // typical authored shape from the Options-page add input.
+    expect(
+      matchesDenylist("https://mail.example.test/foo", [
+        "https://*.example.test/*",
+      ]),
+    ).toBe(true);
+  });
+
+  it("ignores invalid patterns instead of throwing", () => {
+    expect(
+      matchesDenylist("https://example.test/", [
+        "not-a-valid-pattern",
+        "https://example.test/*",
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("findMatchingPatterns", () => {
+  it("returns every pattern that matches the URL", () => {
+    const patterns = [
+      "https://mail.example.test/*",
+      "https://*.example.test/*",
+      "https://other.test/*",
+    ];
+    expect(
+      findMatchingPatterns("https://mail.example.test/inbox", patterns),
+    ).toEqual(["https://mail.example.test/*", "https://*.example.test/*"]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(
+      findMatchingPatterns("https://example.test/", ["https://other.test/*"]),
+    ).toEqual([]);
+  });
+});
+
+describe("addHostPattern", () => {
+  it("appends a scheme-host pattern derived from the URL", () => {
+    expect(addHostPattern("https://example.test/foo", [])).toEqual({
+      patterns: ["https://example.test/*"],
+      added: "https://example.test/*",
+    });
+  });
+
+  it("is a no-op when the exact pattern is already present", () => {
+    const result = addHostPattern("https://example.test/foo", [
+      "https://example.test/*",
+    ]);
+    expect(result).toEqual({
+      patterns: ["https://example.test/*"],
+      added: null,
+    });
+  });
+
+  it("returns added: null for non-content scheme URLs", () => {
+    const result = addHostPattern("chrome://extensions", []);
+    expect(result).toEqual({ patterns: [], added: null });
+  });
+
+  it("preserves existing entries", () => {
+    const existing = ["https://other.test/*"];
+    const result = addHostPattern("https://example.test/", existing);
+    expect(result).toEqual({
+      patterns: ["https://other.test/*", "https://example.test/*"],
+      added: "https://example.test/*",
+    });
+    // Pure: caller's array untouched.
+    expect(existing).toEqual(["https://other.test/*"]);
+  });
+});
+
+describe("removeMatchingPatterns", () => {
+  it("removes every pattern that matches the URL", () => {
+    const result = removeMatchingPatterns("https://mail.example.test/inbox", [
+      "https://mail.example.test/*",
+      "https://*.example.test/*",
+      "https://other.test/*",
+    ]);
+    expect(result).toEqual({
+      patterns: ["https://other.test/*"],
+      removed: 2,
+    });
+  });
+
+  it("is a no-op when no pattern matches", () => {
+    const result = removeMatchingPatterns("https://example.test/", [
+      "https://other.test/*",
+    ]);
+    expect(result).toEqual({
+      patterns: ["https://other.test/*"],
+      removed: 0,
+    });
+  });
+
+  it("returns removed: 0 for unparseable URLs", () => {
+    const result = removeMatchingPatterns("not a url", [
+      "https://example.test/*",
+    ]);
+    expect(result).toEqual({
+      patterns: ["https://example.test/*"],
+      removed: 0,
+    });
+  });
+});
+
+describe("isValidPattern", () => {
+  it.each([
+    ["https://example.test/*", true],
+    ["https://*.example.test/*", true],
+    ["https://example.test/foo/:bar", true],
+    ["", false],
+    ["not-a-url-pattern!! :::", false],
+  ])("isValidPattern(%s) = %s", (pattern, expected) => {
+    expect(isValidPattern(pattern)).toBe(expected);
+  });
+});

--- a/extension/src/lib/effective-enforcement.ts
+++ b/extension/src/lib/effective-enforcement.ts
@@ -118,10 +118,6 @@ export async function initEffectiveEnforcement(): Promise<boolean> {
   return lastEffective;
 }
 
-export function getEffectiveEnforcement(): boolean {
-  return lastEffective;
-}
-
 export function subscribeEffectiveEnforcement(
   listener: (enabled: boolean) => void,
 ): () => void {

--- a/extension/src/lib/effective-enforcement.ts
+++ b/extension/src/lib/effective-enforcement.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Composes the global enforcement kill-switch with the per-site denylist
+// (ADR-0018) into a single boolean the rule engine acts on. The rule
+// engine treats this exactly the way it treated raw `enforcementStorage`
+// before — fail-open until init resolves, then the masked rule-state path
+// (`mask` in `rule-engine.ts`) reads from here instead.
+//
+// URL source:
+//   - Top frame uses `globalThis.location.href` at evaluation time, so
+//     SPA route changes within the top frame are picked up the next time
+//     a storage change re-evaluates. (Pure SPA route changes don't
+//     re-evaluate by themselves; this matches how the rest of the engine
+//     handles availability — storage events drive reconciliation.)
+//   - Sub-frames ask the background for the top-frame URL once at init
+//     (`get-tab-url` message). When the background can't be reached, the
+//     fallback is "URL unknown → fail open" — better than silently
+//     pausing rules in iframes whose tab URL we can't read.
+//
+// Subframes deliberately do NOT compute the denylist match against their
+// own URL. The user's mental model when clicking "Disable on this site"
+// in the popup is "disable the shield on this tab"; per ADR-0018, the
+// match is evaluated against the tab's top-frame URL and subframes
+// inherit.
+
+import { enforcementStorage, subscribeEnforcementEnabled } from "./enforcement";
+import { isTopFrame } from "./frame";
+import { matchesDenylist, siteDenylistStorage } from "./site-denylist";
+
+let cachedTopFrameUrl: string | null = null;
+let cachedGlobal = true;
+let cachedDenylist: string[] = [];
+let lastEffective = true;
+const listeners = new Set<(enabled: boolean) => void>();
+
+function readTopFrameUrl(): string | null {
+  // For the top frame, `globalThis.location.href` is always the truth —
+  // and updates in real time across SPA pushState. For a subframe it's
+  // the iframe's own URL, which is the WRONG URL for denylist purposes,
+  // so we fall back to the value cached from the background at init.
+  return isTopFrame() ? globalThis.location.href : cachedTopFrameUrl;
+}
+
+function computeEffective(): boolean {
+  if (!cachedGlobal) {
+    return false;
+  }
+  const url = readTopFrameUrl();
+  if (url === null) {
+    // Unknown subframe top-URL — fail open. Silently pausing rules in a
+    // subframe whose tab URL we can't resolve would surprise the user
+    // more than letting rules run.
+    return true;
+  }
+  return !matchesDenylist(url, cachedDenylist);
+}
+
+function notify(): void {
+  const next = computeEffective();
+  if (next === lastEffective) {
+    return;
+  }
+  lastEffective = next;
+  for (const listener of listeners) {
+    listener(next);
+  }
+}
+
+async function fetchTopFrameUrl(): Promise<string | null> {
+  if (isTopFrame()) {
+    return null;
+  }
+  try {
+    const response: unknown = await chrome.runtime.sendMessage({
+      type: "get-tab-url",
+    });
+    if (
+      response &&
+      typeof response === "object" &&
+      "url" in response &&
+      typeof response.url === "string"
+    ) {
+      return response.url;
+    }
+  } catch {
+    // Background may be asleep / restarting / unreachable. Fall through
+    // to "unknown URL", which `computeEffective` interprets as fail-open.
+  }
+  return null;
+}
+
+// Resolves to the current effective enforcement boolean and installs the
+// underlying storage subscriptions. Idempotent: callers (rule-engine) only
+// call this once, but a second call would re-fetch + re-subscribe without
+// duplicating listeners (storage subscriptions are scoped to AbortControllers
+// held by the chrome-storage-value wrapper).
+export async function initEffectiveEnforcement(): Promise<boolean> {
+  const [global, denylist, topUrl] = await Promise.all([
+    enforcementStorage.get(),
+    siteDenylistStorage.get(),
+    fetchTopFrameUrl(),
+  ]);
+  cachedGlobal = global;
+  cachedDenylist = denylist;
+  cachedTopFrameUrl = topUrl;
+  lastEffective = computeEffective();
+
+  subscribeEnforcementEnabled((next) => {
+    cachedGlobal = next;
+    notify();
+  });
+  siteDenylistStorage.subscribe((next) => {
+    cachedDenylist = next;
+    notify();
+  });
+
+  return lastEffective;
+}
+
+export function getEffectiveEnforcement(): boolean {
+  return lastEffective;
+}
+
+export function subscribeEffectiveEnforcement(
+  listener: (enabled: boolean) => void,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/extension/src/lib/rule-engine.ts
+++ b/extension/src/lib/rule-engine.ts
@@ -11,9 +11,9 @@ import {
 import { initDebugTrace } from "./debug-trace";
 import { PLACEHOLDER_MODE_ATTR, PLACEHOLDER_PALETTE_ATTR } from "./dom-markers";
 import {
-  getEnforcementEnabled,
-  subscribeEnforcementEnabled,
-} from "./enforcement";
+  initEffectiveEnforcement,
+  subscribeEffectiveEnforcement,
+} from "./effective-enforcement";
 import { isTopFrame } from "./frame";
 import { createRuleLogger, log } from "./log";
 import {
@@ -297,7 +297,7 @@ export async function start(): Promise<void> {
     adaptivePaletteInitial,
   ] = await Promise.all([
     getRuleStates(),
-    getEnforcementEnabled(),
+    initEffectiveEnforcement(),
     getRuleAvailabilityStates(),
     placeholderAdaptivePaletteStorage.get(),
     initDebugTrace(),
@@ -337,8 +337,8 @@ export async function start(): Promise<void> {
   subscribe((next) => {
     applyChange(next, enforcementCurrent, availabilityCurrent);
   });
-  subscribeEnforcementEnabled((enabled) => {
-    log.info("enforcement toggle changed", { enabled });
+  subscribeEffectiveEnforcement((enabled) => {
+    log.info("effective enforcement changed", { enabled });
     applyChange(rawCurrent, enabled, availabilityCurrent);
   });
   subscribeRuleAvailability((next) => {

--- a/extension/src/lib/site-denylist.ts
+++ b/extension/src/lib/site-denylist.ts
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Per-site enforcement denylist. Each entry is a URL Pattern string accepted
+// by `new URLPattern(string)`. When the active tab's top-frame URL matches
+// any entry, the rule engine treats this tab as enforcement-off (same code
+// path as the global enforcement kill-switch, scoped to the tab). See
+// ADR-0018 and spec 0010 §"Per-site enforcement denylist".
+//
+// Authoring shape:
+//   - Popup writes `${scheme}//${host}/*` for the active tab on click.
+//   - Options-page list shows every entry with a remove control plus an
+//     add-by-pattern input that validates against `new URLPattern(string)`.
+//   - Build-time overrides file's `siteDenylist` reserved key seeds fresh
+//     `chrome.storage` only; user-edited storage wins on rebuild
+//     (spec 0011 FR-6).
+//
+// The matcher matches against the top-frame URL only. Subframes inherit the
+// tab's effective enforcement from `effective-enforcement.ts` rather than
+// matching their own URL — keeps the user model ("this site") clean even
+// when a denylisted page embeds a cross-origin iframe.
+
+import { URLPattern } from "urlpattern-polyfill";
+import { createChromeStorageValue } from "./chrome-storage-value";
+
+export const SITE_DENYLIST_STORAGE_KEY = "agent-browser-shield.site-denylist";
+
+// Compiles a URL Pattern string. Returns null for any input that doesn't
+// satisfy `new URLPattern(string)`. Callers use the null to drop invalid
+// entries on read; build-time validation is loud (see
+// `scripts/load-default-overrides.ts`).
+function compilePattern(pattern: string): URLPattern | null {
+  try {
+    return new URLPattern(pattern);
+  } catch {
+    return null;
+  }
+}
+
+// Drops non-string entries and entries that don't parse as a URL Pattern.
+// Mirrors the silent-degrade posture of `lib/storage.ts`'s `normalize` and
+// of `EXTENSION_DEFAULT_OVERRIDES` parsing (ADR-0009 + ADR-0018 §"Decision
+// Outcome").
+function normalize(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const result: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry === "string" && compilePattern(entry) !== null) {
+      result.push(entry);
+    }
+  }
+  return result;
+}
+
+// `process.env.EXTENSION_DEFAULT_DENYLIST` is substituted by build.ts when
+// the operator passes a defaults file with a `siteDenylist` array. The
+// build-time loader validates each entry with `new URLPattern(entry)` and
+// fails the build loudly on a bad pattern (spec 0011 FR-4). Here we still
+// normalize defensively — if the substitution ever lands as malformed JSON,
+// degrade to an empty list rather than crash the content script.
+function parseBuildDefault(): string[] {
+  const raw = process.env.EXTENSION_DEFAULT_DENYLIST;
+  if (!raw) {
+    return [];
+  }
+  try {
+    return normalize(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
+const BUILD_DEFAULT: string[] = parseBuildDefault();
+
+export const siteDenylistStorage = createChromeStorageValue<string[]>({
+  key: SITE_DENYLIST_STORAGE_KEY,
+  defaultValue: BUILD_DEFAULT,
+  normalize,
+});
+
+// Tabs the popup can offer a per-site toggle on. The content script doesn't
+// run on `chrome://`, `about:`, `view-source:`, etc., so the affordance
+// would be a no-op on those URLs even if storage accepted a pattern for
+// them. file:// runs the content script when the user has granted access,
+// so we include it.
+export function isContentSchemeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === "http:" ||
+      parsed.protocol === "https:" ||
+      parsed.protocol === "file:"
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Pattern the popup writes when the user clicks "Disable on this site".
+// Preserves the scheme and host as they appear in the URL bar; no eTLD+1
+// inference, no port stripping. Returns null for non-content schemes and
+// unparseable URLs so callers can no-op gracefully.
+export function hostPatternFor(url: string): string | null {
+  if (!isContentSchemeUrl(url)) {
+    return null;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  return `${parsed.protocol}//${parsed.host}/*`;
+}
+
+// True iff at least one pattern in `patterns` matches `url`. Invalid
+// patterns silently no-op (they should already have been filtered by
+// `normalize`; this is belt-and-suspenders).
+export function matchesDenylist(
+  url: string,
+  patterns: readonly string[],
+): boolean {
+  if (!url || patterns.length === 0) {
+    return false;
+  }
+  for (const pattern of patterns) {
+    const compiled = compilePattern(pattern);
+    if (compiled?.test(url) === true) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Returns every pattern in `patterns` that matches `url`. Used by the popup
+// to surface the count of patterns that "Re-enable on this site" would
+// remove (ADR-0018 §"Decision Outcome": removing every matching pattern is
+// the only way to honor the user's intent of "I want rules to run here").
+export function findMatchingPatterns(
+  url: string,
+  patterns: readonly string[],
+): string[] {
+  if (!url || patterns.length === 0) {
+    return [];
+  }
+  const matching: string[] = [];
+  for (const pattern of patterns) {
+    const compiled = compilePattern(pattern);
+    if (compiled?.test(url) === true) {
+      matching.push(pattern);
+    }
+  }
+  return matching;
+}
+
+// Append `hostPatternFor(url)` to `current` unless an identical entry is
+// already present. Returns the next array and the pattern that was added
+// (or null if no pattern was written — non-content scheme, or already
+// present). Pure: caller persists the next array.
+export function addHostPattern(
+  url: string,
+  current: readonly string[],
+): { patterns: string[]; added: string | null } {
+  const pattern = hostPatternFor(url);
+  if (pattern === null) {
+    return { patterns: [...current], added: null };
+  }
+  if (current.includes(pattern)) {
+    return { patterns: [...current], added: null };
+  }
+  return { patterns: [...current, pattern], added: pattern };
+}
+
+// Drop every pattern in `current` whose `URLPattern.test` returns true for
+// `url`. Returns the next array and the number of patterns removed. Pure:
+// caller persists the next array.
+export function removeMatchingPatterns(
+  url: string,
+  current: readonly string[],
+): { patterns: string[]; removed: number } {
+  const matching = findMatchingPatterns(url, current);
+  if (matching.length === 0) {
+    return { patterns: [...current], removed: 0 };
+  }
+  const matchingSet = new Set(matching);
+  return {
+    patterns: current.filter((pattern) => !matchingSet.has(pattern)),
+    removed: matching.length,
+  };
+}
+
+// Predicate the Options-page *Add pattern* input uses to validate the
+// user's string before saving. Exported separately from `compilePattern`
+// so test code can assert it without coupling to the internal nullable
+// shape.
+export function isValidPattern(pattern: string): boolean {
+  return compilePattern(pattern) !== null;
+}

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -221,6 +221,51 @@
         gap: 8px;
         align-items: center;
       }
+      .site-denylist__list {
+        list-style: none;
+        margin: 0 0 12px;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .site-denylist__row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 10px;
+        background: #fff;
+        border: 1px solid #e4e4e7;
+        border-radius: 4px;
+      }
+      .site-denylist__pattern {
+        flex: 1;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+        word-break: break-all;
+      }
+      .site-denylist__empty {
+        margin: 0 0 12px;
+        color: #888;
+      }
+      .site-denylist__add {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+      .site-denylist__add input {
+        flex: 1;
+        padding: 6px 10px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+        border: 1px solid #d4d4d8;
+        border-radius: 4px;
+      }
+      .site-denylist__add input:focus {
+        outline: 2px solid #2563eb;
+        outline-offset: -1px;
+        border-color: transparent;
+      }
       .status {
         font-size: 12px;
         color: #16a34a;

--- a/extension/src/options/Options.tsx
+++ b/extension/src/options/Options.tsx
@@ -11,11 +11,13 @@ import type { PlaceholderDisplayMode } from "../lib/placeholder-display";
 import { placeholderDisplayStorage } from "../lib/placeholder-display";
 import { RuleList } from "../lib/RuleList";
 import { runOnInactiveTabsStorage } from "../lib/run-on-inactive-tabs";
+import { siteDenylistStorage } from "../lib/site-denylist";
 import { ruleStatesStorage, setAllRuleStates } from "../lib/storage";
 import { useChromeStorageValue } from "../lib/use-chrome-storage-value";
 import { useTransientStatus } from "../lib/use-transient-status";
 import { parseConfig } from "./parse-config";
 import { Section } from "./Section";
+import { SitesDenylistSection } from "./SitesDenylistSection";
 
 export function Options() {
   const states = useChromeStorageValue(ruleStatesStorage);
@@ -27,6 +29,7 @@ export function Options() {
   const adaptivePalette = useChromeStorageValue(
     placeholderAdaptivePaletteStorage,
   );
+  const denylist = useChromeStorageValue(siteDenylistStorage);
 
   const [draft, setDraft] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -50,13 +53,23 @@ export function Options() {
     apiKeyDraft === null ||
     optionsButtonEnabled === null ||
     runOnInactiveTabs === null ||
-    adaptivePalette === null
+    adaptivePalette === null ||
+    denylist === null
   ) {
     return <div className="loading">Loading…</div>;
   }
 
+  // Same shape as the build-time overrides file (spec 0011 FR-3) so a
+  // tuned extension's export round-trips into the next build. Today
+  // that's rule states + siteDenylist; the reserved boolean keys
+  // (optionsButton, runOnInactiveTabs, etc.) are wired through their
+  // own storage and intentionally NOT round-tripped here.
   const handleExport = () => {
-    const blob = new Blob([JSON.stringify(states, null, 2)], {
+    const exported: Record<string, unknown> = { ...states };
+    if (denylist.length > 0) {
+      exported.siteDenylist = denylist;
+    }
+    const blob = new Blob([JSON.stringify(exported, null, 2)], {
       type: "application/json",
     });
     const url = URL.createObjectURL(blob);
@@ -76,7 +89,10 @@ export function Options() {
       return;
     }
     setError(null);
-    await setAllRuleStates(result.value);
+    await setAllRuleStates(result.value.rules);
+    if (result.value.siteDenylist !== undefined) {
+      await siteDenylistStorage.set(result.value.siteDenylist);
+    }
     showStatus("Applied");
   };
 
@@ -96,6 +112,7 @@ export function Options() {
         <a href="#options-button">On-page options button</a>
         <a href="#inactive-tabs">Inactive tabs</a>
         <a href="#api-key">OpenAI API key</a>
+        <a href="#site-denylist">Sites with enforcement disabled</a>
         <a href="#rules">Rules</a>
         <a href="#disclaimer">Disclaimer</a>
       </nav>
@@ -105,6 +122,8 @@ export function Options() {
           Paste a JSON object mapping rule IDs to booleans, then click Apply.
           Replaces the full configuration: any rule not listed resets to its
           default (enabled). Unknown keys and non-boolean values are rejected.
+          An optional <code>siteDenylist</code> key (an array of URL Pattern
+          strings) replaces the per-site denylist.
         </p>
         <textarea
           className="json-input"
@@ -293,6 +312,10 @@ export function Options() {
             </span>
           )}
         </div>
+      </Section>
+
+      <Section id="site-denylist" title="Sites with enforcement disabled">
+        <SitesDenylistSection denylist={denylist} />
       </Section>
 
       <Section id="rules" title="Rules">

--- a/extension/src/options/SitesDenylistSection.tsx
+++ b/extension/src/options/SitesDenylistSection.tsx
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import { useState } from "react";
+import { isValidPattern, siteDenylistStorage } from "../lib/site-denylist";
+
+// Audit + power-user editor for the per-site enforcement denylist
+// (ADR-0018). The popup is the one-click authoring surface; this list is
+// where users see what they've scoped off and remove individual entries.
+// The *Add pattern* input accepts any URL Pattern string and validates
+// against `new URLPattern(input)` before saving — loud failure here so
+// users typing patterns by hand get an immediate signal.
+export function SitesDenylistSection({ denylist }: { denylist: string[] }) {
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAdd = async (): Promise<void> => {
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      setError("Pattern cannot be empty.");
+      return;
+    }
+    if (!isValidPattern(trimmed)) {
+      setError(
+        "Not a valid URL Pattern. Example: https://example.com/* or https://*.example.com/*",
+      );
+      return;
+    }
+    if (denylist.includes(trimmed)) {
+      setError("Pattern is already in the denylist.");
+      return;
+    }
+    setError(null);
+    await siteDenylistStorage.set([...denylist, trimmed]);
+    setDraft("");
+  };
+
+  const handleRemove = async (pattern: string): Promise<void> => {
+    await siteDenylistStorage.set(denylist.filter((p) => p !== pattern));
+  };
+
+  const sorted = denylist.toSorted((a, b) => a.localeCompare(b));
+
+  return (
+    <>
+      <p className="hint">
+        Sites where you've paused every rule. Authored from the toolbar popup
+        ("Disable on this site") or added by URL Pattern below. Matches the
+        active tab's top-frame URL; subframes inherit.
+      </p>
+      {sorted.length === 0 ? (
+        <p className="hint site-denylist__empty">
+          No sites disabled. Open a site in a tab and click the toolbar icon to
+          scope the shield off on that host.
+        </p>
+      ) : (
+        <ul className="site-denylist__list">
+          {sorted.map((pattern) => (
+            <li key={pattern} className="site-denylist__row">
+              <code className="site-denylist__pattern">{pattern}</code>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => {
+                  void handleRemove(pattern);
+                }}
+                aria-label={`Remove ${pattern}`}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="site-denylist__add">
+        <label htmlFor="site-denylist-input" className="visually-hidden">
+          Add a URL Pattern to the denylist
+        </label>
+        <input
+          id="site-denylist-input"
+          type="text"
+          spellCheck={false}
+          placeholder="https://example.com/*"
+          value={draft}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setError(null);
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => {
+            void handleAdd();
+          }}
+        >
+          Add pattern
+        </button>
+      </div>
+      {error && (
+        <div className="error" role="alert">
+          {error}
+        </div>
+      )}
+    </>
+  );
+}

--- a/extension/src/options/__tests__/parse-config.test.ts
+++ b/extension/src/options/__tests__/parse-config.test.ts
@@ -20,7 +20,7 @@ describe("parseConfig", () => {
     const result = parseConfig(JSON.stringify({ [KNOWN_RULE_ID]: false }));
     expect(result).toEqual({
       ok: true,
-      value: { [KNOWN_RULE_ID]: false },
+      value: { rules: { [KNOWN_RULE_ID]: false } },
     });
   });
 
@@ -78,6 +78,78 @@ describe("parseConfig", () => {
   });
 
   it("accepts an empty object", () => {
-    expect(parseConfig("{}")).toEqual({ ok: true, value: {} });
+    expect(parseConfig("{}")).toEqual({ ok: true, value: { rules: {} } });
+  });
+
+  describe("siteDenylist", () => {
+    it("accepts an empty array", () => {
+      expect(parseConfig(JSON.stringify({ siteDenylist: [] }))).toEqual({
+        ok: true,
+        value: { rules: {}, siteDenylist: [] },
+      });
+    });
+
+    it("accepts an array of valid URL Pattern strings", () => {
+      const result = parseConfig(
+        JSON.stringify({
+          siteDenylist: ["https://example.test/*", "https://*.mail.test/*"],
+        }),
+      );
+      expect(result).toEqual({
+        ok: true,
+        value: {
+          rules: {},
+          siteDenylist: ["https://example.test/*", "https://*.mail.test/*"],
+        },
+      });
+    });
+
+    it("coexists with rule entries", () => {
+      const result = parseConfig(
+        JSON.stringify({
+          [KNOWN_RULE_ID]: false,
+          siteDenylist: ["https://example.test/*"],
+        }),
+      );
+      expect(result).toEqual({
+        ok: true,
+        value: {
+          rules: { [KNOWN_RULE_ID]: false },
+          siteDenylist: ["https://example.test/*"],
+        },
+      });
+    });
+
+    it("rejects a non-array siteDenylist", () => {
+      const result = parseConfig(
+        JSON.stringify({ siteDenylist: "https://example.test/*" }),
+      );
+      expect(result).toEqual({
+        ok: false,
+        error: "siteDenylist must be an array of URL Pattern strings.",
+      });
+    });
+
+    it("rejects a non-string entry", () => {
+      const result = parseConfig(JSON.stringify({ siteDenylist: [42] }));
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBe(
+          "siteDenylist[0]: expected string, got number",
+        );
+      }
+    });
+
+    it("rejects an invalid URL Pattern entry", () => {
+      const result = parseConfig(
+        JSON.stringify({ siteDenylist: ["not-a-pattern!!! :::"] }),
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBe(
+          "siteDenylist[0]: invalid URL Pattern (not-a-pattern!!! :::)",
+        );
+      }
+    });
   });
 });

--- a/extension/src/options/parse-config.ts
+++ b/extension/src/options/parse-config.ts
@@ -1,18 +1,32 @@
 // Copyright (c) 2026 PixieBrix, Inc.
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
+import { isValidPattern } from "../lib/site-denylist";
 import type { RuleStates } from "../lib/storage";
 import { RULE_IDS } from "../lib/storage";
 
 const RULE_ID_SET = new Set<string>(RULE_IDS);
 
+// Reserved non-rule keys the Options-page *Apply configuration* round-trip
+// understands. Mirrors the reserved-keys set in the build-time defaults
+// loader (`scripts/load-default-overrides.ts`). Today only `siteDenylist`
+// round-trips through this surface; the boolean reserved keys
+// (`optionsButton`, `runOnInactiveTabs`, etc.) are wired through their own
+// storage modules and ignored here so a paste-in won't churn them
+// silently.
+export interface ParsedConfig {
+  rules: Partial<RuleStates>;
+  siteDenylist?: string[];
+}
+
 export type ParseResult =
-  | { ok: true; value: Partial<RuleStates> }
+  | { ok: true; value: ParsedConfig }
   | { ok: false; error: string };
 
-// Parses the JSON pasted into the "Apply configuration" textarea. Returns a
-// partial rule-state map on success; on failure returns a single multi-line
-// error string suitable for rendering in the alert region.
+// Parses the JSON pasted into the "Apply configuration" textarea. Returns
+// the parsed rule states and any supported reserved keys; on failure
+// returns a single multi-line error string suitable for rendering in the
+// alert region.
 export function parseConfig(input: string): ParseResult {
   let parsed: unknown;
   try {
@@ -30,8 +44,18 @@ export function parseConfig(input: string): ParseResult {
   }
 
   const errors: string[] = [];
-  const result: Partial<RuleStates> = {};
+  const rules: Partial<RuleStates> = {};
+  let siteDenylist: string[] | undefined;
   for (const [key, value] of Object.entries(parsed)) {
+    if (key === "siteDenylist") {
+      const result = parseSiteDenylist(value);
+      if (result.ok) {
+        siteDenylist = result.value;
+      } else {
+        errors.push(...result.errors);
+      }
+      continue;
+    }
     if (!RULE_ID_SET.has(key)) {
       errors.push(`Unknown rule: ${key}`);
       continue;
@@ -40,11 +64,45 @@ export function parseConfig(input: string): ParseResult {
       errors.push(`Non-boolean value for ${key}: ${typeof value}`);
       continue;
     }
-    result[key] = value;
+    rules[key] = value;
   }
 
   if (errors.length > 0) {
     return { ok: false, error: errors.join("\n") };
   }
-  return { ok: true, value: result };
+  const value: ParsedConfig = { rules };
+  if (siteDenylist !== undefined) {
+    value.siteDenylist = siteDenylist;
+  }
+  return { ok: true, value };
+}
+
+function parseSiteDenylist(
+  raw: unknown,
+): { ok: true; value: string[] } | { ok: false; errors: string[] } {
+  if (!Array.isArray(raw)) {
+    return {
+      ok: false,
+      errors: ["siteDenylist must be an array of URL Pattern strings."],
+    };
+  }
+  const errors: string[] = [];
+  const value: string[] = [];
+  for (const [index, entry] of raw.entries()) {
+    if (typeof entry !== "string") {
+      errors.push(
+        `siteDenylist[${index}]: expected string, got ${typeof entry}`,
+      );
+      continue;
+    }
+    if (!isValidPattern(entry)) {
+      errors.push(`siteDenylist[${index}]: invalid URL Pattern (${entry})`);
+      continue;
+    }
+    value.push(entry);
+  }
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+  return { ok: true, value };
 }

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -110,6 +110,54 @@
         outline: 2px solid #2563eb;
         outline-offset: 2px;
       }
+      .site-disable {
+        margin: 0 0 12px;
+        padding: 8px 10px;
+        border: 1px solid #e4e4e7;
+        border-radius: 6px;
+        background: #fafafa;
+      }
+      .site-disable--off {
+        border-color: #fde68a;
+        background: #fffbeb;
+      }
+      .site-disable__button {
+        display: block;
+        width: 100%;
+        padding: 6px 8px;
+        font: inherit;
+        font-weight: 600;
+        color: #2563eb;
+        background: #fff;
+        border: 1px solid #2563eb;
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      .site-disable--off .site-disable__button {
+        color: #92400e;
+        border-color: #92400e;
+      }
+      .site-disable__button:hover {
+        background: #eff6ff;
+      }
+      .site-disable--off .site-disable__button:hover {
+        background: #fef3c7;
+      }
+      .site-disable__button:disabled {
+        color: #888;
+        border-color: #d4d4d8;
+        background: #f4f4f5;
+        cursor: not-allowed;
+      }
+      .site-disable__hint {
+        margin: 6px 0 0;
+        font-size: 11px;
+        color: #555;
+        line-height: 1.3;
+      }
+      .site-disable--off .site-disable__hint {
+        color: #92400e;
+      }
       .open-options {
         display: block;
         width: 100%;

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -5,24 +5,29 @@ import { useEffect, useState } from "react";
 import { debugTraceStorage } from "../lib/debug-trace";
 import { enforcementStorage } from "../lib/enforcement";
 import { HelpLinks } from "../lib/HelpLinks";
+import { siteDenylistStorage } from "../lib/site-denylist";
 import { useChromeStorageValue } from "../lib/use-chrome-storage-value";
 import { DebugTraceSection } from "./DebugTraceSection";
 import { DetectionsSection } from "./DetectionsSection";
 import { PerRuleCountsSection } from "./PerRuleCountsSection";
+import { SiteDisableSection } from "./SiteDisableSection";
 import { useTabDebugTrace } from "./use-tab-debug-trace";
 import { useTabActivity } from "./use-tab-detections";
 
 export function Popup() {
   const enforcementEnabled = useChromeStorageValue(enforcementStorage);
   const debugTraceEnabled = useChromeStorageValue(debugTraceStorage);
+  const denylist = useChromeStorageValue(siteDenylistStorage);
   const activity = useTabActivity();
   const [activeTabId, setActiveTabId] = useState<number | null>(null);
+  const [activeTabUrl, setActiveTabUrl] = useState<string | null>(null);
 
   useEffect(() => {
     void chrome.tabs
       .query({ active: true, currentWindow: true })
       .then(([tab]) => {
         setActiveTabId(typeof tab?.id === "number" ? tab.id : null);
+        setActiveTabUrl(typeof tab?.url === "string" ? tab.url : "");
       });
   }, []);
 
@@ -68,6 +73,9 @@ export function Popup() {
           </p>
         )}
       </div>
+      {enforcementEnabled && (
+        <SiteDisableSection activeTabUrl={activeTabUrl} denylist={denylist} />
+      )}
       <button
         type="button"
         className="open-options"

--- a/extension/src/popup/SiteDisableSection.tsx
+++ b/extension/src/popup/SiteDisableSection.tsx
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import {
+  addHostPattern,
+  findMatchingPatterns,
+  isContentSchemeUrl,
+  removeMatchingPatterns,
+  siteDenylistStorage,
+} from "../lib/site-denylist";
+
+// One control: a toggle that disables / re-enables the whole rule set on
+// the active tab's host. ADR-0018 §"Decision Outcome" — the affordance is
+// scoped per-site, not per-rule; "Re-enable on this site" removes every
+// pattern in the denylist that matches the active tab URL.
+//
+// Renders nothing while the tab URL or denylist is still loading. Renders
+// a disabled button with a hint on non-content schemes (chrome://,
+// about:, view-source:) where the content script doesn't run anyway.
+export function SiteDisableSection({
+  activeTabUrl,
+  denylist,
+}: {
+  activeTabUrl: string | null;
+  denylist: string[] | null;
+}) {
+  if (activeTabUrl === null || denylist === null) {
+    return null;
+  }
+  if (!isContentSchemeUrl(activeTabUrl)) {
+    return (
+      <div className="site-disable site-disable--unavailable">
+        <button
+          type="button"
+          className="site-disable__button"
+          disabled
+          aria-label="Disable on this site (unavailable on this page)"
+        >
+          Disable on this site
+        </button>
+        <p className="site-disable__hint">
+          The shield doesn't run on this page (browser-internal URL).
+        </p>
+      </div>
+    );
+  }
+
+  const matching = findMatchingPatterns(activeTabUrl, denylist);
+  const denylisted = matching.length > 0;
+
+  let host = "this site";
+  try {
+    host = new URL(activeTabUrl).host;
+  } catch {
+    // Should not happen — isContentSchemeUrl already parsed it. Fall through
+    // to the generic copy.
+  }
+
+  const handleClick = async (): Promise<void> => {
+    const current = await siteDenylistStorage.get();
+    if (denylisted) {
+      const { patterns } = removeMatchingPatterns(activeTabUrl, current);
+      await siteDenylistStorage.set(patterns);
+    } else {
+      const { patterns } = addHostPattern(activeTabUrl, current);
+      await siteDenylistStorage.set(patterns);
+    }
+  };
+
+  return (
+    <div
+      className={
+        denylisted
+          ? "site-disable site-disable--off"
+          : "site-disable site-disable--on"
+      }
+    >
+      <button
+        type="button"
+        className="site-disable__button"
+        onClick={() => {
+          void handleClick();
+        }}
+      >
+        {denylisted
+          ? matching.length > 1
+            ? `Re-enable on this site (${matching.length} patterns)`
+            : "Re-enable on this site"
+          : "Disable on this site"}
+      </button>
+      <p className="site-disable__hint">
+        {denylisted
+          ? `Rules are paused on ${host}. Clicking will remove every denylist entry matching this URL.`
+          : `Pause every rule on ${host}. Manage entries on the Options page.`}
+      </p>
+    </div>
+  );
+}

--- a/skills/agent-browser-shield-install/SKILL.md
+++ b/skills/agent-browser-shield-install/SKILL.md
@@ -215,6 +215,16 @@ JSON override file instead of using the hosted ZIP.
      against the page chrome. Off by default while the visual heuristic is still
      being tuned. Enable for deployments on consistently dark UIs.
 
+   - `siteDenylist` (array of URL Pattern strings, default `[]`) — start with
+     these hosts already in the per-site enforcement denylist. When the active
+     tab's top-frame URL matches any entry, every rule is paused on that tab;
+     subframes inherit. Each entry must satisfy `new URLPattern(entry)` (build
+     fails on a bad pattern) and supports the full URL Pattern grammar —
+     subdomain wildcards (`https://*.example.com/*`) and path scopes
+     (`https://example.com/admin/*`) included. Round-trips through the
+     Options-page export / apply so a tuned extension's exported JSON can be fed
+     back into the next build.
+
 2. Pass the path via CLI flag or env var to `bun run build`:
 
    ```sh

--- a/specs/0010-extension-ui-and-controls.md
+++ b/specs/0010-extension-ui-and-controls.md
@@ -31,6 +31,13 @@ all-or-nothing, and users pick "nothing."
 - As a **person hitting a false positive**, I want a one-click enforcement pause
   that disables every rule for every tab without losing my per-rule selections,
   so that I can finish my task and restore protection later.
+- As a **person whose shield is breaking one specific site**, I want a one-click
+  *disable on this site* toggle in the popup that scopes the kill-switch to the
+  active tab's host, so that I keep protection everywhere else without editing a
+  config file.
+- As a **person auditing what I've scoped off**, I want the Options page to list
+  every site I've disabled the shield on, with a remove control per entry, so
+  that I can see and undo exceptions I no longer want.
 - As a **person tuning the rule set**, I want an Options page with each rule's
   label, description, and a toggle, so that I can pick exactly the defenses I
   want.
@@ -66,10 +73,11 @@ all-or-nothing, and users pick "nothing."
 
 ### Popup
 
-- **FR-4.** The popup renders a master **Enforcement** toggle, a **Configure
-  rules** button that opens the Options page, a **Heads up** detections section,
-  a **Per-rule activity** section, a **Debug trace** toggle, and an **Export**
-  button (visible when the debug-trace recorder is on).
+- **FR-4.** The popup renders a master **Enforcement** toggle, a **Site
+  disable** control (FR-7a), a **Configure rules** button that opens the Options
+  page, a **Heads up** detections section, a **Per-rule activity** section, a
+  **Debug trace** toggle, and an **Export** button (visible when the debug-trace
+  recorder is on).
 - **FR-5.** Toggling enforcement off pauses every rule for every tab. The
   per-rule selection is preserved in `chrome.storage` and restored when
   enforcement turns back on. The popup shows a hint when enforcement is off
@@ -85,6 +93,34 @@ all-or-nothing, and users pick "nothing."
   `extension/src/popup/rule-labels.ts`, which is kept in lockstep with rule
   labels by the `catalog.test.ts` invariant *"popup labels match each rule's own
   label"*.
+
+### Per-site enforcement denylist
+
+- **FR-7a.** The popup shows a *Disable on this site* button when the active
+  tab's top-frame URL is a content scheme (http/https/file) **and** no entry in
+  the site denylist matches that URL. Clicking it appends the pattern
+  `` `${activeUrl.protocol}//${activeUrl.host}/*` `` to the denylist storage. On
+  non-content tabs (`chrome://`, `about:`, `view-source:`) the control is
+  rendered disabled with a hint explaining why.
+- **FR-7b.** When at least one denylist entry matches the active tab's top-frame
+  URL, the popup shows a *Re-enable on this site* button in place of FR-7a.
+  Clicking it removes **every** denylist entry whose `URLPattern.test` returns
+  true for the active URL. The popup surfaces the count of matching entries
+  removed (e.g. *"Removed 2 patterns"*) so a user who had a wildcard plus a
+  specific entry knows both were dropped; the Options page (FR-10a) is the place
+  to re-add individual patterns.
+- **FR-7c.** Effective per-tab enforcement is
+  `globalEnforcement && !matchesAnyDenylistPattern(topFrameUrl)`. Global
+  enforcement (FR-5 / spec 0002 FR-14) remains the master kill-switch: toggling
+  it off pauses every tab regardless of denylist content, and toggling it back
+  on restores both per-rule selections and denylist scoping. The denylist
+  applies to the whole rule set; per-rule per-host scoping is not in scope (see
+  *Future work*).
+- **FR-7d.** Matching is evaluated against the **top-frame** URL only, and the
+  per-tab effective-enforcement signal is computed in the background worker and
+  pushed to every frame in the tab. Subframes inherit the tab's enforcement
+  state rather than matching their own URL against the denylist, so a denylisted
+  top-frame pauses every frame regardless of cross-origin embedding.
 
 ### Options page
 
@@ -103,6 +139,7 @@ all-or-nothing, and users pick "nothing."
   - **Export configuration** — download the current rule states as
     `agent-browser-shield-config.json`. Export shape matches the build-time
     overrides format so the same JSON works in both places.
+  - **Sites with enforcement disabled** — see FR-10a.
   - **Placeholder display** — choose between label and icon-only modes for
     click-to-reveal placeholders. Persisted in storage and applied via the
     `data-abs-placeholder-mode` attribute on `<html>`. Also exposes *Adaptive
@@ -120,6 +157,23 @@ all-or-nothing, and users pick "nothing."
   - **OpenAI API key** — input for the key that backs
     `irrelevant-sections-redact`. When a key is already bundled at build time
     (`HAS_BUILT_IN_OPENAI_KEY`), the field acts as an override.
+
+### Site denylist on the Options page
+
+- **FR-10a.** The Options page includes a *Sites with enforcement disabled*
+  section that:
+  - Lists every pattern in the denylist, sorted alphabetically. Each row has a
+    *Remove* button.
+  - Provides an *Add pattern* input that validates the string with
+    `new URLPattern(input)` and rejects invalid entries with a user-visible
+    error before saving. Power users can author patterns the popup wouldn't
+    write (subdomain wildcards, path scopes).
+  - Renders empty-state copy when the denylist has no entries.
+- **FR-10b.** The denylist is included in the *Export configuration* JSON
+  (FR-10) under a reserved `siteDenylist` key, and *Apply configuration* reads
+  the same key. The round-trip preserves both rule states and denylist patterns;
+  unknown reserved keys are surfaced with a parse-message rather than silently
+  dropped.
 
 ### Floating on-page options button
 
@@ -147,6 +201,14 @@ all-or-nothing, and users pick "nothing."
   enforces that every rule appears in exactly one group (FR-8 grouping is
   exhaustive and non-overlapping), and that every rule has a popup label
   matching its own `Rule.label`.
+- **FR-15.** The site denylist is persisted as a `string[]` under
+  `agent-browser-shield.site-denylist` in `chrome.storage.local`. On read,
+  entries that fail `new URLPattern(entry)` are dropped silently — mirroring the
+  silent-degrade behaviour of the rule-state and build-time-overrides loaders
+  (ADR-0009). The popup's write path can never produce an invalid entry because
+  it composes the pattern from a parsed `URL`; loud failure belongs on the
+  Options-page *Add pattern* input (FR-10a) and on the build-time defaults
+  loader (spec 0011).
 
 ## Non-functional requirements
 
@@ -169,12 +231,21 @@ all-or-nothing, and users pick "nothing."
   `extension/src/popup/DebugTraceSection.tsx`,
   `extension/src/popup/rule-labels.ts`,
   `extension/src/popup/use-tab-detections.ts`.
+- FR-7a, FR-7b, FR-7c, FR-7d: `extension/src/popup/Popup.tsx` (*Disable on this
+  site* / *Re-enable on this site* control),
+  `extension/src/lib/site-denylist.ts` (storage + `matchesDenylist` matcher),
+  `extension/src/background.ts` (per-tab effective enforcement computation +
+  broadcast). See
+  [ADR-0018](../decisions/0018-per-site-enforcement-denylist.md).
 - FR-8, FR-9, FR-10: `extension/src/options/Options.tsx`,
   `extension/src/options/Section.tsx`, `extension/src/options/parse-config.ts`,
   `extension/src/lib/RuleList.tsx`, `extension/src/lib/storage.ts`,
   `extension/src/lib/placeholder-display.ts`,
   `extension/src/lib/placeholder-adaptive-palette.ts`,
   `extension/src/lib/api-key-storage.ts`, `extension/src/options/__tests__/`.
+- FR-10a, FR-10b: `extension/src/options/Options.tsx` (*Sites with enforcement
+  disabled* section), `extension/src/options/parse-config.ts` (`siteDenylist`
+  key in apply/export round-trip).
 - FR-11: `extension/src/lib/options-button-toggle.ts`,
   `extension/src/lib/options-badge.ts`.
 - FR-12: `extension/src/lib/run-on-inactive-tabs.ts`,
@@ -182,20 +253,30 @@ all-or-nothing, and users pick "nothing."
 - FR-13, FR-14: `extension/src/lib/chrome-storage-value.ts`,
   `extension/src/lib/rule-groups.ts`,
   `extension/src/rules/__tests__/catalog.test.ts`.
+- FR-15: `extension/src/lib/site-denylist.ts` (`siteDenylistStorage.normalize`
+  drops invalid entries), tested in
+  `extension/src/lib/__tests__/site-denylist.test.ts` (alongside a `fast-check`
+  property test that round-trips `addHostPattern` / `removeMatchingPatterns`
+  against arbitrary URLs).
 
 ## Future work
 
 - Detection promotion: when a detection-producing rule is off, surface a hint
   that turning it on would catch this kind of pattern. Not implemented;
   detections only render when their producing rule is on.
-- Per-host enable/disable for specific rules from the popup — only per-host
-  kill-switches today are baked into rule files (`hidden-affiliate-sanitize`,
-  `hidden-fee-annotate`); no UI surface.
+- **Per-rule** per-host enable/disable from the popup — the v1 site denylist
+  (FR-7a, FR-7c, [ADR-0018](../decisions/0018-per-site-enforcement-denylist.md))
+  scopes the whole rule set, not individual rules. A user with one specific rule
+  misfiring on a site has to either silence every rule there or globally disable
+  just that rule. Per-host kill-switches *baked into* specific rule files
+  (`hidden-affiliate-sanitize`, `hidden-fee-annotate`) remain independent of the
+  user-facing denylist.
 
 ## Related
 
 - ADRs: [ADR-0009](../decisions/0009-rule-defaults-and-build-time-overrides.md),
-  [ADR-0013](../decisions/0013-background-worker-purity-canary.md).
+  [ADR-0013](../decisions/0013-background-worker-purity-canary.md),
+  [ADR-0018](../decisions/0018-per-site-enforcement-denylist.md).
 - Docs:
   [`docs/src/content/docs/install.md`](../docs/src/content/docs/install.md)
   §"Customizing defaults at build time".

--- a/specs/0011-build-time-customization.md
+++ b/specs/0011-build-time-customization.md
@@ -79,10 +79,19 @@ shield release.
     the light default. Default off while the visual heuristic is still being
     tuned; the same toggle is exposed in the Options page under *Placeholder
     display* (spec [0010](./0010-extension-ui-and-controls.md) FR-10).
+  - `siteDenylist` (`string[]`, default `[]`) — start with these URL Pattern
+    strings already in the per-site enforcement denylist (spec 0010 FR-7a /
+    FR-15, [ADR-0018](../decisions/0018-per-site-enforcement-denylist.md)). Each
+    entry must parse via `new URLPattern(entry)` — invalid entries fail the
+    build under FR-4. The same key round-trips through the Options-page export /
+    apply (spec 0010 FR-10b) so a tuned extension's exported JSON can be fed
+    straight back into the next build.
 - **FR-4.** Unknown keys (neither a registered rule ID nor a reserved key),
   unknown sub-rule or sub-field keys under a rule object, object values for
-  rules without declared options, and leaf values whose type does not match the
-  declared default (boolean → non-boolean, number → non-finite or non-number)
+  rules without declared options, leaf values whose type does not match the
+  declared default (boolean → non-boolean, number → non-finite or non-number),
+  and reserved-key values that fail their declared shape — `siteDenylist` not
+  being an array of strings each of which parses via `new URLPattern(entry)` —
   fail the build with a message naming the offending paths. The validator does
   not range-check numeric thresholds (FR-2a) — operators tuning thresholds are
   reading the rule source by definition.
@@ -105,11 +114,13 @@ shield release.
   literals at build time so the shipped JS contains no runtime `atob` of
   obfuscated strings. See
   [ADR-0011](../decisions/0011-build-time-decoded-injection-patterns.md).
-- **NFR-S-2.** The build-time `EXTENSION_DEFAULT_OVERRIDES` and
-  `EXTENSION_RULE_OPTIONS` values are parsed at content-script startup via
-  `JSON.parse` and validated against the rule registry / option-shape tree
-  respectively; a malformed value silently degrades to "no overrides" rather
-  than crashing the engine.
+- **NFR-S-2.** The build-time `EXTENSION_DEFAULT_OVERRIDES`,
+  `EXTENSION_RULE_OPTIONS`, and `EXTENSION_DEFAULT_DENYLIST` values are parsed
+  at content-script startup via `JSON.parse` and validated against the rule
+  registry / option-shape tree / `URLPattern` constructor respectively; a
+  malformed value silently degrades to "no overrides" rather than crashing the
+  engine. Loud failure happens at build time (FR-4), not at content-script
+  start.
 - **NFR-M-1.** Rule defaults and IDs live in a single hand-edited file
   (`extension/src/rules/rule-metadata.ts`). The `catalog.test.ts` invariant
   enforces parity with `rules/index.ts`. See
@@ -129,7 +140,10 @@ shield release.
   `extension/src/lib/options-button-toggle.ts`,
   `extension/src/lib/run-on-inactive-tabs.ts`,
   `extension/src/lib/debug-trace.ts`,
-  `extension/src/lib/placeholder-adaptive-palette.ts`.
+  `extension/src/lib/placeholder-adaptive-palette.ts`,
+  `extension/src/lib/site-denylist.ts` (reads
+  `process.env.EXTENSION_DEFAULT_DENYLIST` and seeds `siteDenylistStorage`'s
+  `defaultValue`).
 - FR-2a: `extension/src/rules/rule-metadata.ts` (`RULE_OPTION_DEFAULTS`),
   `extension/scripts/load-default-overrides.ts` (sub-rule validation),
   `extension/src/lib/rule-options.ts` (`getRuleOptions`, parses
@@ -142,8 +156,11 @@ shield release.
 
 ## Future work
 
-- Per-host default overrides — today overrides are flat and global; no way to
-  ship "rule X off on host Y" as a build-time default.
+- **Per-rule** per-host default overrides — the `siteDenylist` reserved key
+  (FR-3, [ADR-0018](../decisions/0018-per-site-enforcement-denylist.md)) scopes
+  the whole rule set off on a host, not individual rules. Shipping "rule X off
+  on host Y" as a build-time default needs either a per-rule denylist map or
+  per-host rule overrides; neither is implemented.
 - Build-time API key bundling for `irrelevant-sections-redact` is supported via
   `OPENAI_API_KEY` at build time (see `extension/src/lib/api-key-storage.ts`)
   but is not part of the override file. Folding it into the same JSON shape
@@ -155,6 +172,7 @@ shield release.
   [ADR-0011](../decisions/0011-build-time-decoded-injection-patterns.md),
   [ADR-0016](../decisions/0016-eslint-style-per-rule-options-shape.md),
   [ADR-0017](../decisions/0017-numeric-thresholds-as-rule-options.md),
+  [ADR-0018](../decisions/0018-per-site-enforcement-denylist.md),
   [ADR-0013](../decisions/0013-background-worker-purity-canary.md).
 - Docs:
   [`docs/src/content/docs/install.md`](../docs/src/content/docs/install.md)


### PR DESCRIPTION
## Summary

- Adds a one-click *Disable on this site* / *Re-enable on this site* toggle to the toolbar popup and an audit-and-edit *Sites with enforcement disabled* section to the Options page.
- Storage is `string[]` of URL Pattern strings under `agent-browser-shield.site-denylist`; the popup writes `` `${scheme}//${host}/*` `` for the active tab; *Re-enable* removes every entry matching the active URL.
- Effective enforcement = `globalEnforcement && !matchesAnyDenylistPattern(topFrameUrl)`. Subframes inherit by asking the background once for the tab's top-frame URL (new `get-tab-url` message); pure-top-frame computation uses `globalThis.location.href` so SPA route changes re-evaluate on the next storage event.
- New `siteDenylist` reserved key on the build-time overrides file (spec 0011 / ADR-0018), validated via zod + `new URLPattern(entry)`. Round-trips through the Options-page *Export configuration* / *Apply configuration* surface.

ADR: [`decisions/0018-per-site-enforcement-denylist.md`](./decisions/0018-per-site-enforcement-denylist.md)

Spec updates: [`specs/0010-extension-ui-and-controls.md`](./specs/0010-extension-ui-and-controls.md) FR-7a–FR-7d, FR-10a, FR-10b, FR-15; [`specs/0011-build-time-customization.md`](./specs/0011-build-time-customization.md) FR-3 (`siteDenylist`), FR-4 (loud failure on bad pattern).

## What's NOT in scope

- **Per-rule** per-host control. v1 scopes the whole rule set off on a host; the per-rule axis remains future work in spec 0010 §"Future work".
- Per-host *enable* overrides (the user explicitly chose denylist-only).

## Test plan

- [x] `extension/src/lib/__tests__/site-denylist.test.ts` — unit coverage for `hostPatternFor`, `matchesDenylist`, `findMatchingPatterns`, `addHostPattern`, `removeMatchingPatterns`, `isContentSchemeUrl`, `isValidPattern`.
- [x] `extension/src/lib/__tests__/site-denylist.property.test.ts` — `fast-check` round-trip invariants: pattern from `addHostPattern` always matches the URL; `removeMatchingPatterns` leaves no matching pattern.
- [x] `extension/src/options/__tests__/parse-config.test.ts` — `siteDenylist` round-trip + bad-shape rejections through the Options-page *Apply configuration* surface.
- [x] `extension/scripts/__tests__/load-default-overrides.test.ts` — build-time `siteDenylist` validation (valid list, empty list, non-array, non-string entry, invalid URL Pattern).
- [x] `extension/src/lib/__tests__/rule-engine.test.ts` — mock swapped from `enforcement.ts` to `effective-enforcement.ts`; all 12 existing reconciliation cases pass.
- [x] Full suite: 2001 / 2001 pass.
- [x] `bun run check` (biome + eslint): clean.
- [x] `pre-commit run --all-files`: clean (after `bun install` in `demo-site/`).
- [x] `bun run build --defaults <file>` with a valid `siteDenylist` injects the pattern into `dist/content.js`; with an invalid pattern, build fails loudly with a path-qualified zod message.
- [ ] **Manual verification needed (no headed browser in this environment):** load the unpacked build, click "Disable on this site" on a few URLs, confirm the rule engine pauses on that tab and re-enables on click. Spot-check that subframes inherit by visiting a page with a cross-origin iframe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)