### PR TITLE
Add: tab-scoped recovery pause, in one unified popup off-switch card (spec 0010 FR-7e–h, ADR-0018/0019)

### DIFF
--- a/decisions/0019-tab-scoped-enforcement-pause.md
+++ b/decisions/0019-tab-scoped-enforcement-pause.md
@@ -1,0 +1,241 @@
+---
+status: proposed
+date: 2026-06-09
+---
+
+# Tab-scoped, non-persistent enforcement pause for fast recovery
+
+## Context and Problem Statement
+
+When a rule blanks content the user actually wants, the recovery paths today are
+both bad:
+
+1. Hunt for the per-element click-to-reveal placeholder — fine for one element,
+   useless when a rule ate a whole region or the page needs many reveals.
+2. *Disable on this site* (FR-7a,
+   [ADR-0018](./0018-per-site-enforcement-denylist.md)) — writes a **permanent**
+   denylist entry to `chrome.storage.local`. A daily driver who just wants to
+   get through one checkout ends up with a denylist entry they will never clean
+   up, silently unprotected on that site forever.
+
+There is no "reveal this page now" panic button and no "let me through for the
+next 15 minutes" snooze. Both are table-stakes affordances for a defensive
+extension that wants to stay installed (spec 0010's framing: *"the shield broke
+my page" turns into "I uninstalled the shield"*).
+
+The shape questions:
+
+1. **Where does the pause state live**, given it must be tab-scoped, survive an
+   MV3 service-worker eviction, but vanish on browser restart with zero cleanup
+   debt — and be readable by the toolbar (background) and popup, and
+   *actionable* by content scripts that can't read it directly?
+2. **How does a timed snooze end** without yanking content back while the user
+   is mid-task?
+3. **How is the reveal actually performed** — new code, or can it reuse the
+   existing global-enforcement teardown?
+
+## Decision Drivers
+
+- Recovery must be **distinct from** the persistent denylist: tab-scoped, and
+  forgotten on its own (on navigation, on expiry, on tab close, on browser
+  restart) so it never becomes stale unprotected state.
+- The reveal must be the same observable behaviour as turning enforcement off,
+  so there is one teardown path to reason about and test.
+- A timed snooze expiring must not surprise the user by re-hiding content they
+  are looking at; protection should come back on the next page, not mid-page.
+- Reuse the storage primitive the codebase already standardizes on
+  (`webext-storage`) rather than hand-rolling `chrome.storage` access.
+- No new permissions, no new background machinery (alarms) unless a requirement
+  genuinely needs them.
+
+## Considered Options
+
+### State location
+
+- **A. `chrome.storage.session` via webext-storage `StorageItemMap`, keyed by
+  tabId.** Durable across SW restarts, auto-cleared on browser restart. Popup
+  and background read/write directly; content scripts reached by message.
+- **B. In-memory `Map` in the background worker.** Simplest, but an MV3 service
+  worker is evicted aggressively — a pause would silently drop on the next
+  eviction, un-revealing a page the user paused.
+- **C. `chrome.storage.local` with manual cleanup.** Persists across browser
+  restart, reintroducing exactly the stale-state problem the denylist already
+  has and this feature is trying to avoid.
+
+### Snooze expiry
+
+- **D. Lazy expiry + content-side latch.** Liveness is `expiresAt > now`,
+  evaluated at content-script init. A timed expiry produces no event; the open
+  page stays revealed until its next navigation re-reads fresh state.
+- **E. `chrome.alarms` at the deadline.** Fires an event that re-enforces the
+  open page immediately — accurate to the second, but re-hides content mid-task
+  and needs the `alarms` permission.
+
+### Performing the reveal
+
+- **F. Third input to `effective-enforcement.ts`.** The pause joins
+  `global && !denylist` as a third factor; when it flips the boolean false the
+  rule engine already runs `revealAll(ruleId)` + `teardown()` for every rule.
+- **G. Bespoke "reveal everything" routine in the content script.** Duplicates
+  the teardown logic the engine already has on the enforcement-off path.
+
+## Decision Outcome
+
+Chosen: **A + D + F.**
+
+- **Storage (A).** A `webext-storage` `StorageItemMap<TabPause>` on
+  `area: "session"` under `agent-browser-shield.tab-pause`, secondary key =
+  `String(tabId)`.
+  `TabPause = { scope: "page" | "tab"; expiresAt: number | null }`.
+  - *Reveal everything on this page* → `{ scope: "page", expiresAt: null }`.
+  - *Pause for this tab* → `{ scope: "tab", expiresAt: null }`.
+  - *15 min* / *1 hour* → `{ scope: "tab", expiresAt: Date.now() + ms }`.
+  - `isPauseActive(pause, now)` = pause exists AND (`expiresAt` null OR
+    `> now`). A malformed `expiresAt` resolves to not-active (fail-open to
+    protected).
+- **Scope semantics.** `page` is the panic button: cleared on the tab's next
+  top-frame navigation. `tab` survives navigation within the tab (so a
+  multi-page checkout stays unblocked) until `expiresAt` or tab close.
+- **Expiry (D).** Liveness is computed lazily from `expiresAt`; there are **no
+  alarms**. The content script seeds `cachedTabPaused` at rule-engine init and
+  thereafter only changes it on an explicit popup edit (a `tab-pause-changed`
+  push). A *timed* expiry writes nothing and pushes nothing, so the open page
+  stays revealed until its next navigation re-reads fresh state at init — this
+  is the "resume on next navigation" behaviour (FR-7g). *Manual* "Resume now"
+  does write (a `remove`), so it re-enforces the open page immediately, which is
+  the desired confirmation of a deliberate action.
+- **Reveal (F).** The pause is a third input to `effective-enforcement.ts`:
+  `global && !denylist && !tabPaused`. Flipping it false routes through the
+  engine's existing `subscribeEffectiveEnforcement → reconcile` path, which
+  calls `revealAll(ruleId)` + `rule.teardown()` per rule. No new reveal code.
+- **Content bridge.** Content scripts can't read the `session` area, and —
+  unlike the denylist, which they match by URL — a pause is keyed by a tabId
+  they don't know. So the background resolves it: a `get-tab-pause` message at
+  init returns the resolved boolean for `sender.tab.id`, and the background
+  pushes `tab-pause-changed` (carrying the resolved boolean) to every frame in
+  the tab whenever the map changes. The popup and background, being privileged
+  contexts, read/write the map directly — mirroring the denylist flow (popup
+  writes storage; background reacts via `onChanged`).
+- **Lifecycle clearing.** The background clears a tab's entry on tab close
+  (`tabs.onRemoved`), clears `page`-scoped entries and reaps expired entries on
+  top-frame navigation (`tabs.onUpdated` loading), and keeps an in-memory
+  `tabPauses` cache (hydrated from the map at startup, kept current via
+  `onChanged`) so `refreshBadge` stays synchronous.
+- **Toolbar.** `ProtectionState` gains a `"paused"` reason → the existing greyed
+  icon + `off` badge (FR-2a), tooltip *"protection paused on this tab"*. A
+  denylisted-and-paused tab reports the more durable `site` reason; in practice
+  the popup only offers the pause when the tab isn't denylisted, so they don't
+  overlap.
+- **No new permissions.** `chrome.storage.session` is covered by the existing
+  `storage` permission; no `alarms`.
+
+### Consequences
+
+- Good, because the reveal is literally the enforcement-off teardown scoped to a
+  tab — one code path, already tested, no duplicate "reveal everything" routine.
+- Good, because `session` storage gives exactly the desired lifetime: survives
+  SW eviction (so a paused page doesn't silently re-hide), auto-cleared on
+  browser restart (so there is no persistent stale-state debt, unlike the
+  denylist).
+- Good, because dropping `chrome.alarms` removes a permission and a moving part;
+  lazy expiry is sufficient and gives the resume-on-next-navigation UX for free.
+- Good, because the storage primitive is the one the codebase already uses
+  (`StorageItem` is wrapped in `chrome-storage-value.ts`; `StorageItemMap` is
+  the keyed sibling), so there's no hand-rolled `chrome.storage.session`
+  plumbing.
+- Neutral, because a still-open page can briefly disagree with the toolbar after
+  a timed expiry: the page stays revealed (by design) while the toolbar, next
+  time `refreshBadge` runs, computes the pause as expired and flips back to
+  protected. The next navigation reconciles them. This is the accepted cost of
+  resume-on-next-navigation.
+- Neutral, because the content bridge is message-based rather than a pure
+  storage subscription (as the denylist is). The asymmetry is forced: content
+  scripts can't observe `session` and don't know their tabId. Considered
+  `chrome.storage.session.setAccessLevel(TRUSTED_AND_UNTRUSTED_CONTEXTS)` to let
+  content read the map directly and rejected it — content would *still* need a
+  round-trip to learn its tabId, so the message is unavoidable either way, and
+  the access-level change widens session exposure for no benefit.
+- Bad, because there is a small race: a popup edit that lands in the narrow
+  window between a content script starting and its `initEffectiveEnforcement`
+  resolving (when the `tab-pause-changed` listener is registered) is missed. The
+  init fetch already captured the latest state, and the next edit or navigation
+  reconciles, so the window is both narrow and self-healing.
+
+### Confirmation
+
+- `extension/src/lib/tab-pause.ts` exports the `StorageItemMap<TabPause>`
+  (`area: "session"`), the snooze presets, and a pure
+  `isPauseActive(pause, now)` — the latter covered by `tab-pause.test.ts` and a
+  `fast-check` `tab-pause.property.test.ts` (deadline-vs-now invariant), per the
+  project's "include property tests for matchers" guideline.
+- `extension/src/lib/effective-enforcement.ts` adds `cachedTabPaused` as a third
+  factor, seeded via `get-tab-pause` and updated via `tab-pause-changed`.
+- `extension/src/lib/toolbar-protection.ts` adds the `"paused"` reason;
+  `toolbar-protection.test.ts` asserts the new state, title, and appearance key.
+- `extension/src/background.ts` mirrors the map into a `tabPauses` cache,
+  bridges `onChanged` to the tab's frames, answers `get-tab-pause`, and clears
+  entries on navigation / tab close.
+- `extension/src/popup/RecoverySection.tsx` + `use-tab-pause.ts` render the
+  panic button, the three snooze presets, and the active-pause status with a
+  live countdown and *Resume now* — writing `tabPauseMap` directly, the way
+  `SiteDisableSection` writes `siteDenylistStorage`.
+- `extension/src/__test-mocks__/webext-storage.ts` gains an in-memory
+  `StorageItemMap` stub so background/popup map code round-trips under Jest.
+
+## Pros and Cons of the Options
+
+### A. `chrome.storage.session` `StorageItemMap` (chosen)
+
+- Good, survives SW eviction; auto-cleared on browser restart; keyed-map API
+  already in the dependency.
+- Bad, content scripts can't read it — needs the background bridge.
+
+### B. In-memory background `Map`
+
+- Good, trivial.
+- Bad, MV3 evicts the worker; a paused page would re-hide on the next eviction.
+
+### C. `chrome.storage.local`
+
+- Good, survives everything.
+- Bad, survives *too much* — reintroduces the persistent stale-unprotected-state
+  problem this feature exists to avoid.
+
+### D. Lazy expiry + latch (chosen)
+
+- Good, no permission, no alarm; gives resume-on-next-navigation for free.
+- Bad, brief toolbar/page disagreement after expiry until the next refresh.
+
+### E. `chrome.alarms` at the deadline
+
+- Good, second-accurate resume.
+- Bad, needs the `alarms` permission and re-hides content mid-task — the
+  surprise the chosen design specifically avoids.
+
+### F. Third input to effective enforcement (chosen)
+
+- Good, reuses the engine's reveal-all + teardown; nothing new to test.
+- Bad, couples recovery to the enforcement signal — acceptable, since "reveal
+  everything" *is* "enforcement off, for this tab".
+
+### G. Bespoke reveal routine
+
+- Bad, duplicates the teardown the engine already performs on enforcement-off,
+  with a second code path to keep in sync.
+
+## More Information
+
+- Spec
+  [0010 — Extension UI and controls](../specs/0010-extension-ui-and-controls.md)
+  FR-7e–FR-7h (this feature), FR-2a (toolbar paused state), FR-5 (the global
+  kill-switch whose teardown path this reuses).
+- [ADR-0018](./0018-per-site-enforcement-denylist.md) — the *permanent* per-site
+  denylist this feature is deliberately distinct from, and whose popup
+  write-through-storage pattern it mirrors.
+- [ADR-0007](./0007-scrub-instead-of-detach-for-framework-dom.md) — why reveal
+  is non-destructive (the original node is preserved), which is what makes a
+  reveal-everything pass safe.
+- `extension/src/lib/chrome-storage-value.ts` — the existing `StorageItem`
+  wrapper; `StorageItemMap` is the keyed sibling used here.
+- `extension/src/lib/effective-enforcement.ts` — the composition point the pause
+  plugs into as a third factor.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -32,6 +32,7 @@ that is not supported by one of those citations.
 | [0016](./0016-eslint-style-per-rule-options-shape.md)       | ESLint-style per-rule build-time options shape                                                | Accepted                                          |
 | [0017](./0017-numeric-thresholds-as-rule-options.md)        | Numeric thresholds exposed as per-sub-rule options                                            | Accepted                                          |
 | [0018](./0018-per-site-enforcement-denylist.md)             | Per-site enforcement denylist authored from the popup; stored as URL Pattern strings          | Proposed                                          |
+| [0019](./0019-tab-scoped-enforcement-pause.md)              | Tab-scoped, non-persistent enforcement pause for fast recovery (reveal-everything + snooze)   | Proposed                                          |
 
 ## Conventions
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -72,8 +72,31 @@ have to open the popup:
   example, a hard-to-cancel subscription). When there's a detection but no
   count, the badge shows `!`.
 - **Greyed shield with an `off` badge** — enforcement is paused on this tab,
-  either because you turned the master switch off (every tab) or because the
-  site is on your *Disable on this site* list. Hover the icon to see which.
+  because you turned the master switch off (every tab), the site is on your
+  *Disable on this site* list, or you used a temporary recovery pause (*Reveal
+  everything on this page* or a snooze) on this tab. Hover the icon to see
+  which.
+
+### Recovering a page the shield broke
+
+If a rule hides something you actually wanted, open the popup for two quick,
+**temporary** escapes — both scoped to the current tab and forgotten on their
+own, so they never become a setting you have to remember to undo:
+
+- **Reveal everything on this page** — one click un-hides everything the shield
+  scrubbed on the current page and stops it re-hiding for this page view. It's
+  the panic button: reload the page (or navigate away) and protection comes
+  back.
+- **Pause protection** — snooze the shield on this tab for *15 min*, *1 hour*,
+  or until you close the tab. Unlike *Reveal everything*, a snooze carries
+  across page navigations in the same tab, so you can get through a multi-step
+  flow like a checkout. The popup shows the time remaining and a *Resume now*
+  button; when a timed snooze runs out while you're still on the page, the page
+  stays as-is and protection re-engages the next time you navigate.
+
+Both are deliberately separate from *Disable on this site*, which is a permanent
+choice saved until you remove it. Use the recovery controls for a one-off; use
+*Disable on this site* for a site you never want the shield to touch.
 
 ## Customizing defaults at build time
 

--- a/extension/src/__test-mocks__/webext-storage.ts
+++ b/extension/src/__test-mocks__/webext-storage.ts
@@ -72,9 +72,100 @@ export class StorageItem<Base, Return = Base | undefined> {
   }
 }
 
+// In-memory stub mirroring `StorageItemMap`'s secondary-key model: each entry
+// is stored under `${key}:::${secondaryKey}` in a shared map so `get` round-
+// trips through `set`/`remove` and `onChanged` fires the (secondaryKey, value)
+// shape the real package emits (value undefined on removal).
+const mapValues = new Map<string, unknown>();
+const mapListeners = new Map<
+  string,
+  Set<(secondaryKey: string, value: unknown) => void>
+>();
+
 export class StorageItemMap<T> {
-  constructor(
-    public readonly key: string,
-    public readonly options: StorageItemOptions<T> = {},
-  ) {}
+  readonly prefix: string;
+  readonly defaultValue?: T;
+
+  constructor(key: string, options: StorageItemOptions<T> = {}) {
+    this.prefix = `${key}:::`;
+    if (options.defaultValue !== undefined) {
+      this.defaultValue = options.defaultValue;
+    }
+  }
+
+  has(secondaryKey: string): Promise<boolean> {
+    return Promise.resolve(mapValues.has(this.prefix + secondaryKey));
+  }
+
+  get(secondaryKey: string): Promise<T | undefined> {
+    const rawKey = this.prefix + secondaryKey;
+    const value = mapValues.has(rawKey)
+      ? mapValues.get(rawKey)
+      : this.defaultValue;
+    return Promise.resolve(value as T | undefined);
+  }
+
+  set(secondaryKey: string, value: T): Promise<void> {
+    mapValues.set(this.prefix + secondaryKey, value);
+    for (const listener of mapListeners.get(this.prefix) ?? []) {
+      listener(secondaryKey, value);
+    }
+    return Promise.resolve();
+  }
+
+  remove(secondaryKey: string): Promise<void> {
+    mapValues.delete(this.prefix + secondaryKey);
+    for (const listener of mapListeners.get(this.prefix) ?? []) {
+      listener(secondaryKey, undefined);
+    }
+    return Promise.resolve();
+  }
+
+  delete(secondaryKey: string): Promise<void> {
+    return this.remove(secondaryKey);
+  }
+
+  keys(): Promise<string[]> {
+    const result: string[] = [];
+    for (const rawKey of mapValues.keys()) {
+      if (rawKey.startsWith(this.prefix)) {
+        result.push(rawKey.slice(this.prefix.length));
+      }
+    }
+    return Promise.resolve(result);
+  }
+
+  clear(): Promise<void> {
+    for (const rawKey of mapValues.keys()) {
+      if (rawKey.startsWith(this.prefix)) {
+        mapValues.delete(rawKey);
+      }
+    }
+    return Promise.resolve();
+  }
+
+  async *entries(): AsyncIterableIterator<[string, T]> {
+    for (const secondaryKey of await this.keys()) {
+      yield [secondaryKey, (await this.get(secondaryKey)) as T];
+    }
+  }
+
+  onChanged(
+    callback: (secondaryKey: string, value: T) => void,
+    signal?: AbortSignal,
+  ): void {
+    const set = mapListeners.get(this.prefix) ?? new Set();
+    const wrapped = (secondaryKey: string, value: unknown) => {
+      callback(secondaryKey, value as T);
+    };
+    set.add(wrapped);
+    mapListeners.set(this.prefix, set);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        set.delete(wrapped);
+      },
+      { once: true },
+    );
+  }
 }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -18,10 +18,12 @@ import type {
   GetTabDebugTraceResponse,
   GetTabDetectionsRequest,
   GetTabDetectionsResponse,
+  GetTabPauseResponse,
   GetTabRuleCountsRequest,
   GetTabRuleCountsResponse,
   RuleCountEntry,
   RuleDetectionMessage,
+  TabPauseChangedMessage,
 } from "./lib/detection-messages";
 import { startDumpTraceBridgeRegistration } from "./lib/dump-trace-bridge-registration";
 import {
@@ -34,6 +36,8 @@ import { startShadowRootProbeRegistration } from "./lib/shadow-root-probe-regist
 import { installShadowRootProbe } from "./lib/shadow-root-probe-source";
 import { siteDenylistStorage } from "./lib/site-denylist";
 import { ruleStatesStorage } from "./lib/storage";
+import type { TabPause } from "./lib/tab-pause";
+import { isPauseActive, tabPauseMap } from "./lib/tab-pause";
 import type { ProtectionState } from "./lib/toolbar-protection";
 import {
   ACTION_ICON_OFF,
@@ -80,6 +84,13 @@ let denylist: readonly string[] = [];
 // denylist for any tab without round-tripping the page. Captured from
 // tabs.onUpdated / onActivated / a startup tabs.query; dropped on tab close.
 const tabUrls = new Map<number, string>();
+
+// In-memory mirror of the tab-scoped recovery pause map (ADR-0019), so
+// `refreshBadge` stays sync and the content bridge can resolve liveness without
+// an async read. Hydrated from `tabPauseMap` at startup and kept current by its
+// `onChanged`. The authoritative store is `chrome.storage.session`; this is the
+// same cache posture as `enforcementEnabled` / `denylist`.
+const tabPauses = new Map<number, TabPause>();
 
 // Memo of the icon/title appearance last applied per tab, keyed by
 // `protectionAppearanceKey`, so we only call setIcon/setTitle when the
@@ -150,6 +161,7 @@ function refreshBadge(tabId: number): void {
     enforcementEnabled,
     tabUrl: tabUrls.get(tabId) ?? null,
     denylist,
+    paused: isPauseActive(tabPauses.get(tabId) ?? null, Date.now()),
   });
   applyProtectionAppearance(tabId, state);
   if (state.off) {
@@ -293,6 +305,14 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   tabDetections.delete(tabId);
   tabUrls.delete(tabId);
   tabAppearanceKey.delete(tabId);
+  // Drop any recovery pause for the closed tab. The cache delete is immediate;
+  // the session-storage remove is fire-and-forget (the value is auto-cleared on
+  // browser restart regardless, this just keeps it tidy within the session).
+  if (tabPauses.delete(tabId)) {
+    void tabPauseMap.remove(String(tabId)).catch(() => {
+      // noop
+    });
+  }
   // Fire-and-forget — IDB write may outlive the listener context.
   void clearDebugTraceTab(tabId).catch(() => {
     // noop
@@ -321,6 +341,16 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
       refreshBadge(tabId);
     }
     return;
+  }
+  // A top-frame navigation ends a "page"-scoped reveal (the panic button is
+  // current-page-only) and reaps any timed "tab" pause that has since expired.
+  // Active timed pauses survive so a multi-page flow stays unblocked.
+  const pause = tabPauses.get(tabId);
+  if (pause && (pause.scope === "page" || !isPauseActive(pause, Date.now()))) {
+    tabPauses.delete(tabId);
+    void tabPauseMap.remove(String(tabId)).catch(() => {
+      // noop
+    });
   }
   clearTab(tabId);
   void (async () => {
@@ -395,6 +425,52 @@ void siteDenylistStorage.get().then((next) => {
   refreshAllTabs();
 });
 
+// The tab-scoped recovery pause (ADR-0019) is the third input to the protection
+// signal — but only the popup and background write it, and content scripts
+// can't observe the session area, so the background bridges every change to the
+// tab's frames. On a popup edit (reveal/pause/snooze, or "Resume now") push the
+// new liveness so a still-open page reveals or re-enforces without a reload; a
+// *timed* expiry produces no write and hence no push, which is what leaves the
+// open page revealed until its next navigation.
+// webext-storage types the change value as non-undefined, but it IS undefined
+// when the entry was removed (resume / nav-clear / tab close). A wider param
+// type is contravariantly assignable — no cast needed.
+tabPauseMap.onChanged((key, value: TabPause | undefined) => {
+  const tabId = Number(key);
+  if (!Number.isInteger(tabId)) {
+    return;
+  }
+  if (value === undefined) {
+    tabPauses.delete(tabId);
+  } else {
+    tabPauses.set(tabId, value);
+  }
+  const paused = isPauseActive(tabPauses.get(tabId) ?? null, Date.now());
+  const message: TabPauseChangedMessage = { type: "tab-pause-changed", paused };
+  chrome.tabs.sendMessage(tabId, message).catch(() => {
+    // Tab has no content script (restricted URL) or has closed — ignore.
+  });
+  refreshBadge(tabId);
+});
+// Hydrate the cache from the session store so a service-worker restart doesn't
+// drop a still-active pause from the toolbar signal. Async generator over the
+// map's entries; tabIds are the secondary keys.
+// eslint-disable-next-line unicorn/prefer-top-level-await -- IIFE bundle, no TLA
+void (async () => {
+  try {
+    for await (const [key, value] of tabPauseMap.entries()) {
+      const tabId = Number(key);
+      if (Number.isInteger(tabId)) {
+        tabPauses.set(tabId, value);
+      }
+    }
+    refreshAllTabs();
+  } catch {
+    // Session storage unreadable at startup — the caches stay empty and the
+    // signal fails open to "protected", same posture as the other seeds.
+  }
+})();
+
 // When a user disables one of the detection-producing rules mid-session,
 // drop the now-stale entries from every tab so the popup matches the
 // current rule selection. Detections for the other (still-enabled) rule
@@ -452,6 +528,33 @@ chrome.runtime.onMessage.addListener(
       const url = sender.tab?.url ?? null;
       sendResponse({ url });
       return undefined;
+    }
+
+    if (message.type === "get-tab-pause") {
+      // Content scripts ask this once at rule-engine init to seed the
+      // tab-scoped recovery pause (ADR-0019). Read the session store directly
+      // rather than the in-memory cache so a request that lands before startup
+      // hydration still resolves accurately. The background applies the
+      // `expiresAt` check so the content side only ever sees a boolean.
+      const tabId = sender.tab?.id;
+      if (typeof tabId !== "number") {
+        const response: GetTabPauseResponse = { paused: false };
+        sendResponse(response);
+        return undefined;
+      }
+      void tabPauseMap
+        .get(String(tabId))
+        .then((value) => {
+          const response: GetTabPauseResponse = {
+            paused: isPauseActive(value ?? null, Date.now()),
+          };
+          sendResponse(response);
+        })
+        .catch(() => {
+          const response: GetTabPauseResponse = { paused: false };
+          sendResponse(response);
+        });
+      return true;
     }
 
     if (message.type === "inject-webdriver-probe") {

--- a/extension/src/lib/__tests__/tab-pause.property.test.ts
+++ b/extension/src/lib/__tests__/tab-pause.property.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Property tests for the tab-pause liveness check. Two invariants the example
+// tests can't exhaust:
+//   - A no-time-limit pause is active at every instant.
+//   - A timed pause is active exactly when its deadline is strictly in the
+//     future, for any deadline/now pair.
+
+import fc from "fast-check";
+import type { TabPause } from "../tab-pause";
+import { isPauseActive } from "../tab-pause";
+
+const scope = fc.constantFrom<TabPause["scope"]>("page", "tab");
+
+describe("isPauseActive properties", () => {
+  it("a no-time-limit pause is active at every instant", () => {
+    fc.assert(
+      fc.property(scope, fc.integer(), (s, now) => {
+        expect(isPauseActive({ scope: s, expiresAt: null }, now)).toBe(true);
+      }),
+    );
+  });
+
+  it("a timed pause is active iff its deadline is in the future", () => {
+    fc.assert(
+      fc.property(scope, fc.integer(), fc.integer(), (s, expiresAt, now) => {
+        expect(isPauseActive({ scope: s, expiresAt }, now)).toBe(
+          expiresAt > now,
+        );
+      }),
+    );
+  });
+});

--- a/extension/src/lib/__tests__/tab-pause.test.ts
+++ b/extension/src/lib/__tests__/tab-pause.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import {
+  isPauseActive,
+  SNOOZE_1_HOUR_MS,
+  SNOOZE_15_MIN_MS,
+  TAB_PAUSE_STORAGE_KEY,
+} from "../tab-pause";
+
+const NOW = 1_700_000_000_000;
+
+describe("isPauseActive", () => {
+  it("is not active for a missing pause", () => {
+    expect(isPauseActive(null, NOW)).toBe(false);
+    expect(isPauseActive(undefined, NOW)).toBe(false);
+  });
+
+  it("is active for a no-time-limit pause (reveal / pause-this-tab)", () => {
+    expect(isPauseActive({ scope: "page", expiresAt: null }, NOW)).toBe(true);
+    expect(isPauseActive({ scope: "tab", expiresAt: null }, NOW)).toBe(true);
+  });
+
+  it("is active while a timed snooze still has time left", () => {
+    expect(isPauseActive({ scope: "tab", expiresAt: NOW + 1 }, NOW)).toBe(true);
+  });
+
+  it("is not active once a timed snooze has elapsed", () => {
+    // The deadline itself counts as expired — strictly-greater semantics.
+    expect(isPauseActive({ scope: "tab", expiresAt: NOW }, NOW)).toBe(false);
+    expect(isPauseActive({ scope: "tab", expiresAt: NOW - 1 }, NOW)).toBe(
+      false,
+    );
+  });
+
+  it("fails safe (not active) on a malformed expiresAt", () => {
+    expect(
+      isPauseActive(
+        { scope: "tab", expiresAt: undefined as unknown as number },
+        NOW,
+      ),
+    ).toBe(false);
+    expect(
+      isPauseActive(
+        { scope: "tab", expiresAt: "soon" as unknown as number },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("snooze constants", () => {
+  it("encodes the two presets in milliseconds", () => {
+    expect(SNOOZE_15_MIN_MS).toBe(15 * 60 * 1000);
+    expect(SNOOZE_1_HOUR_MS).toBe(60 * 60 * 1000);
+  });
+
+  it("namespaces the storage key", () => {
+    expect(TAB_PAUSE_STORAGE_KEY).toMatch(/^agent-browser-shield\./);
+  });
+});

--- a/extension/src/lib/__tests__/toolbar-protection.test.ts
+++ b/extension/src/lib/__tests__/toolbar-protection.test.ts
@@ -73,6 +73,38 @@ describe("computeProtectionState", () => {
       }),
     ).toEqual({ off: false });
   });
+
+  it("is off (paused) when the tab-scoped recovery pause is active", () => {
+    expect(
+      computeProtectionState({
+        enforcementEnabled: true,
+        tabUrl: "https://allowed.test/page",
+        denylist: DENYLIST,
+        paused: true,
+      }),
+    ).toEqual({ off: true, reason: "paused" });
+  });
+
+  it("reports the durable site reason when both denylisted and paused", () => {
+    expect(
+      computeProtectionState({
+        enforcementEnabled: true,
+        tabUrl: "https://denied.test/checkout",
+        denylist: DENYLIST,
+        paused: true,
+      }),
+    ).toEqual({ off: true, reason: "site" });
+  });
+
+  it("treats a missing paused flag as not paused", () => {
+    expect(
+      computeProtectionState({
+        enforcementEnabled: true,
+        tabUrl: "https://allowed.test/page",
+        denylist: [],
+      }),
+    ).toEqual({ off: false });
+  });
 });
 
 describe("actionTitle", () => {
@@ -89,6 +121,12 @@ describe("actionTitle", () => {
       "on this site",
     );
   });
+
+  it("names the tab-scoped pause when protection is paused", () => {
+    expect(actionTitle({ off: true, reason: "paused" })).toContain(
+      "paused on this tab",
+    );
+  });
 });
 
 describe("protectionAppearanceKey", () => {
@@ -96,10 +134,13 @@ describe("protectionAppearanceKey", () => {
     expect(protectionAppearanceKey({ off: false })).toBe("on");
   });
 
-  it("distinguishes the two off reasons so a global→site flip repaints", () => {
-    expect(protectionAppearanceKey({ off: true, reason: "global" })).not.toBe(
+  it("distinguishes the off reasons so a global→site→paused flip repaints", () => {
+    const keys = new Set([
+      protectionAppearanceKey({ off: true, reason: "global" }),
       protectionAppearanceKey({ off: true, reason: "site" }),
-    );
+      protectionAppearanceKey({ off: true, reason: "paused" }),
+    ]);
+    expect(keys.size).toBe(3);
   });
 });
 

--- a/extension/src/lib/detection-messages.ts
+++ b/extension/src/lib/detection-messages.ts
@@ -87,6 +87,30 @@ export interface GetTabRuleCountsResponse {
   detections: DetectionPayload[];
 }
 
+// Content-script ↔ background messages for the tab-scoped enforcement pause
+// (ADR-0019). The pause lives in `chrome.storage.session` keyed by tabId —
+// which content scripts can't read and is keyed by a tabId they don't know — so
+// the background resolves liveness for them. `get-tab-pause` is the init fetch
+// a content script makes when its rule engine starts; `tab-pause-changed` is
+// the background's push when the popup edits the pause, so a still-open page
+// reveals (or, on manual resume, re-enforces) without waiting for a reload.
+export interface GetTabPauseRequest {
+  type: "get-tab-pause";
+}
+
+export interface GetTabPauseResponse {
+  // Resolved liveness for the requesting frame's tab — the background applies
+  // the `expiresAt` check so the content side never sees the raw record.
+  paused: boolean;
+}
+
+export interface TabPauseChangedMessage {
+  type: "tab-pause-changed";
+  // New resolved liveness for the tab, carried in the message so the content
+  // script needn't round-trip back for the value.
+  paused: boolean;
+}
+
 // Dev-mode structured trace of every rule-driven mutation. Captured only
 // when the user enables the "Debug trace" toggle in the popup; gated at
 // emission by `debug-trace.ts` so a disabled toggle drops the work

--- a/extension/src/lib/effective-enforcement.ts
+++ b/extension/src/lib/effective-enforcement.ts
@@ -24,6 +24,11 @@
 // match is evaluated against the tab's top-frame URL and subframes
 // inherit.
 
+import type {
+  GetTabPauseRequest,
+  GetTabPauseResponse,
+  TabPauseChangedMessage,
+} from "./detection-messages";
 import { enforcementStorage, subscribeEnforcementEnabled } from "./enforcement";
 import { isTopFrame } from "./frame";
 import { matchesDenylist, siteDenylistStorage } from "./site-denylist";
@@ -31,6 +36,15 @@ import { matchesDenylist, siteDenylistStorage } from "./site-denylist";
 let cachedTopFrameUrl: string | null = null;
 let cachedGlobal = true;
 let cachedDenylist: string[] = [];
+// Tab-scoped recovery pause (ADR-0019). Unlike `cachedGlobal`/`cachedDenylist`,
+// this isn't storage-backed on the content side — content scripts can't read
+// `chrome.storage.session` and don't know their own tabId — so it's seeded by a
+// `get-tab-pause` round-trip at init and updated by `tab-pause-changed`
+// broadcasts. A *timed* snooze expiring produces no broadcast, so the open page
+// stays revealed until its next navigation re-reads fresh state at init
+// ("resume on next navigation"); only an explicit popup edit (pause/reveal, or
+// "Resume now") flips this mid-page.
+let cachedTabPaused = false;
 let lastEffective = true;
 const listeners = new Set<(enabled: boolean) => void>();
 
@@ -44,6 +58,9 @@ function readTopFrameUrl(): string | null {
 
 function computeEffective(): boolean {
   if (!cachedGlobal) {
+    return false;
+  }
+  if (cachedTabPaused) {
     return false;
   }
   const url = readTopFrameUrl();
@@ -90,20 +107,44 @@ async function fetchTopFrameUrl(): Promise<string | null> {
   return null;
 }
 
+// Unlike the URL fetch, every frame asks — the pause applies to the whole tab,
+// and the background resolves it from `sender.tab.id` regardless of frame.
+async function fetchTabPaused(): Promise<boolean> {
+  try {
+    const response: unknown = await chrome.runtime.sendMessage({
+      type: "get-tab-pause",
+    } satisfies GetTabPauseRequest);
+    if (
+      response &&
+      typeof response === "object" &&
+      "paused" in response &&
+      typeof (response as GetTabPauseResponse).paused === "boolean"
+    ) {
+      return (response as GetTabPauseResponse).paused;
+    }
+  } catch {
+    // Background unreachable → assume not paused (fail-open to protected),
+    // matching the URL fetch's posture.
+  }
+  return false;
+}
+
 // Resolves to the current effective enforcement boolean and installs the
 // underlying storage subscriptions. Idempotent: callers (rule-engine) only
 // call this once, but a second call would re-fetch + re-subscribe without
 // duplicating listeners (storage subscriptions are scoped to AbortControllers
 // held by the chrome-storage-value wrapper).
 export async function initEffectiveEnforcement(): Promise<boolean> {
-  const [global, denylist, topUrl] = await Promise.all([
+  const [global, denylist, topUrl, tabPaused] = await Promise.all([
     enforcementStorage.get(),
     siteDenylistStorage.get(),
     fetchTopFrameUrl(),
+    fetchTabPaused(),
   ]);
   cachedGlobal = global;
   cachedDenylist = denylist;
   cachedTopFrameUrl = topUrl;
+  cachedTabPaused = tabPaused;
   lastEffective = computeEffective();
 
   subscribeEnforcementEnabled((next) => {
@@ -113,6 +154,20 @@ export async function initEffectiveEnforcement(): Promise<boolean> {
   siteDenylistStorage.subscribe((next) => {
     cachedDenylist = next;
     notify();
+  });
+  // The background pushes the tab's pause liveness on every popup edit. Each
+  // frame listens independently so its own rule engine reveals / re-applies.
+  chrome.runtime.onMessage.addListener((message: unknown) => {
+    if (
+      message &&
+      typeof message === "object" &&
+      (message as { type?: unknown }).type === "tab-pause-changed" &&
+      typeof (message as TabPauseChangedMessage).paused === "boolean"
+    ) {
+      cachedTabPaused = (message as TabPauseChangedMessage).paused;
+      notify();
+    }
+    return undefined;
   });
 
   return lastEffective;

--- a/extension/src/lib/tab-pause.ts
+++ b/extension/src/lib/tab-pause.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Tab-scoped, non-persistent enforcement pause — the "this page looks broken"
+// recovery path (ADR-0019, spec 0010 §"Recovery controls"). Two flavors, both
+// distinct from the per-site denylist (ADR-0018), which is permanent and the
+// thing a daily driver never gets around to cleaning up:
+//
+//   - "Reveal everything on this page" (scope "page") — the zero-decision
+//     panic button. Reveals every hidden element now and stops re-hiding for
+//     the current page load. Cleared on the tab's next top-frame navigation.
+//   - Time-boxed snooze (scope "tab") — "Pause for this tab" / "15 min" /
+//     "1 hour". Survives navigation within the tab so a multi-page flow (a
+//     checkout) stays unblocked, until `expiresAt` or tab close.
+//
+// Stored in `chrome.storage.session` keyed by tabId via webext-storage's
+// `StorageItemMap`: durable across MV3 service-worker restarts and auto-cleared
+// on browser restart — exactly the ephemerality we want, with none of the
+// denylist's persistent cleanup debt. The popup and background read/write this
+// directly; content scripts can't read the `session` area (and don't know their
+// own tabId), so the background bridges changes to them by message.
+
+import { StorageItemMap } from "webext-storage";
+
+export const TAB_PAUSE_STORAGE_KEY = "agent-browser-shield.tab-pause";
+
+export interface TabPause {
+  // "page" clears on the next top-frame navigation; "tab" survives navigation
+  // within the tab until `expiresAt` or the tab closes.
+  scope: "page" | "tab";
+  // Epoch ms after which the pause is no longer active. `null` = no time limit
+  // (a "page" reveal that lasts the page load, or a "tab" pause that lasts
+  // until the tab closes).
+  expiresAt: number | null;
+}
+
+// The two timed-snooze presets, in ms.
+export const SNOOZE_15_MIN_MS = 15 * 60 * 1000;
+export const SNOOZE_1_HOUR_MS = 60 * 60 * 1000;
+
+// Secondary key is the tabId as a string. The raw storage key webext-storage
+// writes is `${TAB_PAUSE_STORAGE_KEY}:::${tabId}`.
+export const tabPauseMap = new StorageItemMap<TabPause>(TAB_PAUSE_STORAGE_KEY, {
+  area: "session",
+});
+
+// True iff the pause exists and hasn't timed out. `now` is injected rather than
+// read internally so the content script, the popup countdown, and the
+// background all evaluate against one clock and the function stays trivially
+// unit-testable. A malformed record (missing/!number `expiresAt`) resolves to
+// not-active — fail-open to "protected", the safe default.
+export function isPauseActive(
+  pause: TabPause | null | undefined,
+  now: number,
+): boolean {
+  if (!pause) {
+    return false;
+  }
+  if (pause.expiresAt === null) {
+    return true;
+  }
+  return typeof pause.expiresAt === "number" && pause.expiresAt > now;
+}

--- a/extension/src/lib/toolbar-protection.ts
+++ b/extension/src/lib/toolbar-protection.ts
@@ -16,23 +16,33 @@ import { matchesDenylist } from "./site-denylist";
 
 export type ProtectionState =
   | { readonly off: false }
-  | { readonly off: true; readonly reason: "global" | "site" };
+  | { readonly off: true; readonly reason: "global" | "site" | "paused" };
 
 // `tabUrl` is null when the background hasn't yet learned the tab's URL
 // (e.g. a tab open before the service worker started, before the first
 // tabs.get / onUpdated). Treat unknown as protected — fail open, matching
 // the rule engine, rather than flashing an "off" badge on a tab whose state
 // we can't actually determine.
+//
+// `paused` is the resolved liveness of the tab-scoped recovery pause (ADR-0019)
+// — the background applies the `expiresAt` check before calling. It's checked
+// after the denylist so a denylisted-and-also-paused tab reports the more
+// durable `site` reason; in practice the popup only offers the pause when the
+// tab isn't denylisted, so the two don't overlap.
 export function computeProtectionState(input: {
   enforcementEnabled: boolean;
   tabUrl: string | null;
   denylist: readonly string[];
+  paused?: boolean;
 }): ProtectionState {
   if (!input.enforcementEnabled) {
     return { off: true, reason: "global" };
   }
   if (input.tabUrl !== null && matchesDenylist(input.tabUrl, input.denylist)) {
     return { off: true, reason: "site" };
+  }
+  if (input.paused) {
+    return { off: true, reason: "paused" };
   }
   return { off: false };
 }
@@ -67,9 +77,17 @@ export function actionTitle(state: ProtectionState): string {
   if (!state.off) {
     return "Agent Browser Shield";
   }
-  return state.reason === "global"
-    ? "Agent Browser Shield — enforcement off (all tabs)"
-    : "Agent Browser Shield — enforcement off on this site";
+  switch (state.reason) {
+    case "global": {
+      return "Agent Browser Shield — enforcement off (all tabs)";
+    }
+    case "site": {
+      return "Agent Browser Shield — enforcement off on this site";
+    }
+    case "paused": {
+      return "Agent Browser Shield — protection paused on this tab";
+    }
+  }
 }
 
 // Stable key for the icon/title appearance so the background only issues

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -110,16 +110,34 @@
         outline: 2px solid #2563eb;
         outline-offset: 2px;
       }
-      .site-disable {
+      /* Unified protection card: one bordered box holding a scope ladder of
+         rows (ProtectionSection). The row divider is an adjacent-sibling rule
+         so it appears only when both the recovery and site rows are present. */
+      .protection {
         margin: 0 0 12px;
-        padding: 8px 10px;
         border: 1px solid #e4e4e7;
         border-radius: 6px;
         background: #fafafa;
+        overflow: hidden;
       }
-      .site-disable--off {
-        border-color: #fde68a;
+      .protection__row {
+        padding: 8px 10px;
+      }
+      .protection__row + .protection__row {
+        border-top: 1px solid #ececef;
+      }
+      .protection__row--active,
+      .protection__row--off {
         background: #fffbeb;
+      }
+      .protection__cap {
+        display: block;
+        margin: 0 0 6px;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #9ca3af;
       }
       .site-disable__button {
         display: block;
@@ -133,14 +151,14 @@
         border-radius: 6px;
         cursor: pointer;
       }
-      .site-disable--off .site-disable__button {
+      .protection__row--off .site-disable__button {
         color: #92400e;
         border-color: #92400e;
       }
       .site-disable__button:hover {
         background: #eff6ff;
       }
-      .site-disable--off .site-disable__button:hover {
+      .protection__row--off .site-disable__button:hover {
         background: #fef3c7;
       }
       .site-disable__button:disabled {
@@ -155,35 +173,26 @@
         color: #555;
         line-height: 1.3;
       }
-      .site-disable--off .site-disable__hint {
+      .protection__row--off .site-disable__hint {
         color: #92400e;
       }
-      .recovery {
-        margin: 0 0 12px;
-        padding: 8px 10px;
-        border: 1px solid #e4e4e7;
-        border-radius: 6px;
-        background: #fafafa;
-      }
-      .recovery--active {
-        border-color: #fde68a;
-        background: #fffbeb;
-      }
+      /* The panic button is the only orange element in the popup; an outline
+         (not a fill) keeps it findable without letting the most ephemeral,
+         narrowest-scope action dominate the card. */
       .recovery__panic {
         display: block;
         width: 100%;
         padding: 8px 10px;
         font: inherit;
         font-weight: 600;
-        color: #fff;
-        background: #d97706;
+        color: #b45309;
+        background: #fff;
         border: 1px solid #d97706;
         border-radius: 6px;
         cursor: pointer;
       }
       .recovery__panic:hover {
-        background: #b45309;
-        border-color: #b45309;
+        background: #fff7ed;
       }
       .recovery__panic:focus-visible {
         outline: 2px solid #d97706;

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -158,6 +158,104 @@
       .site-disable--off .site-disable__hint {
         color: #92400e;
       }
+      .recovery {
+        margin: 0 0 12px;
+        padding: 8px 10px;
+        border: 1px solid #e4e4e7;
+        border-radius: 6px;
+        background: #fafafa;
+      }
+      .recovery--active {
+        border-color: #fde68a;
+        background: #fffbeb;
+      }
+      .recovery__panic {
+        display: block;
+        width: 100%;
+        padding: 8px 10px;
+        font: inherit;
+        font-weight: 600;
+        color: #fff;
+        background: #d97706;
+        border: 1px solid #d97706;
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      .recovery__panic:hover {
+        background: #b45309;
+        border-color: #b45309;
+      }
+      .recovery__panic:focus-visible {
+        outline: 2px solid #d97706;
+        outline-offset: 2px;
+      }
+      .recovery__snooze {
+        margin: 8px 0 0;
+      }
+      .recovery__snooze-label {
+        display: block;
+        margin: 0 0 4px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #555;
+      }
+      .recovery__snooze-buttons {
+        display: flex;
+        gap: 6px;
+      }
+      .recovery__snooze-button {
+        flex: 1;
+        padding: 5px 4px;
+        font: inherit;
+        font-size: 12px;
+        font-weight: 600;
+        color: #2563eb;
+        background: #fff;
+        border: 1px solid #2563eb;
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      .recovery__snooze-button:hover {
+        background: #eff6ff;
+      }
+      .recovery__snooze-button:focus-visible {
+        outline: 2px solid #2563eb;
+        outline-offset: 2px;
+      }
+      .recovery__hint {
+        margin: 8px 0 0;
+        font-size: 11px;
+        color: #666;
+        line-height: 1.3;
+      }
+      .recovery__status {
+        margin: 0 0 8px;
+        font-size: 12px;
+        font-weight: 600;
+        color: #92400e;
+        line-height: 1.3;
+      }
+      .recovery__resume {
+        display: block;
+        width: 100%;
+        padding: 6px 8px;
+        font: inherit;
+        font-weight: 600;
+        color: #92400e;
+        background: #fff;
+        border: 1px solid #92400e;
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      .recovery__resume:hover {
+        background: #fef3c7;
+      }
+      .recovery__resume:focus-visible {
+        outline: 2px solid #92400e;
+        outline-offset: 2px;
+      }
       .open-options {
         display: block;
         width: 100%;

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -10,8 +10,7 @@ import { useChromeStorageValue } from "../lib/use-chrome-storage-value";
 import { DebugTraceSection } from "./DebugTraceSection";
 import { DetectionsSection } from "./DetectionsSection";
 import { PerRuleCountsSection } from "./PerRuleCountsSection";
-import { RecoverySection } from "./RecoverySection";
-import { SiteDisableSection } from "./SiteDisableSection";
+import { ProtectionSection } from "./ProtectionSection";
 import { useTabDebugTrace } from "./use-tab-debug-trace";
 import { useTabActivity } from "./use-tab-detections";
 
@@ -75,10 +74,7 @@ export function Popup() {
         )}
       </div>
       {enforcementEnabled && (
-        <SiteDisableSection activeTabUrl={activeTabUrl} denylist={denylist} />
-      )}
-      {enforcementEnabled && (
-        <RecoverySection
+        <ProtectionSection
           activeTabId={activeTabId}
           activeTabUrl={activeTabUrl}
           denylist={denylist}

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -10,6 +10,7 @@ import { useChromeStorageValue } from "../lib/use-chrome-storage-value";
 import { DebugTraceSection } from "./DebugTraceSection";
 import { DetectionsSection } from "./DetectionsSection";
 import { PerRuleCountsSection } from "./PerRuleCountsSection";
+import { RecoverySection } from "./RecoverySection";
 import { SiteDisableSection } from "./SiteDisableSection";
 import { useTabDebugTrace } from "./use-tab-debug-trace";
 import { useTabActivity } from "./use-tab-detections";
@@ -75,6 +76,13 @@ export function Popup() {
       </div>
       {enforcementEnabled && (
         <SiteDisableSection activeTabUrl={activeTabUrl} denylist={denylist} />
+      )}
+      {enforcementEnabled && (
+        <RecoverySection
+          activeTabId={activeTabId}
+          activeTabUrl={activeTabUrl}
+          denylist={denylist}
+        />
       )}
       <button
         type="button"

--- a/extension/src/popup/ProtectionSection.tsx
+++ b/extension/src/popup/ProtectionSection.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// The unified "turn protection off" card (spec 0010 §"Recovery controls",
+// ADR-0018/0019). One bordered card holding a scope ladder of every escape
+// hatch, so the four controls read as one family ordered narrow→broad instead
+// of four competing cards with mismatched visual weight:
+//
+//   - "This tab · temporary" (RecoverySection) — the in-the-moment "this page
+//     looks broken" escapes: reveal-everything + a tab-scoped snooze. Ephemeral.
+//   - "This site · saved" (SiteDisableSection) — the deliberate, persistent
+//     per-host denylist entry.
+//
+// The global Enforcement master switch stays in its own card above this one
+// (Popup.tsx); this card only appears while enforcement is on.
+//
+// Each child keeps its own render-null logic (loading, non-content schemes, a
+// denylisted host where there's nothing left to recover). The card itself
+// mirrors only the shared loading guard so it never renders as an empty box;
+// once the tab URL and denylist have loaded, SiteDisableSection always renders
+// at least the disable row, so the card always has content. The row divider is
+// a pure CSS adjacent-sibling rule, so it appears only when both rows are present.
+
+import { RecoverySection } from "./RecoverySection";
+import { SiteDisableSection } from "./SiteDisableSection";
+
+export function ProtectionSection({
+  activeTabId,
+  activeTabUrl,
+  denylist,
+}: {
+  activeTabId: number | null;
+  activeTabUrl: string | null;
+  denylist: string[] | null;
+}) {
+  if (activeTabUrl === null || denylist === null) {
+    return null;
+  }
+  return (
+    <div className="protection">
+      <RecoverySection
+        activeTabId={activeTabId}
+        activeTabUrl={activeTabUrl}
+        denylist={denylist}
+      />
+      <SiteDisableSection activeTabUrl={activeTabUrl} denylist={denylist} />
+    </div>
+  );
+}

--- a/extension/src/popup/RecoverySection.tsx
+++ b/extension/src/popup/RecoverySection.tsx
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// The "this page looks broken" recovery controls (ADR-0019, spec 0010
+// §"Recovery controls"). Two tab-scoped, non-persistent escapes that are
+// deliberately distinct from "Disable on this site" (which writes a permanent
+// denylist entry):
+//   - "Reveal everything on this page" — the panic button. One click reveals
+//     all hidden content for the current page load; a reload restores it.
+//   - A snooze — pause protection for this tab, or for 15 min / 1 hour, so a
+//     daily driver can get through a checkout without leaving a denylist entry
+//     behind to clean up.
+//
+// Writes the active tab's entry in `tabPauseMap` directly, exactly as
+// `SiteDisableSection` writes `siteDenylistStorage`. Renders nothing while the
+// tab is still loading, on non-content schemes, or when the site is already
+// denylisted (rules don't run there, so there's nothing to recover).
+
+import { findMatchingPatterns, isContentSchemeUrl } from "../lib/site-denylist";
+import {
+  SNOOZE_1_HOUR_MS,
+  SNOOZE_15_MIN_MS,
+  tabPauseMap,
+} from "../lib/tab-pause";
+import { useTabPause } from "./use-tab-pause";
+
+// mm:ss, or h:mm:ss past an hour. `ceil` so a fresh "15 min" snooze reads
+// "15:00" rather than "14:59".
+function formatRemaining(ms: number): string {
+  const totalSeconds = Math.ceil(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const mm = String(minutes).padStart(2, "0");
+  const ss = String(seconds).padStart(2, "0");
+  return hours > 0 ? `${hours}:${mm}:${ss}` : `${minutes}:${ss}`;
+}
+
+export function RecoverySection({
+  activeTabId,
+  activeTabUrl,
+  denylist,
+}: {
+  activeTabId: number | null;
+  activeTabUrl: string | null;
+  denylist: string[] | null;
+}) {
+  const { pause, active, remainingMs } = useTabPause(activeTabId);
+
+  if (activeTabId === null || activeTabUrl === null || denylist === null) {
+    return null;
+  }
+  // The shield doesn't run on browser-internal URLs, and a denylisted site is
+  // already fully off — in both cases there's nothing to reveal or snooze, and
+  // SiteDisableSection already explains the state. Stay out of the way.
+  if (
+    !isContentSchemeUrl(activeTabUrl) ||
+    findMatchingPatterns(activeTabUrl, denylist).length > 0
+  ) {
+    return null;
+  }
+
+  const key = String(activeTabId);
+  const revealEverything = (): void => {
+    void tabPauseMap.set(key, { scope: "page", expiresAt: null });
+  };
+  const snooze = (durationMs: number | null): void => {
+    void tabPauseMap.set(key, {
+      scope: "tab",
+      expiresAt: durationMs === null ? null : Date.now() + durationMs,
+    });
+  };
+  const resume = (): void => {
+    void tabPauseMap.remove(key);
+  };
+
+  if (active && pause) {
+    let status: string;
+    if (pause.scope === "page") {
+      status =
+        "Everything on this page is revealed. Reload the page to restore protection.";
+    } else if (remainingMs === null) {
+      status = "Protection is paused on this tab.";
+    } else {
+      status = `Protection is paused — ${formatRemaining(remainingMs)} left.`;
+    }
+    return (
+      <div className="recovery recovery--active">
+        <p className="recovery__status">{status}</p>
+        <button type="button" className="recovery__resume" onClick={resume}>
+          Resume now
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="recovery">
+      <button
+        type="button"
+        className="recovery__panic"
+        onClick={revealEverything}
+      >
+        Reveal everything on this page
+      </button>
+      <div className="recovery__snooze">
+        <span className="recovery__snooze-label">Pause protection</span>
+        <div className="recovery__snooze-buttons">
+          <button
+            type="button"
+            className="recovery__snooze-button"
+            onClick={() => {
+              snooze(null);
+            }}
+          >
+            This tab
+          </button>
+          <button
+            type="button"
+            className="recovery__snooze-button"
+            onClick={() => {
+              snooze(SNOOZE_15_MIN_MS);
+            }}
+          >
+            15 min
+          </button>
+          <button
+            type="button"
+            className="recovery__snooze-button"
+            onClick={() => {
+              snooze(SNOOZE_1_HOUR_MS);
+            }}
+          >
+            1 hour
+          </button>
+        </div>
+      </div>
+      <p className="recovery__hint">
+        Temporary and only for this tab — nothing is saved. To pause a site for
+        good, use “Disable on this site” above.
+      </p>
+    </div>
+  );
+}

--- a/extension/src/popup/RecoverySection.tsx
+++ b/extension/src/popup/RecoverySection.tsx
@@ -2,9 +2,10 @@
 // Licensed under PolyForm Shield 1.0.0 — see LICENSE.
 
 // The "this page looks broken" recovery controls (ADR-0019, spec 0010
-// §"Recovery controls"). Two tab-scoped, non-persistent escapes that are
-// deliberately distinct from "Disable on this site" (which writes a permanent
-// denylist entry):
+// §"Recovery controls"). The "this tab · temporary" row of the unified
+// protection card (ProtectionSection). Two tab-scoped, non-persistent escapes,
+// deliberately distinct from the "this site · saved" row below ("Disable on
+// this site", which writes a permanent denylist entry):
 //   - "Reveal everything on this page" — the panic button. One click reveals
 //     all hidden content for the current page load; a reload restores it.
 //   - A snooze — pause protection for this tab, or for 15 min / 1 hour, so a
@@ -14,7 +15,8 @@
 // Writes the active tab's entry in `tabPauseMap` directly, exactly as
 // `SiteDisableSection` writes `siteDenylistStorage`. Renders nothing while the
 // tab is still loading, on non-content schemes, or when the site is already
-// denylisted (rules don't run there, so there's nothing to recover).
+// denylisted (rules don't run there, so there's nothing to recover) — in which
+// case the card shows only the site row.
 
 import { findMatchingPatterns, isContentSchemeUrl } from "../lib/site-denylist";
 import {
@@ -85,7 +87,7 @@ export function RecoverySection({
       status = `Protection is paused — ${formatRemaining(remainingMs)} left.`;
     }
     return (
-      <div className="recovery recovery--active">
+      <div className="protection__row protection__row--active">
         <p className="recovery__status">{status}</p>
         <button type="button" className="recovery__resume" onClick={resume}>
           Resume now
@@ -95,7 +97,8 @@ export function RecoverySection({
   }
 
   return (
-    <div className="recovery">
+    <div className="protection__row">
+      <span className="protection__cap">This tab · temporary</span>
       <button
         type="button"
         className="recovery__panic"
@@ -104,7 +107,7 @@ export function RecoverySection({
         Reveal everything on this page
       </button>
       <div className="recovery__snooze">
-        <span className="recovery__snooze-label">Pause protection</span>
+        <span className="recovery__snooze-label">Or pause this tab</span>
         <div className="recovery__snooze-buttons">
           <button
             type="button"
@@ -113,7 +116,7 @@ export function RecoverySection({
               snooze(null);
             }}
           >
-            This tab
+            Until closed
           </button>
           <button
             type="button"
@@ -135,10 +138,7 @@ export function RecoverySection({
           </button>
         </div>
       </div>
-      <p className="recovery__hint">
-        Temporary and only for this tab — nothing is saved. To pause a site for
-        good, use “Disable on this site” above.
-      </p>
+      <p className="recovery__hint">Temporary — nothing is saved.</p>
     </div>
   );
 }

--- a/extension/src/popup/SiteDisableSection.tsx
+++ b/extension/src/popup/SiteDisableSection.tsx
@@ -9,9 +9,10 @@ import {
   siteDenylistStorage,
 } from "../lib/site-denylist";
 
-// One control: a toggle that disables / re-enables the whole rule set on
-// the active tab's host. ADR-0018 §"Decision Outcome" — the affordance is
-// scoped per-site, not per-rule; "Re-enable on this site" removes every
+// The "this site · saved" row of the unified protection card
+// (ProtectionSection): one control that disables / re-enables the whole rule
+// set on the active tab's host. ADR-0018 §"Decision Outcome" — the affordance
+// is scoped per-site, not per-rule; "Re-enable on this site" removes every
 // pattern in the denylist that matches the active tab URL.
 //
 // Renders nothing while the tab URL or denylist is still loading. Renders
@@ -29,7 +30,8 @@ export function SiteDisableSection({
   }
   if (!isContentSchemeUrl(activeTabUrl)) {
     return (
-      <div className="site-disable site-disable--unavailable">
+      <div className="protection__row">
+        <span className="protection__cap">This site · saved</span>
         <button
           type="button"
           className="site-disable__button"
@@ -70,11 +72,10 @@ export function SiteDisableSection({
   return (
     <div
       className={
-        denylisted
-          ? "site-disable site-disable--off"
-          : "site-disable site-disable--on"
+        denylisted ? "protection__row protection__row--off" : "protection__row"
       }
     >
+      <span className="protection__cap">This site · saved</span>
       <button
         type="button"
         className="site-disable__button"

--- a/extension/src/popup/use-tab-pause.ts
+++ b/extension/src/popup/use-tab-pause.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Popup-side view of the active tab's recovery pause (ADR-0019). The popup runs
+// at the extension origin, so unlike content scripts it can read the `session`
+// area directly: `tabPauseMap.get` for the initial value, `onChanged` for live
+// updates from the background or another popup. A 1s tick drives the snooze
+// countdown and flips `active` to false the moment a timed pause expires while
+// the popup is open.
+
+import { useEffect, useState } from "react";
+import type { TabPause } from "../lib/tab-pause";
+import { isPauseActive, tabPauseMap } from "../lib/tab-pause";
+
+const TICK_INTERVAL_MS = 1000;
+
+export interface TabPauseState {
+  // The active pause, or null when none is active (absent or expired).
+  pause: TabPause | null;
+  active: boolean;
+  // Milliseconds left on a timed snooze; null for a pause with no time limit
+  // ("page" reveal or "Pause for this tab"). Always null when not active.
+  remainingMs: number | null;
+}
+
+export function useTabPause(tabId: number | null): TabPauseState {
+  const [pause, setPause] = useState<TabPause | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (tabId === null) {
+      setPause(null);
+      return;
+    }
+    const key = String(tabId);
+    let cancelled = false;
+    void tabPauseMap.get(key).then((value) => {
+      if (!cancelled) {
+        setPause(value ?? null);
+      }
+    });
+    const controller = new AbortController();
+    // webext-storage types the change value as non-undefined, but it IS
+    // undefined when the entry was removed (resume / nav-clear / tab close).
+    // A wider param type is contravariantly assignable — no cast needed.
+    tabPauseMap.onChanged((changedKey, value: TabPause | undefined) => {
+      if (changedKey === key) {
+        setPause(value ?? null);
+      }
+    }, controller.signal);
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [tabId]);
+
+  useEffect(() => {
+    const intervalId = globalThis.setInterval(() => {
+      setNow(Date.now());
+    }, TICK_INTERVAL_MS);
+    return () => {
+      globalThis.clearInterval(intervalId);
+    };
+  }, []);
+
+  const active = isPauseActive(pause, now);
+  const remainingMs =
+    active && pause?.expiresAt != null
+      ? Math.max(0, pause.expiresAt - now)
+      : null;
+  return { pause: active ? pause : null, active, remainingMs };
+}

--- a/specs/0010-extension-ui-and-controls.md
+++ b/specs/0010-extension-ui-and-controls.md
@@ -35,6 +35,12 @@ all-or-nothing, and users pick "nothing."
 - As a **person hitting a false positive**, I want a one-click enforcement pause
   that disables every rule for every tab without losing my per-rule selections,
   so that I can finish my task and restore protection later.
+- As a **person whose shield just ate real content on this page**, I want a
+  one-click *Reveal everything on this page* panic button and a time-boxed
+  snooze (*this tab* / *15 min* / *1 hour*), both scoped to the tab and
+  automatically forgotten, so that I can recover the page or get through a
+  one-off checkout without hunting for a per-element reveal or leaving behind a
+  permanent denylist entry I'll never clean up.
 - As a **person whose shield is breaking one specific site**, I want a one-click
   *disable on this site* toggle in the popup that scopes the kill-switch to the
   active tab's host, so that I keep protection everywhere else without editing a
@@ -73,16 +79,19 @@ all-or-nothing, and users pick "nothing."
   count, the badge text falls back to `!` so the badge stays visible.
 - **FR-2a.** The toolbar action reflects per-tab **protection state** so a
   protected page and an unprotected page never look identical. A tab is *off*
-  when global enforcement is off (FR-5) **or** the active tab's top-frame URL
-  matches the per-site denylist (FR-7c). On an *off* tab the action shows the
-  greyed icon variant (`icons/icon-off-*.png`), an `off` badge in neutral grey
-  (`#6b7280` — deliberately not the amber detection color, so the three badge
-  meanings stay distinct), and a tooltip naming the scope (*"enforcement off
-  (all tabs)"* vs *"enforcement off on this site"*). The signal is recomputed
-  when enforcement toggles, the denylist changes, or the tab navigates; the
-  icon/tooltip are only re-issued when the on/off state flips, while the count
-  badge still refreshes on every rule-count message. The greyed icon is the
-  primary signal; the badge and tooltip reinforce it.
+  when global enforcement is off (FR-5), the active tab's top-frame URL matches
+  the per-site denylist (FR-7c), **or** a tab-scoped recovery pause is active
+  (FR-7e–FR-7h). On an *off* tab the action shows the greyed icon variant
+  (`icons/icon-off-*.png`), an `off` badge in neutral grey (`#6b7280` —
+  deliberately not the amber detection color, so the three badge meanings stay
+  distinct), and a tooltip naming the scope (*"enforcement off (all tabs)"* vs
+  *"enforcement off on this site"* vs *"protection paused on this tab"*). When a
+  tab is both denylisted and paused, the more durable *site* reason is reported.
+  The signal is recomputed when enforcement toggles, the denylist changes, the
+  recovery pause changes, or the tab navigates; the icon/tooltip are only
+  re-issued when the on/off state flips, while the count badge still refreshes
+  on every rule-count message. The greyed icon is the primary signal; the badge
+  and tooltip reinforce it.
 - **FR-3.** Top-level navigation drops stale per-frame counts so the new
   document starts from zero; content scripts in the new document report fresh
   numbers as rules run.
@@ -90,10 +99,11 @@ all-or-nothing, and users pick "nothing."
 ### Popup
 
 - **FR-4.** The popup renders a master **Enforcement** toggle, a **Site
-  disable** control (FR-7a), a **Configure rules** button that opens the Options
-  page, a **Heads up** detections section, a **Per-rule activity** section, a
-  **Debug trace** toggle, and an **Export** button (visible when the debug-trace
-  recorder is on).
+  disable** control (FR-7a), a **Recovery** control (*Reveal everything on this
+  page* + snooze, FR-7e–FR-7g), a **Configure rules** button that opens the
+  Options page, a **Heads up** detections section, a **Per-rule activity**
+  section, a **Debug trace** toggle, and an **Export** button (visible when the
+  debug-trace recorder is on).
 - **FR-5.** Toggling enforcement off pauses every rule for every tab. The
   per-rule selection is preserved in `chrome.storage` and restored when
   enforcement turns back on. The popup shows a hint when enforcement is off
@@ -137,6 +147,45 @@ all-or-nothing, and users pick "nothing."
   pushed to every frame in the tab. Subframes inherit the tab's enforcement
   state rather than matching their own URL against the denylist, so a denylisted
   top-frame pauses every frame regardless of cross-origin embedding.
+
+### Tab-scoped recovery and snooze
+
+Fast, reversible recovery for the "this page looks broken" case, distinct from
+the permanent per-site denylist (FR-7a). See
+[ADR-0019](../decisions/0019-tab-scoped-enforcement-pause.md).
+
+- **FR-7e.** The popup shows a *Reveal everything on this page* button when the
+  active tab is a content scheme (http/https/file) **and** not denylisted.
+  Clicking it writes a **page-scoped** recovery pause for the active tab, which
+  the rule engine treats exactly like enforcement-off: every hidden element is
+  revealed and re-hiding stops for the current page load. The pause is
+  non-persistent — cleared on the tab's next top-frame navigation, so a reload
+  restores protection. Nothing is written to the persistent denylist; this is
+  the zero-decision panic button, deliberately distinct from *Disable on this
+  site* (FR-7a).
+- **FR-7f.** The popup offers a time-boxed snooze with three presets: *Pause for
+  this tab* (no time limit, until the tab closes), *15 min*, and *1 hour*. A
+  snooze writes a **tab-scoped** recovery pause that survives navigation within
+  the tab — so a multi-page flow such as a checkout stays unblocked — until its
+  deadline passes or the tab closes.
+- **FR-7g.** While a recovery pause is active, the popup shows its status — for
+  a timed snooze, a live countdown of the time remaining — and a *Resume now*
+  control that clears the pause and re-engages protection immediately. When a
+  timed snooze expires on its own while the page is still open, the current page
+  stays revealed and protection re-engages on the **next navigation**: a timer
+  the user has forgotten never yanks content back mid-task.
+- **FR-7h.** The recovery pause is stored per tab in `chrome.storage.session`,
+  keyed by tabId — durable across service-worker restarts and auto-cleared on
+  browser restart, never persisted to disk (so there is no denylist-style
+  cleanup debt). Effective per-tab enforcement becomes
+  `globalEnforcement && !matchesAnyDenylistPattern(topFrameUrl) && !tabPaused`.
+  The popup offers the recovery controls only when the tab is actually enforced
+  (global on, not denylisted). Because content scripts can neither read the
+  `session` area nor know their own tabId, the background resolves liveness for
+  them: each content script seeds its state with a `get-tab-pause` message at
+  init, and the background pushes a `tab-pause-changed` message to every frame
+  in the tab when the popup edits the pause. A timed expiry produces no write
+  and hence no push — the mechanism behind FR-7g's resume-on-next-navigation.
 
 ### Options page
 
@@ -242,11 +291,12 @@ all-or-nothing, and users pick "nothing."
 - FR-1, FR-2, FR-3: `extension/src/background.ts` (`refreshBadge`,
   `recordFrameRuleCounts`, `recordDetection`, `clearTab`).
 - FR-2a: `extension/src/lib/toolbar-protection.ts` (pure
-  `computeProtectionState` / `actionTitle` / appearance constants, tested in
+  `computeProtectionState` / `actionTitle` / appearance constants, including the
+  `paused` reason, tested in
   `extension/src/lib/__tests__/toolbar-protection.test.ts`),
   `extension/src/background.ts` (`applyProtectionAppearance`, `refreshAllTabs`,
-  the `tabUrls` cache, and the enforcement/denylist subscriptions that drive
-  it), `extension/icons/icon-off.svg` (rendered to PNGs by
+  the `tabUrls` cache, and the enforcement/denylist/recovery-pause subscriptions
+  that drive it), `extension/icons/icon-off.svg` (rendered to PNGs by
   `extension/scripts/build-icons.ts`).
 - FR-4, FR-5, FR-6, FR-7: `extension/src/popup/Popup.tsx`,
   `extension/src/popup/PerRuleCountsSection.tsx`,
@@ -260,6 +310,18 @@ all-or-nothing, and users pick "nothing."
   `extension/src/background.ts` (per-tab effective enforcement computation +
   broadcast). See
   [ADR-0018](../decisions/0018-per-site-enforcement-denylist.md).
+- FR-7e, FR-7f, FR-7g, FR-7h: `extension/src/lib/tab-pause.ts` (the
+  `chrome.storage.session` `StorageItemMap` keyed by tabId + pure
+  `isPauseActive`
+  - snooze presets, tested in `extension/src/lib/__tests__/tab-pause.test.ts`
+    and `.property.test.ts`), `extension/src/popup/RecoverySection.tsx` (panic
+    button + snooze + *Resume now*), `extension/src/popup/use-tab-pause.ts`
+    (popup-side read
+  - countdown), `extension/src/lib/effective-enforcement.ts` (the third input to
+    effective enforcement, latched per page load), `extension/src/background.ts`
+    (the `tabPauses` cache, `get-tab-pause` handler, `tab-pause-changed` bridge,
+    and page-scope/expiry/tab-close clearing). See
+    [ADR-0019](../decisions/0019-tab-scoped-enforcement-pause.md).
 - FR-8, FR-9, FR-10: `extension/src/options/Options.tsx`,
   `extension/src/options/Section.tsx`, `extension/src/options/parse-config.ts`,
   `extension/src/lib/RuleList.tsx`, `extension/src/lib/storage.ts`,
@@ -299,7 +361,8 @@ all-or-nothing, and users pick "nothing."
 
 - ADRs: [ADR-0009](../decisions/0009-rule-defaults-and-build-time-overrides.md),
   [ADR-0013](../decisions/0013-background-worker-purity-canary.md),
-  [ADR-0018](../decisions/0018-per-site-enforcement-denylist.md).
+  [ADR-0018](../decisions/0018-per-site-enforcement-denylist.md),
+  [ADR-0019](../decisions/0019-tab-scoped-enforcement-pause.md).
 - Docs:
   [`docs/src/content/docs/install.md`](../docs/src/content/docs/install.md)
   §"Customizing defaults at build time".


### PR DESCRIPTION
## What

Two tab-scoped, **non-persistent** recovery controls in the popup for the "this page looks broken" case — deliberately distinct from the permanent *Disable on this site* denylist (ADR-0018):

- **Reveal everything on this page** — one-click panic button. Reveals everything the shield hid and stops re-hiding for the current page load. Page-scoped: cleared on the next top-frame navigation, so a reload restores protection.
- **Time-boxed snooze** — *Until closed* / *15 min* / *1 hour*. Tab-scoped: survives navigation within the tab (so a multi-page checkout stays unblocked) until expiry or tab close. The popup shows a live countdown and a *Resume now* button.

## Why

When a rule eats real content today, the only escapes are hunting for the per-element reveal, or writing a **permanent** denylist entry a daily driver never cleans up — silently unprotected on that site forever. There was no panic button and no "just let me through this once."

## How

- **One mechanism, reused teardown.** Both controls write a per-tab `TabPause` into a `webext-storage` **`StorageItemMap`** on the `session` area. It becomes a third input to `effective-enforcement.ts` (`global && !denylist && !tabPaused`); flipping it false routes through the engine's existing `revealAll` + `teardown` path — no new reveal code.
- **`chrome.storage.session`** survives MV3 service-worker restarts and auto-clears on browser restart — exactly the ephemerality we want, no cleanup debt.
- **No `chrome.alarms`, no new permissions.** Liveness is lazy (`expiresAt > now`). A timed snooze that expires while the page is open leaves the page revealed and re-engages protection on the **next navigation** — a forgotten timer never yanks content back mid-task. Manual *Resume now* re-enforces immediately.
- **Toolbar** gains a `"paused"` off-reason, reusing the greyed icon + `off` badge (FR-2a).
- **Content bridge:** content scripts can't read the `session` area or know their own tabId, so the background resolves liveness for them via `get-tab-pause` + `tab-pause-changed` messages. Popup and background (privileged) read/write the map directly, mirroring the denylist flow.

## Popup hierarchy

Landing recovery as a third standalone card under *Disable on this site* left the popup with four ungrouped "turn protection off" controls whose visual weight inverted their scope — the narrowest, most ephemeral action (Reveal) shouted loudest with an orange fill.

Consolidated the site-disable + recovery cards into one **Protection** card with an internal scope ladder, each row carrying an eyebrow that states scope + persistence once:

- **This tab · temporary** — Reveal (now an orange *outline*, not a fill) + the tab snooze.
- **This site · saved** — the denylist toggle.

New `ProtectionSection` wraps both rows; the divider is a CSS adjacent-sibling rule, so it only appears when both render (recovery still drops out on denylisted / non-content pages, leaving the site row alone). Also shortened the indefinite-pause label to *Until closed* so it stops wrapping to three lines at 280px.

## Docs

- Spec 0010 — new FR-7e–FR-7h, updated FR-2a / FR-4, user story, current-impl, related.
- **ADR-0019** — the session-scoped, alarm-free, lazy-expiry decision (incl. rejected alternatives).
- `docs/install.md` — user-facing "Recovering a page the shield broke" section.

## Verification

- `bun run preflight` (build → biome+eslint → tsc → knip → coverage): green; **2027 tests pass**, including new `tab-pause` unit + `fast-check` property tests and extended `toolbar-protection` tests.
- `bun run build`: bundles cleanly; background-worker purity canary passes.
- Popup hierarchy refactor verified against the real popup CSS in all three states (default, paused, denylisted) at the 280px popup width.
- Markdown `pre-commit run`: mdformat + markdownlint pass.

## Review note

A denylisted-and-paused tab reports the `site` toolbar reason (the popup only offers recovery when not denylisted, so they don't overlap in practice) — documented as a consequence in ADR-0019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
