### PR TITLE
Fix: leet detector firing on prose with version numbers (encoded-payload FP)

### DIFF
--- a/extension/src/rules/__tests__/encoded-payload-redact.test.ts
+++ b/extension/src/rules/__tests__/encoded-payload-redact.test.ts
@@ -541,6 +541,22 @@ describe("encoded-payload-redact text-cipher false-positive guards", () => {
     expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
   });
 
+  it("leaves English prose carrying a leet-shaped version number alone", () => {
+    // Real changelog copy: a version string like "11.16.0" supplies four
+    // leet-shape digits (1,1,1,0), clearing the substitution-count floor.
+    // The text is already English, so `deleet` leaves it readable and it
+    // would clear the common-word floor on its own — the already-English
+    // gate is what keeps it visible. (github.blog npm v12 changelog FP.)
+    const prose =
+      "Upgrade to npm 11.16.0 or later, run your normal install, and " +
+      "review the warnings.";
+    document.body.innerHTML = `<p>${prose}</p>`;
+    encodedPayloadRedactRule.apply(document.body);
+
+    expect(document.querySelector(`.${PLACEHOLDER_CLASS}`)).toBeNull();
+    expect(document.body.textContent).toContain(prose);
+  });
+
   it("leaves a sparse dot/dash ASCII-art run alone (Morse valid-ratio floor)", () => {
     // Repeating `--- . --- . ---` style separators — many tokens but
     // most decode to letters with no decoded common-word hits, and the

--- a/extension/src/rules/encoded-payload-redact.ts
+++ b/extension/src/rules/encoded-payload-redact.ts
@@ -321,9 +321,10 @@ function reverseText(text: string): string {
 
 // Leetspeak substitution table — only the substitutions that obscure a
 // letter behind a digit or symbol. Pure digits (`2nd`, `iPhone 13`) get
-// mapped too, which on its own would be a false positive; the
-// surrounding gate requires a minimum substitution count AND a decoded
-// common-word floor, so prose with incidental digits doesn't qualify.
+// mapped too, which on its own would be a false positive; the surrounding
+// gate requires a minimum substitution count, an already-English skip (so
+// prose carrying incidental version-number digits like `11.16.0` is left
+// alone), and a decoded common-word floor.
 const LEET_MAP: Record<string, string> = {
   "0": "o",
   "1": "i",
@@ -745,6 +746,16 @@ function collectLeet(text: string, matches: InlineMatch[]): void {
     if (
       countLeetSubstitutions(candidate) < SUB_RULES.leetspeak.minSubstitutions
     ) {
+      continue;
+    }
+    // Same already-English gate the substitution ciphers use: deleet leaves
+    // genuine letters untouched, so ordinary prose carrying incidental
+    // leet-shaped digits (version strings like `11.16.0`, dates) survives
+    // `deleet` essentially unchanged and would clear the common-word floor
+    // on its own. A real leet payload obscures its letters behind digits, so
+    // its *raw* form is not yet English. Skip candidates that already read as
+    // English — only an actual encode reveals a hidden directive.
+    if (alreadyEnglish(candidate, SUB_RULES.leetspeak.minCommonWords)) {
       continue;
     }
     if (


### PR DESCRIPTION
## Problem

The `leetspeak` sub-rule of `encoded-payload-redact` produced false positives on ordinary English prose that contained a version number. Reported on the [github.blog npm v12 changelog](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/), where lines like:

> Upgrade to npm 11.16.0 or later, run your normal install, and review the warnings.

were redacted as `[encoded payload hidden]`.

## Root cause

1. `11.16.0` supplies four leet-shape digits (`1,1,1,0`), clearing `minSubstitutions: 4`.
2. `deleet` only rewrites digits/symbols — it leaves genuine letters untouched. So already-English text stays readable after decode, and `your`/`and`/`the` clear the `minCommonWords: 3` floor.

`collectSubstitutionCiphers` (ROT13/Atbash/reverse) already skips candidates that are *already* English — a real cipher payload obscures its letters, so its raw form isn't English yet. `collectLeet` was missing that guard.

## Fix

Add the same `alreadyEnglish` short-circuit to `collectLeet`. Prose carrying incidental version-number digits is left visible; genuine leet payloads (`y0u c4n 533 7h15…`, letters broken up by digits, raw form scores ~0 common words) still redact.

## Testing

- New regression test uses the verbatim changelog copy. Confirmed it **fails without** the guard (prose was redacted) and **passes with** it.
- Existing `redacts a leetspeak-encoded English sentence` test still passes — real payloads unaffected.
- Full `encoded-payload-redact` example + property suites pass (52 tests); `bun run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)