### PR TITLE
Fix: stop `bun run watch` infinite rebuild loop (codegen self-trigger)

### DIFF
--- a/extension/scripts/build-injection-patterns.ts
+++ b/extension/scripts/build-injection-patterns.ts
@@ -18,6 +18,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { load } from "js-yaml";
 import { z } from "zod";
+import { fileHasContent } from "./file-has-content";
 
 const ROOT = join(import.meta.dir, "..");
 const INPUT = join(ROOT, "data", "injection-patterns.yaml");
@@ -100,7 +101,13 @@ export function generateInjectionPatterns(): void {
     return { name: entry.name, source, flags: entry.flags };
   });
 
-  writeFileSync(OUTPUT, buildOutput(entries));
+  // Skip the write when nothing changed: the output lives under `src/`, which
+  // `build.ts --watch` watches recursively, so an unconditional write would
+  // re-trigger the watcher and loop forever. See ./file-has-content.
+  const output = buildOutput(entries);
+  if (!fileHasContent(OUTPUT, output)) {
+    writeFileSync(OUTPUT, output);
+  }
   console.log(
     `Generated ${relative(ROOT, OUTPUT)} from ${entries.length} patterns.`,
   );

--- a/extension/scripts/build-site-data.ts
+++ b/extension/scripts/build-site-data.ts
@@ -24,6 +24,7 @@ import {
   SiteFileSchema,
   toEntries,
 } from "../data/site-rules.schema";
+import { fileHasContent } from "./file-has-content";
 
 const ROOT = join(import.meta.dir, "..");
 const SITES_DIR = join(ROOT, "data", "sites");
@@ -313,7 +314,13 @@ export function generateSiteData(): void {
 
   const parsed = loadSites();
   const output = buildOutput(parsed);
-  writeFileSync(OUTPUT, output);
+  // Only write when the content actually changes. The output lives inside
+  // `src/`, which `build.ts --watch` watches recursively; an unconditional
+  // write would re-trigger the watcher on every build and spin into an
+  // infinite rebuild loop.
+  if (!fileHasContent(OUTPUT, output)) {
+    writeFileSync(OUTPUT, output);
+  }
   console.log(
     `Generated ${relative(ROOT, OUTPUT)} from ${parsed.length} site YAML files.`,
   );

--- a/extension/scripts/file-has-content.ts
+++ b/extension/scripts/file-has-content.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+import { readFileSync } from "node:fs";
+
+// Returns true when `path` already holds exactly `expected`. Codegen writes
+// into `src/`, which `build.ts --watch` watches recursively; guarding each
+// `writeFileSync` with this check keeps an unchanged output from re-arming the
+// watcher and spinning into an infinite rebuild loop.
+export function fileHasContent(path: string, expected: string): boolean {
+  try {
+    return readFileSync(path, "utf8") === expected;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Problem

`bun run watch` (`build.ts --watch`) spins into an infinite rebuild loop, pegging CPU indefinitely. The symptoms reported were transient build failures:

- `dist/background.js not found — run the extension build first.` (background-purity check)
- `ENOENT … copyfile 'icons/icon-16.png' -> 'dist/icons/icon-16.png'` (icon copy)

These ENOENT errors are *symptoms*, not real missing files.

## Root cause

`build.ts --watch` watches `src/` recursively (`build.ts:256`). Every build runs `generateSiteData()` / `generateInjectionPatterns()`, which `writeFileSync` **unconditionally** into `src/rules/site-data.generated.ts` and `src/rules/injection-patterns.generated.ts` — *inside the watched tree*. So each build's own write re-triggers the watcher → rebuild → write → loop forever.

The watcher also has no build mutex (just a 50ms debounce, `build.ts:251`), so builds overlap. Each build starts with `await rm(DIST, …)` (`build.ts:122`), so a newer build deletes `dist/` out from under an in-flight one — producing the transient "background.js not found" at the purity check and the icon-copy race.

## Fix

Guard each codegen write with a content comparison (`scripts/file-has-content.ts`) so an unchanged output no longer re-arms the watcher. A settled build stops triggering itself, breaking the loop.

## Verification

- Watch now does exactly **one** build, then idles at **0% CPU** (was ~190%).
- Two consecutive `bun run build`s are clean.
- `bun run check` passes.
- `bun test scripts/` — 37 pass.

## Note (out of scope)

The missing build mutex is a latent issue: rapid saves during a slow build could still overlap and race on `rm(DIST)`. This PR removes the self-triggering case, which is what was actually biting. An in-flight guard to serialize concurrent builds could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)