### PR TITLE
Refactor: createScanRule factory for the hand-rolled watcher lifecycle (15 rules)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,15 +108,26 @@ load, so anything that only ran in `apply` will never see post-navigation
 content — and most of our targets (PII, secrets, scarcity badges, hidden text)
 are exactly the kind of late-mounted content SPAs are built on.
 
-Default to wiring a `createSubtreeWatcher`
-(`extension/src/lib/subtree-watcher.ts`) into any rule that mutates the DOM,
-with `skipPlaceholderSubtrees: true` when the rule inserts placeholders. Mirror
-the pattern used in `pii-redact`, `secrets-redact`, `scarcity-redact`,
-`hidden-text-strip`, etc.: a shared `scanAndX(root)` function called by both
-`apply` and the watcher's `onSubtrees`, plus a `teardown` that calls
-`watcher.stop()`. Skip the watcher only when there is nothing to re-scan after
-initial load — e.g., a one-shot landmark injection — and call that out in a
-comment.
+Default to building any rule that mutates the DOM with the `createScanRule`
+factory (`extension/src/lib/scan-rule.ts`). Pass it the rule's `id` / `label` /
+`description`, a `scanAndX(root)` function, and `skipPlaceholderSubtrees: true`
+when the rule inserts placeholders; the factory owns the watcher lifecycle — the
+shared `createSubtreeWatcher`, the `apply` that scans then starts it, and the
+`teardown` that stops it — so callers don't re-hand-roll that skeleton (and
+can't forget the teardown or the placeholder skip). `scarcity-redact`,
+`json-ld-sanitize`, and `hidden-text-strip` are representative call sites.
+
+Reach for `createSubtreeWatcher` directly only when the lifecycle is more than
+scan-on-apply-and-rescan: a second watcher / head router
+(`meta-injection-strip`), a route / focus subscription
+(`form-prefill-annotate`), a deferred snapshot reconcile
+(`countdown-timer-redact`), an `onSubtrees` that re-scans `document.body`
+instead of the surfaced root (`cross-origin-frame-redact`, `svg-sprite-strip`),
+or a `teardown` that restores page state (`confirmshame-sanitize`). Text-node
+redaction rules (`pii-redact`, `secrets-redact`, `encoded-payload-redact`) have
+their own factory, `defineInlineTextRedactRule`. Skip a watcher entirely only
+when there is nothing to re-scan after initial load — e.g., a one-shot landmark
+injection — and call that out in a comment.
 
 ## DOM marker attributes
 

--- a/extension/src/lib/__tests__/scan-rule.test.ts
+++ b/extension/src/lib/__tests__/scan-rule.test.ts
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Direct unit tests for the createScanRule lifecycle factory. The ~15 rules
+// built on it (scarcity-redact, json-ld-sanitize, hidden-text-strip, …) each
+// cover their own scan logic; this file pins the factory's own contract: it
+// scans once on apply, re-scans subtrees the shared watcher surfaces, forwards
+// skipPlaceholderSubtrees, and stops observing on teardown.
+
+import { PLACEHOLDER_CLASS } from "../placeholder";
+import { __resetRouteChangeForTesting } from "../route-change";
+import { createScanRule } from "../scan-rule";
+import type { RuleId } from "../storage";
+import { __resetSubtreeWatcherForTesting } from "../subtree-watcher";
+
+const RULE_ID = "scarcity-redact" as RuleId;
+
+// createSubtreeWatcher's default throttle window.
+const THROTTLE_MS = 250;
+
+// A MutationObserver callback fires on a microtask; the throttled drain then
+// fires after THROTTLE_MS. Yield the microtask, then advance the fake timer.
+async function flushWatcher(): Promise<void> {
+  await Promise.resolve();
+  jest.advanceTimersByTime(THROTTLE_MS);
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  __resetSubtreeWatcherForTesting();
+  __resetRouteChangeForTesting();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  __resetSubtreeWatcherForTesting();
+  __resetRouteChangeForTesting();
+});
+
+describe("createScanRule rule shape", () => {
+  it("builds a rule with the supplied id/label/description and a teardown", () => {
+    const rule = createScanRule({
+      id: RULE_ID,
+      label: "Test Label",
+      description: "Test description.",
+      scan: jest.fn(),
+    });
+
+    expect(rule.id).toBe(RULE_ID);
+    expect(rule.label).toBe("Test Label");
+    expect(rule.description).toBe("Test description.");
+    // The factory always installs a teardown — callers (and tests) can call it
+    // without an optional-chaining guard.
+    expect(typeof rule.teardown).toBe("function");
+  });
+
+  it("defaults topFrameOnly to false and forwards an explicit value", () => {
+    const defaulted = createScanRule({
+      id: RULE_ID,
+      label: "l",
+      description: "d",
+      scan: jest.fn(),
+    });
+    expect(defaulted.topFrameOnly).toBe(false);
+
+    const topOnly = createScanRule({
+      id: RULE_ID,
+      label: "l",
+      description: "d",
+      scan: jest.fn(),
+      topFrameOnly: true,
+    });
+    expect(topOnly.topFrameOnly).toBe(true);
+  });
+});
+
+describe("createScanRule lifecycle", () => {
+  it("scans the root once synchronously on apply", () => {
+    const scan = jest.fn();
+    const rule = createScanRule({
+      id: RULE_ID,
+      label: "l",
+      description: "d",
+      scan,
+    });
+
+    rule.apply(document.body);
+
+    expect(scan).toHaveBeenCalledTimes(1);
+    expect(scan).toHaveBeenCalledWith(document.body);
+
+    rule.teardown();
+  });
+
+  it("re-scans a subtree injected after apply", async () => {
+    const scan = jest.fn();
+    const rule = createScanRule({
+      id: RULE_ID,
+      label: "l",
+      description: "d",
+      scan,
+    });
+
+    rule.apply(document.body);
+    scan.mockClear();
+
+    const late = document.createElement("div");
+    document.body.append(late);
+
+    await flushWatcher();
+
+    expect(scan).toHaveBeenCalledWith(late);
+
+    rule.teardown();
+  });
+
+  it("does not re-scan placeholder subtrees when skipPlaceholderSubtrees is set", async () => {
+    const scan = jest.fn();
+    const rule = createScanRule({
+      id: RULE_ID,
+      label: "l",
+      description: "d",
+      scan,
+      skipPlaceholderSubtrees: true,
+    });
+
+    rule.apply(document.body);
+    scan.mockClear();
+
+    // The rule's own inserted placeholder must not re-trigger its scan.
+    const placeholder = document.createElement("div");
+    placeholder.classList.add(PLACEHOLDER_CLASS);
+    document.body.append(placeholder);
+
+    await flushWatcher();
+
+    expect(scan).not.toHaveBeenCalled();
+
+    rule.teardown();
+  });
+
+  it("re-scans placeholder subtrees when skipPlaceholderSubtrees is not set", async () => {
+    const scan = jest.fn();
+    const rule = createScanRule({
+      id: RULE_ID,
+      label: "l",
+      description: "d",
+      scan,
+    });
+
+    rule.apply(document.body);
+    scan.mockClear();
+
+    const placeholder = document.createElement("div");
+    placeholder.classList.add(PLACEHOLDER_CLASS);
+    document.body.append(placeholder);
+
+    await flushWatcher();
+
+    expect(scan).toHaveBeenCalledWith(placeholder);
+
+    rule.teardown();
+  });
+
+  it("stops observing after teardown", async () => {
+    const scan = jest.fn();
+    const rule = createScanRule({
+      id: RULE_ID,
+      label: "l",
+      description: "d",
+      scan,
+    });
+
+    rule.apply(document.body);
+    rule.teardown();
+    scan.mockClear();
+
+    const late = document.createElement("div");
+    document.body.append(late);
+
+    await flushWatcher();
+
+    expect(scan).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/lib/scan-rule.ts
+++ b/extension/src/lib/scan-rule.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 PixieBrix, Inc.
+// Licensed under PolyForm Shield 1.0.0 — see LICENSE.
+
+// Factory for the most common DOM-mutating rule shape: scan a root once on
+// `apply`, then re-scan every lazily-inserted subtree the shared
+// MutationObserver surfaces. The rules that adopt this (scarcity-redact,
+// json-ld-sanitize, hidden-text-strip, …) previously hand-rolled the identical
+// four-part skeleton — a module-level `watcher`, a `scanAndX(root)`, an `apply`
+// wiring the two, and a `teardown` calling `watcher.stop()` — once each.
+// AGENTS.md documented that skeleton, but documenting boilerplate doesn't stop
+// a new rule from forgetting `skipPlaceholderSubtrees` (its own placeholders
+// then re-trigger the watcher) or dropping the teardown (the observer leaks).
+//
+// This factory deliberately covers ONLY the no-extra-lifecycle case. Rules
+// whose lifecycle is anything more keep hand-wiring `createSubtreeWatcher`
+// directly:
+//   - a second watcher / head router (meta-injection-strip)
+//   - a route / focus subscription (form-prefill-annotate)
+//   - a deferred snapshot reconcile (countdown-timer-redact)
+//   - an onSubtrees callback that ignores `roots` and re-scans document.body
+//     (cross-origin-frame-redact, svg-sprite-strip)
+//   - a teardown that restores page state (confirmshame-sanitize)
+
+import type { Rule } from "../rules/types";
+import type { RuleId } from "./storage";
+import { createSubtreeWatcher } from "./subtree-watcher";
+
+export interface ScanRuleOptions<Id extends RuleId = RuleId> {
+  // Generic over the literal id so `rule.id` keeps its narrow `RuleId` literal
+  // (inferred from the call site) rather than widening to `RuleId`. The rule
+  // catalog's compile-time agreement check in `rules/index.ts` relies on it.
+  id: Id;
+  label: string;
+  description: string;
+  // Scan `root` and apply the rule's mutation to every match within it. Called
+  // once per `apply(root)` and once per subtree the watcher surfaces, so it
+  // must be idempotent (the same node can be handed back on a later batch).
+  //
+  // `querySelectorAll` only matches descendants, so when the rule's targets can
+  // arrive as a bare inserted root (a `<script type="application/ld+json">`
+  // appended directly), `scan` is responsible for the `root.matches(...)`
+  // self-check — see json-ld-sanitize / attribute-injection-sanitize.
+  scan: (root: ParentNode) => void;
+  // Forwarded to `createSubtreeWatcher`. Set when `scan` inserts placeholders
+  // so the rule's own insertions don't re-trigger the watcher.
+  skipPlaceholderSubtrees?: boolean;
+  // Propagated to the Rule. See `Rule.topFrameOnly` for semantics. Default
+  // false: the rule runs in every frame the content script reaches.
+  topFrameOnly?: boolean;
+}
+
+// Tighter than `Rule` — the factory always installs a teardown, so callers
+// (notably tests that call `rule.teardown()` directly in `afterEach`) don't
+// need to widen with `?.()` or an assertion.
+export type ScanRule<Id extends RuleId = RuleId> = Rule & {
+  id: Id;
+  teardown: () => void;
+};
+
+export function createScanRule<Id extends RuleId>(
+  options: ScanRuleOptions<Id>,
+): ScanRule<Id> {
+  const {
+    id,
+    label,
+    description,
+    scan,
+    skipPlaceholderSubtrees = false,
+    topFrameOnly = false,
+  } = options;
+
+  const watcher = createSubtreeWatcher({
+    skipPlaceholderSubtrees,
+    onSubtrees: (roots) => {
+      for (const root of roots) {
+        scan(root);
+      }
+    },
+  });
+
+  return {
+    id,
+    label,
+    description,
+    topFrameOnly,
+    apply(root: ParentNode): void {
+      scan(root);
+      watcher.start(root);
+    },
+    teardown(): void {
+      watcher.stop();
+    },
+  } satisfies ScanRule<Id>;
+}

--- a/extension/src/rules/attribute-injection-sanitize.ts
+++ b/extension/src/rules/attribute-injection-sanitize.ts
@@ -37,10 +37,9 @@
 // lets the normal name calculation proceed. Same logic applies to
 // `title` and `alt`.
 
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import { createScanRule } from "../lib/scan-rule";
 import { traceMutation } from "../lib/trace-mutation";
 import { INJECTION_PATTERNS } from "./injection-patterns.generated";
-import type { Rule } from "./types";
 
 const RULE_ID = "attribute-injection-sanitize" as const;
 
@@ -109,26 +108,10 @@ function scrub(root: ParentNode): void {
   }
 }
 
-const watcher = createSubtreeWatcher({
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scrub(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  scrub(root);
-  watcher.start(root);
-}
-
-export const attributeInjectionSanitizeRule = {
+export const attributeInjectionSanitizeRule = createScanRule({
   id: RULE_ID,
+  scan: scrub,
   label: "Scrub Attribute Injection",
   description:
     "Remove aria-label, alt, title, placeholder, and similar attributes carrying prompt-injection text.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/cart-addon-annotate.ts
+++ b/extension/src/rules/cart-addon-annotate.ts
@@ -33,9 +33,8 @@ import {
 } from "../lib/dom-markers";
 import { findInnermostMatches } from "../lib/dom-utils";
 import { createRuleLogger } from "../lib/log";
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import { createScanRule } from "../lib/scan-rule";
 import { traceMutation } from "../lib/trace-mutation";
-import type { Rule } from "./types";
 
 const RULE_ID = "cart-addon-annotate" as const;
 const log = createRuleLogger(RULE_ID);
@@ -197,26 +196,10 @@ function scanAndFlag(root: ParentNode): void {
   });
 }
 
-const watcher = createSubtreeWatcher({
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scanAndFlag(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  scanAndFlag(root);
-  watcher.start(root);
-}
-
-export const cartAddonAnnotateRule = {
+export const cartAddonAnnotateRule = createScanRule({
   id: RULE_ID,
+  scan: scanAndFlag,
   label: "Flag Cart Add-Ons (Sneak-Into-Basket)",
   description:
     "On checkout pages, flag likely sneak-into-basket line items (protection plans, warranties, insurance, donations, gift wrap, etc.) with a visible annotation. Items are not removed.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/disguised-ad-flag.ts
+++ b/extension/src/rules/disguised-ad-flag.ts
@@ -26,8 +26,7 @@ import {
 } from "../lib/dom-utils";
 import { createRuleLogger } from "../lib/log";
 import { replaceWithBlockPlaceholder } from "../lib/placeholder";
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
-import type { Rule } from "./types";
+import { createScanRule } from "../lib/scan-rule";
 
 const RULE_ID = "disguised-ad-flag" as const;
 const log = createRuleLogger(RULE_ID);
@@ -464,27 +463,11 @@ function scanAndHide(root: ParentNode): void {
   });
 }
 
-const watcher = createSubtreeWatcher({
-  skipPlaceholderSubtrees: true,
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scanAndHide(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  scanAndHide(root);
-  watcher.start(root);
-}
-
-export const disguisedAdFlagRule = {
+export const disguisedAdFlagRule = createScanRule({
   id: RULE_ID,
+  scan: scanAndHide,
+  skipPlaceholderSubtrees: true,
   label: "Hide Disguised Ads (Native Advertorials)",
   description:
     "Hide article-shaped blocks that carry a visible 'Sponsored', 'Promoted', 'Advertorial', or 'Paid Post' disclosure label. Catches native advertorials that bypass network-level ad selectors (EasyList) because the publisher's own CMS renders them. Replaces the card with a click-to-reveal placeholder.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/hidden-affiliate-sanitize.ts
+++ b/extension/src/rules/hidden-affiliate-sanitize.ts
@@ -47,9 +47,8 @@
 import { isCheckoutUrl } from "../lib/checkout-url";
 import { HIDDEN_AFFILIATE_CLEARED_ATTR as CLEARED_ATTR } from "../lib/dom-markers";
 import { createRuleLogger } from "../lib/log";
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import { createScanRule } from "../lib/scan-rule";
 import { traceMutation } from "../lib/trace-mutation";
-import type { Rule } from "./types";
 
 const RULE_ID = "hidden-affiliate-sanitize" as const;
 const log = createRuleLogger(RULE_ID);
@@ -324,26 +323,10 @@ function scanAndClear(root: ParentNode): void {
   }
 }
 
-const watcher = createSubtreeWatcher({
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scanAndClear(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  scanAndClear(root);
-  watcher.start(root);
-}
-
-export const hiddenAffiliateSanitizeRule = {
+export const hiddenAffiliateSanitizeRule = createScanRule({
   id: RULE_ID,
+  scan: scanAndClear,
   label: "Scrub Hidden Affiliate Metadata",
   description:
     "On checkout pages, clear `value` on hidden inputs whose name matches a curated affiliate / UTM / referral attribution allowlist. Promo / coupon / discount names are preserved (legitimate user discount). CSRF, session, cart, order, nonce, signature, and state fields are also preserved.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/hidden-fee-annotate.ts
+++ b/extension/src/rules/hidden-fee-annotate.ts
@@ -43,9 +43,8 @@ import {
 } from "../lib/dom-markers";
 import { findInnermostMatches } from "../lib/dom-utils";
 import { createRuleLogger } from "../lib/log";
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import { createScanRule } from "../lib/scan-rule";
 import { traceMutation } from "../lib/trace-mutation";
-import type { Rule } from "./types";
 
 const RULE_ID = "hidden-fee-annotate" as const;
 const log = createRuleLogger(RULE_ID);
@@ -529,26 +528,10 @@ function scanAndFlag(root: ParentNode): void {
   });
 }
 
-const watcher = createSubtreeWatcher({
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scanAndFlag(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  scanAndFlag(root);
-  watcher.start(root);
-}
-
-export const hiddenFeeAnnotateRule = {
+export const hiddenFeeAnnotateRule = createScanRule({
   id: RULE_ID,
+  scan: scanAndFlag,
   label: "Annotate Drip-Pricing Fees (Experimental)",
   description:
     "On checkout pages, flag mandatory fees that only surface inside the order summary (resort, service, convenience, processing, etc.) with a visible annotation. The row is not removed — the agent reads the annotation and verifies the total before completing the purchase.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -72,10 +72,9 @@ import {
   visibleTextContent,
 } from "../lib/dom-utils";
 import { createRuleLogger } from "../lib/log";
+import { createScanRule } from "../lib/scan-rule";
 import { SR_ONLY_CLASS_NAMES, SR_ONLY_MAX_SIZE_PX } from "../lib/sr-only";
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import { traceMutation } from "../lib/trace-mutation";
-import type { Rule } from "./types";
 
 const RULE_ID = "hidden-text-strip" as const;
 const log = createRuleLogger(RULE_ID);
@@ -909,27 +908,11 @@ function scanAndStrip(root: ParentNode): void {
   }
 }
 
-const watcher = createSubtreeWatcher({
-  skipPlaceholderSubtrees: true,
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scanAndStrip(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  scanAndStrip(root);
-  watcher.start(root);
-}
-
-export const hiddenTextStripRule = {
+export const hiddenTextStripRule = createScanRule({
   id: RULE_ID,
+  scan: scanAndStrip,
+  skipPlaceholderSubtrees: true,
   label: "Strip Hidden Text",
   description:
     'Blank text invisible to humans but readable by agents. Defends against "unseeable" prompt injection; screen-reader-only text is preserved.',
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/html-comment-strip.ts
+++ b/extension/src/rules/html-comment-strip.ts
@@ -23,10 +23,9 @@
 // toggling the rule off requires a page reload to recover the original
 // comment text.
 
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import { createScanRule } from "../lib/scan-rule";
 import { traceMutation } from "../lib/trace-mutation";
 import { INJECTION_PATTERNS } from "./injection-patterns.generated";
-import type { Rule } from "./types";
 
 const RULE_ID = "html-comment-strip" as const;
 const EXCLUDED_PARENT_TAGS = new Set(["SCRIPT", "STYLE", "NOSCRIPT"]);
@@ -77,26 +76,10 @@ function stripComments(root: ParentNode): void {
   }
 }
 
-const watcher = createSubtreeWatcher({
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      stripComments(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  stripComments(root);
-  watcher.start(root);
-}
-
-export const htmlCommentStripRule = {
+export const htmlCommentStripRule = createScanRule({
   id: RULE_ID,
+  scan: stripComments,
   label: "Strip HTML Comments",
   description:
     "Blank HTML comments that carry prompt-injection text. Invisible to humans but readable by agents.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/json-ld-sanitize.ts
+++ b/extension/src/rules/json-ld-sanitize.ts
@@ -19,10 +19,9 @@
 // malformed JSON are left alone (we have no safe transform to apply and
 // the agent will not be able to use the data anyway).
 
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import { createScanRule } from "../lib/scan-rule";
 import { traceMutation } from "../lib/trace-mutation";
 import { INJECTION_PATTERNS } from "./injection-patterns.generated";
-import type { Rule } from "./types";
 
 const RULE_ID = "json-ld-sanitize" as const;
 const SELECTOR = 'script[type="application/ld+json" i]';
@@ -93,26 +92,10 @@ function processRoot(root: ParentNode): void {
   }
 }
 
-const watcher = createSubtreeWatcher({
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      processRoot(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  processRoot(root);
-  watcher.start(root);
-}
-
-export const jsonLdSanitizeRule = {
+export const jsonLdSanitizeRule = createScanRule({
   id: RULE_ID,
+  scan: processRoot,
   label: "Sanitize JSON-LD",
   description:
     "Strip prompt-injection text from JSON-LD structured data while preserving price, rating, and other useful fields.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/link-spoof-annotate.ts
+++ b/extension/src/rules/link-spoof-annotate.ts
@@ -46,9 +46,8 @@ import {
 } from "../lib/dom-markers";
 import { registrableDomain } from "../lib/domain-trust";
 import { createRuleLogger } from "../lib/log";
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import { createScanRule } from "../lib/scan-rule";
 import { traceMutation } from "../lib/trace-mutation";
-import type { Rule } from "./types";
 
 const RULE_ID = "link-spoof-annotate" as const;
 const log = createRuleLogger(RULE_ID);
@@ -235,27 +234,11 @@ function scanAndFlag(root: ParentNode): void {
   }
 }
 
-const watcher = createSubtreeWatcher({
-  skipPlaceholderSubtrees: true,
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scanAndFlag(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  scanAndFlag(root);
-  watcher.start(root);
-}
-
-export const linkSpoofAnnotateRule = {
+export const linkSpoofAnnotateRule = createScanRule({
   id: RULE_ID,
+  scan: scanAndFlag,
+  skipPlaceholderSubtrees: true,
   label: "Flag Spoofed Links",
   description:
     "Annotate <a> elements whose visible text either (a) mixes scripts inside a word, (b) uses Cyrillic / Greek / Armenian letters to visually mimic a Latin domain (homograph / IDN spoof), or (c) shows a domain that differs from the link's actual host. Useful for vision-based agents; DOM-walking agents can spot the same discrepancies themselves.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/noscript-strip.ts
+++ b/extension/src/rules/noscript-strip.ts
@@ -30,9 +30,8 @@
 // The scrub is not reversible within the current page load; toggling the
 // rule off requires a reload to recover the original fallback markup.
 
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import { createScanRule } from "../lib/scan-rule";
 import { traceMutation } from "../lib/trace-mutation";
-import type { Rule } from "./types";
 
 const RULE_ID = "noscript-strip" as const;
 
@@ -63,26 +62,10 @@ function stripNoscript(root: ParentNode): void {
   }
 }
 
-const watcher = createSubtreeWatcher({
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      stripNoscript(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  stripNoscript(root);
-  watcher.start(root);
-}
-
-export const noscriptStripRule = {
+export const noscriptStripRule = createScanRule({
   id: RULE_ID,
+  scan: stripNoscript,
   label: "Strip Noscript",
   description:
     "Blank <noscript> fallback markup. Never rendered when JS is on, but still readable by agents.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/scarcity-redact.ts
+++ b/extension/src/rules/scarcity-redact.ts
@@ -19,8 +19,7 @@
 import { REVEALED_ATTR } from "../lib/dom-markers";
 import { findInnermostMatches, isInsidePlaceholder } from "../lib/dom-utils";
 import { replaceWithBlockPlaceholder } from "../lib/placeholder";
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
-import type { Rule } from "./types";
+import { createScanRule } from "../lib/scan-rule";
 
 const RULE_ID = "scarcity-redact" as const;
 
@@ -105,27 +104,11 @@ function scanAndHide(root: ParentNode): void {
   }
 }
 
-const watcher = createSubtreeWatcher({
-  skipPlaceholderSubtrees: true,
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scanAndHide(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  scanAndHide(root);
-  watcher.start(root);
-}
-
-export const scarcityRedactRule = {
+export const scarcityRedactRule = createScanRule({
   id: RULE_ID,
+  scan: scanAndHide,
+  skipPlaceholderSubtrees: true,
   label: "Hide Scarcity Warnings",
   description:
     'Hide scarcity messages like "Only 3 left" or "12 viewing now". Out-of-stock indicators and bestseller badges stay visible.',
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/schema-trust-sanitize.ts
+++ b/extension/src/rules/schema-trust-sanitize.ts
@@ -37,6 +37,7 @@
 // publishers on those hosts are expected, not suspicious.
 
 import { SCHEMA_TRUST_UNVERIFIED_ATTR } from "../lib/dom-markers";
+import { createScanRule } from "../lib/scan-rule";
 import {
   isAnnotateOnlyAuthorityType,
   isAuthorityContextProperty,
@@ -46,9 +47,7 @@ import {
   shouldSkipPage,
   UNVERIFIED_AUTHORITY_KEY,
 } from "../lib/schema-trust";
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
 import { traceMutation } from "../lib/trace-mutation";
-import type { Rule } from "./types";
 
 const RULE_ID = "schema-trust-sanitize" as const;
 const JSON_LD_SELECTOR = 'script[type="application/ld+json" i]';
@@ -372,26 +371,10 @@ function processRoot(root: ParentNode): void {
   }
 }
 
-const watcher = createSubtreeWatcher({
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      processRoot(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  processRoot(root);
-  watcher.start(root);
-}
-
-export const schemaTrustSanitizeRule = {
+export const schemaTrustSanitizeRule = createScanRule({
   id: RULE_ID,
+  scan: processRoot,
   label: "Sanitize Schema Trust Claims (Experimental)",
   description:
     "Blank schema.org Organization fields (name, url, @id) when the claim's URL is on a different registrable domain than the page. Defends against non-NYT pages asserting publisher = The New York Times, non-Snopes pages forging ClaimReview.author, and similar unearned-authority claims.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/svg-text-strip.ts
+++ b/extension/src/rules/svg-text-strip.ts
@@ -15,10 +15,9 @@
 // accessibility-tree consumers — keeping the element shell preserves the
 // structural mapping while the payload is gone.
 
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import { createScanRule } from "../lib/scan-rule";
 import { traceMutation } from "../lib/trace-mutation";
 import { INJECTION_PATTERNS } from "./injection-patterns.generated";
-import type { Rule } from "./types";
 
 const RULE_ID = "svg-text-strip" as const;
 const SVG_TEXT_SELECTOR = "svg title, svg desc, svg text";
@@ -42,26 +41,10 @@ function scan(root: ParentNode): void {
   }
 }
 
-const watcher = createSubtreeWatcher({
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scan(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  scan(root);
-  watcher.start(root);
-}
-
-export const svgTextStripRule = {
+export const svgTextStripRule = createScanRule({
   id: RULE_ID,
+  scan,
   label: "Strip SVG Injection",
   description:
     "Clear injection-shaped text inside <svg> <title>, <desc>, and <text> elements.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/trust-badge-annotate.ts
+++ b/extension/src/rules/trust-badge-annotate.ts
@@ -30,9 +30,8 @@ import {
 } from "../lib/dom-markers";
 import { registrableDomain } from "../lib/domain-trust";
 import { createRuleLogger } from "../lib/log";
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import { createScanRule } from "../lib/scan-rule";
 import { traceMutation } from "../lib/trace-mutation";
-import type { Rule } from "./types";
 
 const RULE_ID = "trust-badge-annotate" as const;
 const log = createRuleLogger(RULE_ID);
@@ -298,27 +297,11 @@ function scanAndAnnotate(root: ParentNode): void {
   }
 }
 
-const watcher = createSubtreeWatcher({
-  skipPlaceholderSubtrees: true,
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scanAndAnnotate(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  scanAndAnnotate(root);
-  watcher.start(root);
-}
-
-export const trustBadgeAnnotateRule = {
+export const trustBadgeAnnotateRule = createScanRule({
   id: RULE_ID,
+  scan: scanAndAnnotate,
+  skipPlaceholderSubtrees: true,
   label: "Flag Trust Badges (Experimental)",
   description:
     "Annotate image-shaped trust badges (Norton Secured, McAfee SECURE, BBB Accredited, Verified Seller, and similar) whose accessible name carries a self-asserted trust claim that no transport-level signal backs. Useful for vision- and accessibility-tree-driven agents, which over-weight these badges as evidence of trustworthiness. Off by default while we gather real-world signal on false positives.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});

--- a/extension/src/rules/unicode-invisibles-strip.ts
+++ b/extension/src/rules/unicode-invisibles-strip.ts
@@ -30,9 +30,8 @@
 // MutationObserver re-runs on lazily injected subtrees.
 
 import { walkTextNodes } from "../lib/dom-utils";
-import { createSubtreeWatcher } from "../lib/subtree-watcher";
+import { createScanRule } from "../lib/scan-rule";
 import { traceMutation } from "../lib/trace-mutation";
-import type { Rule } from "./types";
 
 const RULE_ID = "unicode-invisibles-strip" as const;
 
@@ -139,27 +138,11 @@ function scrub(root: ParentNode): void {
   scrubAttributes(root);
 }
 
-const watcher = createSubtreeWatcher({
-  skipPlaceholderSubtrees: true,
-  onSubtrees: (roots) => {
-    for (const root of roots) {
-      scrub(root);
-    }
-  },
-});
-
-function apply(root: ParentNode): void {
-  scrub(root);
-  watcher.start(root);
-}
-
-export const unicodeInvisiblesStripRule = {
+export const unicodeInvisiblesStripRule = createScanRule({
   id: RULE_ID,
+  scan: scrub,
+  skipPlaceholderSubtrees: true,
   label: "Strip Unicode Invisibles",
   description:
     "Remove Unicode tag, bidi-override, and zero-width characters that are invisible to humans but readable by agents.",
-  apply,
-  teardown: () => {
-    watcher.stop();
-  },
-} satisfies Rule;
+});


### PR DESCRIPTION
## What

Adds a `createScanRule` lifecycle factory and migrates the 15 holdout rules that hand-rolled the identical subtree-watcher skeleton onto it.

Two factories already cover the clean rule shapes — `createSelectorHideRule` (7 rules) and `defineInlineTextRedactRule` (3 rules). The remaining DOM-mutating rules each hand-rolled the same four-part skeleton, ~23 LOC each:

- a module-level `const watcher = createSubtreeWatcher({...})`
- a `scanAndX(root)` scan function
- `apply` = `scan(root); watcher.start(root)`
- `teardown` = `watcher.stop()`

`AGENTS.md` documented the skeleton, but documenting boilerplate doesn't eliminate the bug surface — a new rule can still forget `skipPlaceholderSubtrees` (its own placeholders then re-trigger the watcher) or drop the teardown (the observer leaks).

## The factory

`extension/src/lib/scan-rule.ts`:

```ts
createScanRule({ id, label, description, scan, skipPlaceholderSubtrees?, topFrameOnly? })
```

Owns the watcher lifecycle and returns a `Rule` with `apply`/`teardown` wired. Generic over the literal `RuleId` (mirroring the two existing factories) so the catalog's compile-time id-agreement check in `rules/index.ts` keeps narrowing.

## Migrated (15 rules, −244 LOC in the rule files)

scarcity-redact, disguised-ad-flag, html-comment-strip, noscript-strip, svg-text-strip, unicode-invisibles-strip, link-spoof-annotate, schema-trust-sanitize, trust-badge-annotate, cart-addon-annotate, attribute-injection-sanitize, json-ld-sanitize, hidden-fee-annotate, hidden-affiliate-sanitize, hidden-text-strip.

## Deliberately left bespoke

Rules whose lifecycle is more than scan-on-apply-and-rescan keep hand-wiring `createSubtreeWatcher` directly: head router (`meta-injection-strip`), route/focus subscription (`form-prefill-annotate`), deferred snapshot (`countdown-timer-redact`), `onSubtrees` that re-scans `document.body` (`cross-origin-frame-redact`, `svg-sprite-strip`), teardown that restores page state (`confirmshame-sanitize`). The factory's doc comment and the updated `AGENTS.md` section spell out when to reach past it.

## Tests

New `scan-rule.test.ts` (7 tests) pins the factory's own contract: scans once on `apply`, re-scans surfaced subtrees, forwards `skipPlaceholderSubtrees`, stops observing on `teardown`. Existing per-rule suites are unchanged and green.

## Verification

`bun run check` (biome + eslint), `tsc` ×2, `knip`, full jest (**2059 tests, 110 suites**), and the markdown pre-commit all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)