### PR TITLE
Refactor: type cleanup — type-fest helpers + buildRuleRecord

### DIFF
--- a/extension/bun.lock
+++ b/extension/bun.lock
@@ -45,6 +45,7 @@
         "js-yaml": "^4.1.0",
         "knip": "^6.15.0",
         "ts-jest": "^29",
+        "type-fest": "^5.7.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.60.0",
         "zod": "^4.4.3",
@@ -1048,7 +1049,7 @@
 
     "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
 
-    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+    "type-fest": ["type-fest@5.7.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
@@ -1256,6 +1257,8 @@
 
     "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
+    "serialize-error/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -1264,11 +1267,11 @@
 
     "tough-cookie/tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
 
+    "ts-jest/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
     "typescript-eslint/@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.60.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.60.0", "@typescript-eslint/type-utils": "8.60.0", "@typescript-eslint/utils": "8.60.0", "@typescript-eslint/visitor-keys": "8.60.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.60.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw=="],
 
     "typescript-eslint/@typescript-eslint/utils": ["@typescript-eslint/utils@8.60.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.60.0", "@typescript-eslint/types": "8.60.0", "@typescript-eslint/typescript-estree": "8.60.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA=="],
-
-    "webext-messenger/type-fest": ["type-fest@5.7.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -82,6 +82,7 @@
     "js-yaml": "^4.1.0",
     "knip": "^6.15.0",
     "ts-jest": "^29",
+    "type-fest": "^5.7.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "8.60.0",
     "zod": "^4.4.3"

--- a/extension/src/lib/background/lifecycle.ts
+++ b/extension/src/lib/background/lifecycle.ts
@@ -9,6 +9,7 @@
 // doesn't own — session-store writes and the content broadcast (content scripts
 // can't observe the session area, so the background bridges every change).
 
+import type { Entries } from "type-fest";
 // `rules/rule-metadata` (not `rules/index`) keeps this worker module free of
 // rule-file DOM access — see `check-background-purity.ts`.
 import type { RuleId } from "../../rules/rule-metadata";
@@ -200,10 +201,9 @@ export function startBackgroundLifecycle(tracker: TabTracker): void {
     if (previous === null) {
       return;
     }
-    for (const [kind, ruleId] of Object.entries(DETECTION_KIND_TO_RULE_ID) as [
-      DetectionKind,
-      RuleId,
-    ][]) {
+    for (const [kind, ruleId] of Object.entries(
+      DETECTION_KIND_TO_RULE_ID,
+    ) as Entries<typeof DETECTION_KIND_TO_RULE_ID>) {
       if (previous[ruleId] && !next[ruleId]) {
         tracker.clearDetectionsOfKind(kind);
       }

--- a/extension/src/lib/background/tab-tracker.ts
+++ b/extension/src/lib/background/tab-tracker.ts
@@ -9,6 +9,7 @@
 // mock. All maps are dropped on a service-worker restart — the same fail-open
 // posture every cache below assumes.
 
+import type { Entries } from "type-fest";
 import type { RuleId } from "../../rules/rule-metadata";
 import type {
   DetectionKind,
@@ -121,10 +122,9 @@ export function createTabTracker(): TabTracker {
       return summed;
     }
     for (const frameCounts of frames.values()) {
-      for (const [ruleId, count] of Object.entries(frameCounts) as [
-        RuleId,
-        number,
-      ][]) {
+      for (const [ruleId, count] of Object.entries(frameCounts) as Entries<
+        Required<RuleCountMap>
+      >) {
         summed[ruleId] = (summed[ruleId] ?? 0) + count;
       }
     }

--- a/extension/src/lib/message-schemas.ts
+++ b/extension/src/lib/message-schemas.ts
@@ -13,6 +13,7 @@
 // bundles — the senders pass typed payloads; the worker is the only context
 // that validates.
 
+import type { IsEqual } from "type-fest";
 import { z } from "zod";
 import type { RuleId } from "../rules/rule-metadata";
 import { RULE_IDS } from "../rules/rule-metadata";
@@ -22,9 +23,10 @@ import type { MessengerMeta, PageWorldInjectType } from "./messenger";
 
 const KNOWN_RULE_IDS = new Set<string>(RULE_IDS);
 
-// Bidirectional `extends` ≈ structural equality — a drift guard that fails the
-// build if a schema and the hand-written wire type stop agreeing.
-type AssertExtends<A extends B, B> = A extends B ? true : never;
+// Compile-time drift guard: `IsEqual` is true only when the schema's inferred
+// type and the hand-written wire type are structurally identical, so the build
+// fails the moment they stop agreeing.
+type AssertTrue<T extends true> = T;
 
 // ── rule-detection payload (discriminated union mirrors DetectionPayload) ──
 const detectionPayloadSchema = z.discriminatedUnion("kind", [
@@ -47,15 +49,10 @@ const detectionPayloadSchema = z.discriminatedUnion("kind", [
     url: z.string(),
   }),
 ]);
-// Fails to compile if `DetectionPayload` and the schema diverge in either
-// direction (a new kind, a renamed field, a widened enum).
-type _DetectionParityA = AssertExtends<
-  z.infer<typeof detectionPayloadSchema>,
-  DetectionPayload
->;
-type _DetectionParityB = AssertExtends<
-  DetectionPayload,
-  z.infer<typeof detectionPayloadSchema>
+// Fails to compile if `DetectionPayload` and the schema diverge (a new kind, a
+// renamed field, a widened enum).
+type _DetectionParity = AssertTrue<
+  IsEqual<z.infer<typeof detectionPayloadSchema>, DetectionPayload>
 >;
 
 // ── per-frame rule counts ──

--- a/extension/src/lib/rule-engine.ts
+++ b/extension/src/lib/rule-engine.ts
@@ -3,6 +3,7 @@
 
 import type { CatalogRule } from "../rules";
 import { RULES } from "../rules";
+import { buildRuleRecord } from "../rules/rule-metadata";
 import type { RuleAvailabilityStates } from "./availability";
 import {
   getRuleAvailabilityStates,
@@ -265,12 +266,7 @@ function applyDisplayMode(mode: PlaceholderDisplayMode): void {
   document.documentElement.setAttribute(PLACEHOLDER_MODE_ATTR, mode);
 }
 
-// `Object.fromEntries` types its result as `{ [k: string]: false }`; every
-// `RuleId` is covered because the entries come from `RULES`, so the cast to the
-// exact `RuleStates` shape is sound.
-const ALL_DISABLED = Object.fromEntries(
-  RULES.map((rule) => [rule.id, false]),
-) as RuleStates;
+const ALL_DISABLED: RuleStates = buildRuleRecord(() => false);
 
 function mask(states: RuleStates, enforcementEnabled: boolean): RuleStates {
   return enforcementEnabled ? states : ALL_DISABLED;

--- a/extension/src/lib/storage.ts
+++ b/extension/src/lib/storage.ts
@@ -9,7 +9,11 @@
 // data. The post-build purity check (`scripts/check-background-purity.ts`)
 // guards against regressions.
 import type { RuleId } from "../rules";
-import { RULE_DEFAULTS, RULE_IDS } from "../rules/rule-metadata";
+import {
+  buildRuleRecord,
+  RULE_DEFAULTS,
+  RULE_IDS,
+} from "../rules/rule-metadata";
 import { createChromeStorageValue } from "./chrome-storage-value";
 
 export type RuleStates = Record<RuleId, boolean>;
@@ -54,11 +58,9 @@ function parseOverrides(): Partial<RuleStates> {
 
 const OVERRIDES: Partial<RuleStates> = parseOverrides();
 
-// `RULE_IDS.map` covers every `RuleId`; `Object.fromEntries` widens the key to
-// `string`, so cast back to the exact `RuleStates` shape.
-const DEFAULT_STATES = Object.fromEntries(
-  RULE_IDS.map((id) => [id, OVERRIDES[id] ?? RULE_DEFAULTS[id]]),
-) as RuleStates;
+const DEFAULT_STATES: RuleStates = buildRuleRecord(
+  (id) => OVERRIDES[id] ?? RULE_DEFAULTS[id],
+);
 
 function normalize(raw: unknown): RuleStates {
   const result: RuleStates = { ...DEFAULT_STATES };

--- a/extension/src/options/__tests__/parse-config.test.ts
+++ b/extension/src/options/__tests__/parse-config.test.ts
@@ -5,11 +5,18 @@
 // from `rules/rule-metadata`. Mock the metadata module so the test runs
 // against a small id set (and so storage.ts's transitive `rules/index.ts`
 // import doesn't pull in every rule file — some of which reach for ESM-only
-// deps that ts-jest's CJS transform can't handle).
-jest.mock("../../rules/rule-metadata", () => ({
-  RULE_DEFAULTS: { "rule-a": true, "rule-b": false },
-  RULE_IDS: ["rule-a", "rule-b"],
-}));
+// deps that ts-jest's CJS transform can't handle). `buildRuleRecord` is mocked
+// too because storage.ts calls it at module-init to build its default state;
+// the stub mirrors the real helper over the small id set above.
+jest.mock("../../rules/rule-metadata", () => {
+  const RULE_IDS = ["rule-a", "rule-b"];
+  return {
+    RULE_DEFAULTS: { "rule-a": true, "rule-b": false },
+    RULE_IDS,
+    buildRuleRecord: (value: (id: string) => unknown) =>
+      Object.fromEntries(RULE_IDS.map((id) => [id, value(id)])),
+  };
+});
 
 import { parseConfig } from "../parse-config";
 

--- a/extension/src/rules/rule-metadata.ts
+++ b/extension/src/rules/rule-metadata.ts
@@ -60,6 +60,21 @@ export type RuleId = keyof typeof RULE_DEFAULTS;
 
 export const RULE_IDS = Object.keys(RULE_DEFAULTS) as readonly RuleId[];
 
+// Build a record that holds an entry for every `RuleId`. `Object.fromEntries`
+// types its result with a `string` key, so the assertion back to
+// `Record<RuleId, V>` lives here once rather than at each call site. Key
+// coverage is guaranteed (the keys come from `RULE_IDS`, the canonical list)
+// and `V` is inferred from `value`, so callers keep a checked value type
+// instead of a blanket `as` cast over the whole map.
+export function buildRuleRecord<V>(
+  value: (id: RuleId) => V,
+): Record<RuleId, V> {
+  return Object.fromEntries(RULE_IDS.map((id) => [id, value(id)])) as Record<
+    RuleId,
+    V
+  >;
+}
+
 // Per-rule build-time options. Rules whose behaviour is governed by more than
 // a single on/off toggle declare their option shape here. The override file
 // loader (`scripts/load-default-overrides.ts`) accepts an object value for any


### PR DESCRIPTION
## What

Type-level cleanup from a survey of hand-rolled type gymnastics. Type-only, no runtime change. Two themes:

### 1. Adopt `type-fest` helpers
Adds `type-fest` as a dev dependency and replaces two hand-written patterns:

- **`Entries<T>`** — `Object.entries(x)` widens keys to `string`, so the code asserted the tuple shape by hand (`as [K, V][]`), which can silently drift from the map it iterates. Now derived from the source type:
  - `lifecycle.ts` → `Entries<typeof DETECTION_KIND_TO_RULE_ID>`
  - `tab-tracker.ts` → `Entries<Required<RuleCountMap>>` (the `Required<>` drops `undefined` from the `Partial` record's value so the cross-frame sum still types as `number`)
- **`IsEqual<A, B>`** — `message-schemas.ts` had an `AssertExtends` helper applied in both directions to approximate structural equality between the zod inference and the hand-written wire type. `IsEqual` expresses that as one stricter assertion. tsc confirms the schema and `DetectionPayload` are still identical.

### 2. Centralize `Object.fromEntries` rule-record casts
`type-fest` has **no `FromEntries`** helper, so the four `Object.fromEntries(...) as T` casts can't be typed off-the-shelf. Two build the same `Record<RuleId, boolean>` shape, so they now route through a small `buildRuleRecord` helper in `rule-metadata.ts`:

- `storage.ts` `DEFAULT_STATES`
- `rule-engine.ts` `ALL_DISABLED`

The single unavoidable `as` (the `string`-key widening) now lives once inside the helper; call sites are cast-free, key coverage is guaranteed by `RULE_IDS`, and the value type is inferred + checked.

## Deliberately not done
- **`PartialRecord` / `FromEntries`** — neither exists in type-fest v5. `Partial<Record<…>>` is already idiomatic; nothing to swap.
- The other two `fromEntries` sites: `availability.ts` builds its map async over `RULES` (needs the rule object) and `rule-options.ts` produces the non-uniform `RuleOptions` shape — neither fits a `Record<RuleId, V>` builder.

## Checks
- `bun run check` ✅
- `tsc --noEmit` ✅
- affected suites (tab-tracker / lifecycle / message-schemas / storage / rule-engine / rule-metadata / catalog) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)