### PR TITLE
Chore: group Dependabot updates (react family + prod patches), add pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,8 @@
 version: 2
+
+# Group rules are evaluated in order: a dependency joins the first group whose
+# rules it satisfies. `react` comes first so the React family travels together
+# (across prod + dev) instead of being split by dependency-type.
 updates:
   - package-ecosystem: bun
     directory: /extension
@@ -8,6 +12,19 @@ updates:
       default-days: 7
     open-pull-requests-limit: 5
     groups:
+      react:
+        patterns:
+          - react
+          - react-dom
+          - react-router*
+          - "@types/react"
+          - "@types/react-dom"
+          - "@vitejs/plugin-react"
+          - eslint-plugin-react-hooks
+        update-types: [minor, patch]
+      production-deps:
+        dependency-type: production
+        update-types: [patch]
       dev-deps:
         dependency-type: development
         update-types: [minor, patch]
@@ -20,6 +37,19 @@ updates:
       default-days: 7
     open-pull-requests-limit: 5
     groups:
+      react:
+        patterns:
+          - react
+          - react-dom
+          - react-router*
+          - "@types/react"
+          - "@types/react-dom"
+          - "@vitejs/plugin-react"
+          - eslint-plugin-react-hooks
+        update-types: [minor, patch]
+      production-deps:
+        dependency-type: production
+        update-types: [patch]
       dev-deps:
         dependency-type: development
         update-types: [minor, patch]
@@ -32,6 +62,9 @@ updates:
       default-days: 7
     open-pull-requests-limit: 5
     groups:
+      production-deps:
+        dependency-type: production
+        update-types: [patch]
       dev-deps:
         dependency-type: development
         update-types: [minor, patch]
@@ -44,6 +77,13 @@ updates:
       default-days: 7
 
   - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: pre-commit
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary

Reduces Dependabot PR noise by grouping updates that belong together, and closes an ecosystem coverage gap.

- **`react` group** (`/extension`, `/demo-site`) — bundles the React family across prod *and* dev (`react`, `react-dom`, `react-router*`, `@types/react`, `@types/react-dom`, `@vitejs/plugin-react`, `eslint-plugin-react-hooks`) at **minor + patch**. This collapses splits like #257 ("Bump react and @types/react") into one PR.
- **`production-deps` group** (all bun ecosystems) — bundles production **patch** bumps together. Production *minor*/*major* still get individual PRs for isolated review.
- **`pre-commit` ecosystem** — added; hook versions in `.pre-commit-config.yaml` were previously drifting unmanaged.
- `dev-deps` group (minor + patch) is unchanged.

Group order matters in Dependabot — a dependency joins the first matching group — so `react` is listed before `production-deps`/`dev-deps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)