### PR TITLE
Ratchet unicorn/better-dom-traversing + prefer-number-is-safe-integer to error

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -212,9 +212,7 @@ export default tseslint.config(
       "unicorn/no-declarations-before-early-exit": "warn",
       "unicorn/no-global-object-property-assignment": "warn",
       "unicorn/prefer-minimal-ternary": "warn",
-      "unicorn/prefer-number-is-safe-integer": "warn",
       "unicorn/prefer-iterator-to-array": "warn",
-      "unicorn/better-dom-traversing": "warn",
       "unicorn/no-incorrect-query-selector": "warn",
       "unicorn/no-top-level-side-effects": "warn",
       // Partially autofixable — fixable instances are corrected in-tree; the

--- a/extension/src/lib/background/lifecycle.ts
+++ b/extension/src/lib/background/lifecycle.ts
@@ -159,7 +159,7 @@ export function startBackgroundLifecycle(tracker: TabTracker): void {
   // type is contravariantly assignable — no cast needed.
   tabPauseMap.onChanged((key, value: TabPause | undefined) => {
     const tabId = Number(key);
-    if (!Number.isInteger(tabId)) {
+    if (!Number.isSafeInteger(tabId)) {
       return;
     }
     tracker.setTabPause(tabId, value);
@@ -177,7 +177,7 @@ export function startBackgroundLifecycle(tracker: TabTracker): void {
     try {
       for await (const [key, value] of tabPauseMap.entries()) {
         const tabId = Number(key);
-        if (Number.isInteger(tabId)) {
+        if (Number.isSafeInteger(tabId)) {
           tracker.setTabPause(tabId, value);
         }
       }

--- a/extension/src/lib/page-tree.ts
+++ b/extension/src/lib/page-tree.ts
@@ -263,9 +263,9 @@ function getElementTree(element: HTMLElement): Node | undefined {
     }
     if (
       compressedElement.childNodes.length === 1 &&
-      compressedElement.childNodes[0]?.nodeType !== Node.TEXT_NODE
+      compressedElement.firstChild?.nodeType !== Node.TEXT_NODE
     ) {
-      return compressedElement.childNodes[0];
+      return compressedElement.firstChild ?? undefined;
     }
   }
 


### PR DESCRIPTION
First ratchet from #279 — the smallest, lowest-risk pair.

## Changes
- `src/lib/page-tree.ts`: `.childNodes[0]` → `.firstChild` (2 sites). `.firstChild` returns `ChildNode | null` while `getElementTree` returns `Node | undefined`, so the return coerces `null` → `undefined`. Behaviorally identical (`childNodes[0]` ≡ `firstChild`).
- `src/lib/background/lifecycle.ts`: `Number.isInteger(tabId)` → `Number.isSafeInteger(tabId)` (2 sites). Tab IDs are well within safe-integer range, so this is strictly more correct.
- `eslint.config.js`: both rules removed from the warn list, reverting to their unicorn/recommended default (`error`).

## Verification
- `bun run typecheck` clean
- `bun run check` exit 0 (the two rules now error; 0 errors remain)
- `bun run test` — 2059/2059 pass

Refs #279