### PR TITLE
Ratchet unicorn/prefer-includes-over-repeated-comparisons to error

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -212,9 +212,7 @@ export default tseslint.config(
       "unicorn/no-declarations-before-early-exit": "warn",
       "unicorn/no-global-object-property-assignment": "warn",
       "unicorn/prefer-minimal-ternary": "warn",
-      "unicorn/prefer-number-is-safe-integer": "warn",
       "unicorn/prefer-iterator-to-array": "warn",
-      "unicorn/better-dom-traversing": "warn",
       "unicorn/no-incorrect-query-selector": "warn",
       "unicorn/no-top-level-side-effects": "warn",
       // Partially autofixable — fixable instances are corrected in-tree; the

--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -204,7 +204,6 @@ export default tseslint.config(
       "unicorn/no-break-in-nested-loop": "warn",
       "unicorn/no-computed-property-existence-check": "warn",
       "unicorn/max-nested-calls": "warn",
-      "unicorn/prefer-includes-over-repeated-comparisons": "warn",
       "unicorn/prefer-number-coercion": "warn",
       "unicorn/no-unreadable-new-expression": "warn",
       "unicorn/require-array-sort-compare": "warn",

--- a/extension/src/lib/__tests__/text-walk-shadow.property.test.ts
+++ b/extension/src/lib/__tests__/text-walk-shadow.property.test.ts
@@ -193,12 +193,7 @@ function referenceTextNodes(
     // Match the helpers' NON_CONTENT_TAGS pruning. The generator
     // doesn't emit script/style/noscript/template, so this is just
     // a defensive mirror.
-    if (
-      element.tagName === "SCRIPT" ||
-      element.tagName === "STYLE" ||
-      element.tagName === "NOSCRIPT" ||
-      element.tagName === "TEMPLATE"
-    ) {
+    if (["SCRIPT", "STYLE", "NOSCRIPT", "TEMPLATE"].includes(element.tagName)) {
       return;
     }
     for (const child of element.childNodes) {

--- a/extension/src/lib/background/lifecycle.ts
+++ b/extension/src/lib/background/lifecycle.ts
@@ -159,7 +159,7 @@ export function startBackgroundLifecycle(tracker: TabTracker): void {
   // type is contravariantly assignable — no cast needed.
   tabPauseMap.onChanged((key, value: TabPause | undefined) => {
     const tabId = Number(key);
-    if (!Number.isInteger(tabId)) {
+    if (!Number.isSafeInteger(tabId)) {
       return;
     }
     tracker.setTabPause(tabId, value);
@@ -177,7 +177,7 @@ export function startBackgroundLifecycle(tracker: TabTracker): void {
     try {
       for await (const [key, value] of tabPauseMap.entries()) {
         const tabId = Number(key);
-        if (Number.isInteger(tabId)) {
+        if (Number.isSafeInteger(tabId)) {
           tracker.setTabPause(tabId, value);
         }
       }

--- a/extension/src/lib/page-tree.ts
+++ b/extension/src/lib/page-tree.ts
@@ -263,9 +263,9 @@ function getElementTree(element: HTMLElement): Node | undefined {
     }
     if (
       compressedElement.childNodes.length === 1 &&
-      compressedElement.childNodes[0]?.nodeType !== Node.TEXT_NODE
+      compressedElement.firstChild?.nodeType !== Node.TEXT_NODE
     ) {
-      return compressedElement.childNodes[0];
+      return compressedElement.firstChild ?? undefined;
     }
   }
 

--- a/extension/src/lib/site-denylist.ts
+++ b/extension/src/lib/site-denylist.ts
@@ -85,14 +85,12 @@ export const siteDenylistStorage = createChromeStorageValue<string[]>({
 // would be a no-op on those URLs even if storage accepted a pattern for
 // them. file:// runs the content script when the user has granted access,
 // so we include it.
+const CONTENT_SCHEME_PROTOCOLS = new Set(["http:", "https:", "file:"]);
+
 export function isContentSchemeUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return (
-      parsed.protocol === "http:" ||
-      parsed.protocol === "https:" ||
-      parsed.protocol === "file:"
-    );
+    return CONTENT_SCHEME_PROTOCOLS.has(parsed.protocol);
   } catch {
     return false;
   }

--- a/extension/src/rules/disguised-ad-flag.ts
+++ b/extension/src/rules/disguised-ad-flag.ts
@@ -140,34 +140,33 @@ function matchLabel(text: string): LabelMatch | null {
   return null;
 }
 
+const INTERACTIVE_TAGS = new Set([
+  "button",
+  "select",
+  "option",
+  "input",
+  "textarea",
+  "label",
+]);
+const INTERACTIVE_ROLES = new Set([
+  "button",
+  "tab",
+  "menuitem",
+  "option",
+  "checkbox",
+  "radio",
+  "switch",
+]);
+
 // Interactive / form-control ancestors indicate the candidate is a filter
 // chip, sort option, or button — not an advertorial label. Stop walking
 // upward as soon as one of these is hit.
 function isInteractiveAncestor(element: Element): boolean {
-  const name = element.localName;
-  if (
-    name === "button" ||
-    name === "select" ||
-    name === "option" ||
-    name === "input" ||
-    name === "textarea" ||
-    name === "label"
-  ) {
+  if (INTERACTIVE_TAGS.has(element.localName)) {
     return true;
   }
   const role = element.getAttribute("role");
-  if (
-    role === "button" ||
-    role === "tab" ||
-    role === "menuitem" ||
-    role === "option" ||
-    role === "checkbox" ||
-    role === "radio" ||
-    role === "switch"
-  ) {
-    return true;
-  }
-  return false;
+  return role !== null && INTERACTIVE_ROLES.has(role);
 }
 
 // Navigation / landmark ancestors — labels here are nav links to the
@@ -182,6 +181,8 @@ function isNavigationAncestor(element: Element): boolean {
   return role === "navigation" || role === "banner";
 }
 
+const PAGE_BOUNDARY_TAGS = new Set(["main", "body", "html"]);
+
 // Boundary tags we treat as "you've walked too far". Once we reach <main>,
 // <body>, or <html>, the label isn't sitting on an article card.
 // `<section>` is intentionally not a boundary — it's the natural wrapper
@@ -189,8 +190,7 @@ function isNavigationAncestor(element: Element): boolean {
 // crossing it would let a label inside one card adopt sibling cards'
 // signals (see #228 — entire reddit feed replaced as one placeholder).
 function isPageBoundary(element: Element): boolean {
-  const name = element.localName;
-  if (name === "main" || name === "body" || name === "html") {
+  if (PAGE_BOUNDARY_TAGS.has(element.localName)) {
     return true;
   }
   const role = element.getAttribute("role");

--- a/extension/src/rules/hidden-fee-annotate.ts
+++ b/extension/src/rules/hidden-fee-annotate.ts
@@ -176,42 +176,52 @@ export function isCurrencyAmount(text: string): boolean {
   return CURRENCY_ONLY_RE.test(text);
 }
 
+const INTERACTIVE_TAGS = new Set([
+  "button",
+  "select",
+  "option",
+  "input",
+  "textarea",
+  "label",
+]);
+const INTERACTIVE_ROLES = new Set([
+  "button",
+  "tab",
+  "menuitem",
+  "option",
+  "checkbox",
+  "radio",
+  "switch",
+]);
+const NAVIGATION_TAGS = new Set(["nav", "header", "footer"]);
+const NAVIGATION_ROLES = new Set(["navigation", "banner", "contentinfo"]);
+const PAGE_BOUNDARY_TAGS = new Set(["main", "body", "html"]);
+const ORDER_SUMMARY_CONTAINER_TAGS = new Set([
+  "aside",
+  "section",
+  "div",
+  "ul",
+  "ol",
+]);
+
 function isInteractiveAncestor(element: Element): boolean {
-  const name = element.localName;
-  if (
-    name === "button" ||
-    name === "select" ||
-    name === "option" ||
-    name === "input" ||
-    name === "textarea" ||
-    name === "label"
-  ) {
+  if (INTERACTIVE_TAGS.has(element.localName)) {
     return true;
   }
   const role = element.getAttribute("role");
-  return (
-    role === "button" ||
-    role === "tab" ||
-    role === "menuitem" ||
-    role === "option" ||
-    role === "checkbox" ||
-    role === "radio" ||
-    role === "switch"
-  );
+  return role !== null && INTERACTIVE_ROLES.has(role);
 }
 
 function isNavigationAncestor(element: Element): boolean {
-  const name = element.localName;
-  if (name === "nav" || name === "header" || name === "footer") {
+  if (NAVIGATION_TAGS.has(element.localName)) {
     return true;
   }
   const role = element.getAttribute("role");
-  return role === "navigation" || role === "banner" || role === "contentinfo";
+  return role !== null && NAVIGATION_ROLES.has(role);
 }
 
 function isPageBoundary(element: Element): boolean {
-  const name = element.localName;
-  if (name === "main" || name === "body" || name === "html") {
+  if (PAGE_BOUNDARY_TAGS.has(element.localName)) {
     return true;
   }
   return element.getAttribute("role") === "main";
@@ -261,13 +271,7 @@ function isOrderSummaryContainer(element: Element): boolean {
     return true;
   }
   // Container element with cart-shaped class or id.
-  if (
-    tag === "aside" ||
-    tag === "section" ||
-    tag === "div" ||
-    tag === "ul" ||
-    tag === "ol"
-  ) {
+  if (ORDER_SUMMARY_CONTAINER_TAGS.has(tag)) {
     const className =
       typeof element.className === "string" ? element.className : "";
     const idAttribute = element.id;

--- a/extension/src/rules/schema-trust-sanitize.ts
+++ b/extension/src/rules/schema-trust-sanitize.ts
@@ -208,6 +208,11 @@ function scopedDescendants(scope: Element, itempropName: string): Element[] {
   return out;
 }
 
+// Microdata URL carriers: <a>/<link>/<area> expose the value via href,
+// <img>/<audio>/<video>/<source> via src.
+const HREF_CARRIER_TAGS = new Set(["A", "LINK", "AREA"]);
+const SRC_CARRIER_TAGS = new Set(["IMG", "AUDIO", "VIDEO", "SOURCE"]);
+
 function readItempropValue(element: Element): string {
   // The microdata spec defines the itemprop value per element type:
   // <meta> uses content, <a>/<link>/<area> use href, <img>/<audio>/etc.
@@ -218,10 +223,10 @@ function readItempropValue(element: Element): string {
   if (tag === "META") {
     return element.getAttribute("content") ?? "";
   }
-  if (tag === "A" || tag === "LINK" || tag === "AREA") {
+  if (HREF_CARRIER_TAGS.has(tag)) {
     return element.getAttribute("href") ?? "";
   }
-  if (tag === "IMG" || tag === "AUDIO" || tag === "VIDEO" || tag === "SOURCE") {
+  if (SRC_CARRIER_TAGS.has(tag)) {
     return element.getAttribute("src") ?? "";
   }
   // `textContent` on an Element (not a Document or DocumentType) is
@@ -239,14 +244,14 @@ function blankItempropValue(element: Element): boolean {
     }
     return false;
   }
-  if (tag === "A" || tag === "LINK" || tag === "AREA") {
+  if (HREF_CARRIER_TAGS.has(tag)) {
     if (element.getAttribute("href") !== "") {
       element.setAttribute("href", "");
       return true;
     }
     return false;
   }
-  if (tag === "IMG" || tag === "AUDIO" || tag === "VIDEO" || tag === "SOURCE") {
+  if (SRC_CARRIER_TAGS.has(tag)) {
     if (element.getAttribute("src") !== "") {
       element.setAttribute("src", "");
       return true;


### PR DESCRIPTION
Second ratchet from #279. **Stacked on #280** (base = `ratchet-unicorn-dom-traversal`).

Pivoted from `no-computed-property-existence-check`: investigation showed it's ~21 false positives vs 2 real wins in this codebase (fires on any `obj[dynamicKey]` in a boolean position, e.g. `!RULE_DEFAULTS[id]`), so it stays a warning. `prefer-includes-over-repeated-comparisons` is a clean, high-value alternative.

## Changes
Replaced 15 repeated `x === "a" || x === "b" || …` literal chains (none autofixable) with membership lookups. Since `unicorn/prefer-set-has` (already an `error`) wants `Set.has()` over array `.includes()` for these — and that matches the codebase's existing tag-set style — the lists became module-level `Set`s, constructed once at module load:

- `disguised-ad-flag.ts` — interactive tags/roles, page-boundary tags
- `hidden-fee-annotate.ts` — interactive tags/roles, navigation tags/roles, page-boundary tags, order-summary container tags
- `schema-trust-sanitize.ts` — href / src microdata carrier tags (each used in two functions)
- `site-denylist.ts` — content-scheme protocols
- `text-walk-shadow.property.test.ts` — non-content tag guard (inline `.includes`, test-only)

`eslint.config.js`: rule removed from the warn list → reverts to unicorn/recommended default (`error`).

## Performance
No production impact. The membership `Set`s are built once at module load (not per call), so per-element checks stay O(1) with no new per-call allocation — if anything marginally faster than the `===` chains for the longer lists. The one inline `.includes` is test-only.

## Verification
- `bun run typecheck` clean
- `bun run check` exit 0 (rule now errors; 0 violations)
- `bun run test` — 2059/2059 pass

Refs #279