### PR TITLE
Ratchet unicorn/prefer-type-literal-last to error

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -217,7 +217,6 @@ export default tseslint.config(
       // Partially autofixable — fixable instances are corrected in-tree; the
       // remainder warn until handled in #279.
       "unicorn/no-unnecessary-global-this": "warn",
-      "unicorn/prefer-type-literal-last": "warn",
       "unicorn/prefer-short-arrow-method": "warn",
 
       // Allow underscore-prefixed unused parameters (e.g. `_root` for the

--- a/extension/src/lib/__tests__/rule-count.test.ts
+++ b/extension/src/lib/__tests__/rule-count.test.ts
@@ -39,7 +39,7 @@ function sentCssOnlyTraces(): RuleApplicationEvent[] {
   return stub
     .sentEntries()
     .filter(
-      (entry): entry is { type: "rule-application" } & RuleApplicationEvent =>
+      (entry): entry is RuleApplicationEvent & { type: "rule-application" } =>
         entry.type === "rule-application" && entry.cssOnly === true,
     );
 }

--- a/extension/src/lib/__tests__/trace-mutation.test.ts
+++ b/extension/src/lib/__tests__/trace-mutation.test.ts
@@ -25,7 +25,7 @@ function ruleApplicationEvents(): RuleApplicationEvent[] {
   return stub
     .sentEntries()
     .filter(
-      (entry): entry is { type: "rule-application" } & RuleApplicationEvent =>
+      (entry): entry is RuleApplicationEvent & { type: "rule-application" } =>
         entry.type === "rule-application",
     );
 }

--- a/extension/src/lib/detection-messages.ts
+++ b/extension/src/lib/detection-messages.ts
@@ -158,9 +158,9 @@ export interface NavigationEvent {
 }
 
 export type DebugTraceEntry =
-  | ({ type: "segment" } & SegmentMarker)
-  | ({ type: "rule-application" } & RuleApplicationEvent)
-  | ({ type: "navigation" } & NavigationEvent);
+  | (SegmentMarker & { type: "segment" })
+  | (RuleApplicationEvent & { type: "rule-application" })
+  | (NavigationEvent & { type: "navigation" });
 
 // Stored shape returned by `getEventsForTab`. Mirrors the `StoredEvent`
 // interface in `debug-trace-store.ts`; kept structurally parallel here


### PR DESCRIPTION
Third ratchet from #279 (now that #280 and #281 have merged, this targets `main`).

Type-only change: the five flagged sites are all `{ type: "…" } & EventType` intersections, reordered so the object type literal comes last (`EventType & { type: "…" }`). Intersection is commutative — zero runtime or type-checking behavior change.

- `detection-messages.ts` — `DebugTraceEntry` union (3 members)
- `rule-count.test.ts`, `trace-mutation.test.ts` — type-guard predicates

`eslint.config.js`: rule removed from the warn list → reverts to unicorn/recommended default (`error`).

Verification: `typecheck` clean, `check` exit 0 (0 violations), `test` 2059/2059 pass.

Refs #279