### PR TITLE
Ratchet unicorn/no-global-object-property-assignment to error (off in tests)

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -209,7 +209,9 @@ export default tseslint.config(
       "unicorn/require-array-sort-compare": "warn",
       "unicorn/prefer-uint8array-base64": "warn",
       "unicorn/no-declarations-before-early-exit": "warn",
-      "unicorn/no-global-object-property-assignment": "warn",
+      // no-global-object-property-assignment stays at its recommended `error`
+      // for production code; it's disabled only for tests (which legitimately
+      // assign globals to set up mocks) in the test-files block below.
       "unicorn/prefer-minimal-ternary": "warn",
       "unicorn/prefer-iterator-to-array": "warn",
       "unicorn/no-incorrect-query-selector": "warn",
@@ -251,6 +253,9 @@ export default tseslint.config(
       // Tests legitimately use literal nulls and many small `for` loops.
       "unicorn/no-useless-undefined": "off",
       "unicorn/consistent-function-scoping": "off",
+      // Tests assign onto global objects to install mocks / stubs; the rule
+      // stays an error everywhere else.
+      "unicorn/no-global-object-property-assignment": "off",
       // Jest matchers and mock patterns routinely pass methods by reference.
       "@typescript-eslint/unbound-method": "off",
 


### PR DESCRIPTION
Fourth ratchet from #279.

All 6 flagged sites were in test files (`subtree-watcher.test.ts`, `hidden-fee-annotate.test.ts`), which legitimately assign onto globals to set up mocks. So instead of keeping it a blanket warning, this enforces it as **error for production code** and disables it **only in tests**.

## Changes (`eslint.config.js` only)
- Removed from the warn list → reverts to the unicorn/recommended default (`error`).
- Added `"unicorn/no-global-object-property-assignment": "off"` to the `src/**/__tests__/**` override block.

## Verification
- No production code violates the rule — `eslint .` reports 0 errors for it, including the `__test-mocks__` tree (which the glob doesn't cover but the rule doesn't flag).
- `bun run check` exit 0
- `bun run test` — 2059/2059 pass

Refs #279