### PR TITLE
Ratchet unicorn/no-declarations-before-early-exit to error

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -208,7 +208,6 @@ export default tseslint.config(
       "unicorn/no-unreadable-new-expression": "warn",
       "unicorn/require-array-sort-compare": "warn",
       "unicorn/prefer-uint8array-base64": "warn",
-      "unicorn/no-declarations-before-early-exit": "warn",
       // no-global-object-property-assignment stays at its recommended `error`
       // for production code; it's disabled only for tests (which legitimately
       // assign globals to set up mocks) in the test-files block below.

--- a/extension/scripts/load-default-overrides.ts
+++ b/extension/scripts/load-default-overrides.ts
@@ -171,10 +171,6 @@ function flattenIssues(
 ): z.core.$ZodIssue[] {
   const out: z.core.$ZodIssue[] = [];
   for (const issue of issues) {
-    const prefixedIssue =
-      prefix.length === 0
-        ? issue
-        : { ...issue, path: [...prefix, ...issue.path] };
     if (
       issue.code === "invalid_union" &&
       "errors" in issue &&
@@ -199,6 +195,10 @@ function flattenIssues(
         continue;
       }
     }
+    const prefixedIssue =
+      prefix.length === 0
+        ? issue
+        : { ...issue, path: [...prefix, ...issue.path] };
     out.push(prefixedIssue);
   }
   return out;

--- a/extension/src/lib/checkout-checkbox-defense-source.ts
+++ b/extension/src/lib/checkout-checkbox-defense-source.ts
@@ -46,15 +46,6 @@ export function installCheckoutCheckboxDefense(this: Window): void {
   }
   defenseWindow[FLAG] = true;
 
-  // Mirror of CHECKOUT_CHECKBOX_CLEARED_ATTR from lib/dom-markers.ts.
-  // Hard-coded because this function runs in the page world with no
-  // module imports; the isolated-world rule and the markers registry
-  // share the same literal, asserted by a unit test. The lint rule that
-  // bans inline `data-abs-*` literals exists to keep the registry the
-  // single source of truth — this is the one principled exception.
-  // eslint-disable-next-line no-restricted-syntax
-  const CLEARED_ATTR = "data-abs-cleared";
-
   // Mirror of the URLPattern set in lib/checkout-url.ts as a single
   // anchored regex. `/cart`, `/cart/`, `/cart/sub` match; `/cartx`,
   // `/products/cart-bag`, `/orders` do not. Asserted against the rule's
@@ -87,6 +78,16 @@ export function installCheckoutCheckboxDefense(this: Window): void {
     // disable the defense rather than block the page.
     return;
   }
+
+  // Mirror of CHECKOUT_CHECKBOX_CLEARED_ATTR from lib/dom-markers.ts.
+  // Hard-coded because this function runs in the page world with no
+  // module imports; the isolated-world rule and the markers registry
+  // share the same literal, asserted by a unit test. The lint rule that
+  // bans inline `data-abs-*` literals exists to keep the registry the
+  // single source of truth — this is the one principled exception.
+  // eslint-disable-next-line no-restricted-syntax
+  const CLEARED_ATTR = "data-abs-cleared";
+
   const nativeSetter = descriptor.set;
   const nativeGetter = descriptor.get;
 

--- a/extension/src/lib/yielding-text-walk.ts
+++ b/extension/src/lib/yielding-text-walk.ts
@@ -108,10 +108,6 @@ export function walkTextNodesChunked(
     shouldSkipParent ? { minLength, shouldSkipParent } : { minLength },
   );
 
-  if (signal?.aborted) {
-    return;
-  }
-
   let index = 0;
 
   function runFinalize(): void {
@@ -196,10 +192,6 @@ export function walkTextNodeGroupsChunked(
     root,
     shouldSkipParent ? { minLength, shouldSkipParent } : { minLength },
   );
-
-  if (signal?.aborted) {
-    return;
-  }
 
   let index = 0;
 

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -31,6 +31,9 @@ export function Popup() {
       });
   }, []);
 
+  // Hooks must run unconditionally before any early return, so this cannot
+  // move below the loading guard (would violate react-hooks/rules-of-hooks).
+  // eslint-disable-next-line unicorn/no-declarations-before-early-exit -- React hook ordering
   const trace = useTabDebugTrace(debugTraceEnabled ? activeTabId : null);
 
   if (enforcementEnabled === null || debugTraceEnabled === null) {

--- a/extension/src/rules/__tests__/hidden-fee-annotate.property.test.ts
+++ b/extension/src/rules/__tests__/hidden-fee-annotate.property.test.ts
@@ -73,13 +73,13 @@ describe("matchFeePhrase precision (property)", () => {
         fc.constantFrom(...PHRASES),
         fc.stringMatching(/^[A-Za-z][A-Za-z ]{0,30}$/),
         (phrase, suffix) => {
-          const text = `${phrase} ${suffix}`;
           // Guard the rare case where fast-check picks a suffix that
           // happens to start with another phrase from the set — the
           // resulting concatenation could still legitimately match.
           if (PHRASES.has(`${phrase} ${suffix}`.toLowerCase())) {
             return;
           }
+          const text = `${phrase} ${suffix}`;
           expect(matchFeePhrase(text)).toBeNull();
         },
       ),

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -257,10 +257,10 @@ function hasStructuralSrOnlyPattern(style: CSSStyleDeclaration): boolean {
     return false;
   }
   const width = parsePixelLength(style.width);
-  const height = parsePixelLength(style.height);
   if (width === null || width > SR_ONLY_MAX_SIZE_PX) {
     return false;
   }
+  const height = parsePixelLength(style.height);
   if (height === null || height > SR_ONLY_MAX_SIZE_PX) {
     return false;
   }


### PR DESCRIPTION
Fifth ratchet from #279.

Seven sites, handled three ways:

**Declaration moved past the guard (also skips the work on the bail path):**
- `hidden-text-strip.ts` — `const height` now computed only after the width check passes
- `scripts/load-default-overrides.ts` — `prefixedIssue` built only on the non-union path (the union branch `continue`s)
- `hidden-fee-annotate.property.test.ts` — `const text` moved below the phrase-collision guard

**Dead-code removal (cleaner than a disable):**
- `yielding-text-walk.ts` (×2) — the flagged `const` is a **synchronous** `collectTextNodes*` call (`: Text[]`) sitting between two identical `if (signal?.aborted) return` checks. Nothing awaits between them, so the second check could never observe a different value — removed it. Aborts during the later async chunked processing are still caught in `runFinalize`.

**Move past a guard:**
- `checkout-checkbox-defense-source.ts` — the `CLEARED_ATTR` marker (plus its comment + `no-restricted-syntax` disable) moved below the descriptor opt-out guard; it's first used after it.

**Unavoidable disable (1):**
- `Popup.tsx` — the declaration is a React hook (`useTabDebugTrace`), which must run unconditionally before any early return. Moving it would violate `react-hooks/rules-of-hooks`. Inline-disabled with a rationale.

`eslint.config.js`: removed from the warn list → reverts to unicorn/recommended default (`error`).

## Verification
- `bun run typecheck` clean
- `bun run check` exit 0 (rule now errors; 0 violations)
- `bun run test` — 2059/2059 pass (covers the yielding-text-walk abort paths)

Refs #279