### PR TITLE
Ratchet unicorn/prefer-short-arrow-method to error

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -211,14 +211,22 @@ export default tseslint.config(
       // no-global-object-property-assignment stays at its recommended `error`
       // for production code; it's disabled only for tests (which legitimately
       // assign globals to set up mocks) in the test-files block below.
+      // prefer-minimal-ternary: 2 of 3 sites rewrite cleanly, but
+      // confirmshame-sanitize's `instanceof`-narrowed ternary can't satisfy it
+      // — factoring the call (`(cond ? f : g)(x)`) widens the arg and breaks
+      // narrowing, while an `if`/`else` trips `prefer-ternary`. Would need a
+      // disable, so kept as warn; tracked in #279.
       "unicorn/prefer-minimal-ternary": "warn",
+      // prefer-iterator-to-array needs `esnext.iterator` in tsconfig `lib`
+      // (runtime supports `Iterator#toArray()` at our Chrome 148 / Node 24
+      // targets, but it isn't typed under the current `ES2023` lib) — tracked
+      // in #279.
       "unicorn/prefer-iterator-to-array": "warn",
       "unicorn/no-incorrect-query-selector": "warn",
       "unicorn/no-top-level-side-effects": "warn",
       // Partially autofixable — fixable instances are corrected in-tree; the
       // remainder warn until handled in #279.
       "unicorn/no-unnecessary-global-this": "warn",
-      "unicorn/prefer-short-arrow-method": "warn",
 
       // Allow underscore-prefixed unused parameters (e.g. `_root` for the
       // Rule#apply signature when a rule ignores the argument).

--- a/extension/src/rules/__tests__/irrelevant-sections-redact.test.ts
+++ b/extension/src/rules/__tests__/irrelevant-sections-redact.test.ts
@@ -40,10 +40,8 @@ jest.mock("../../lib/llm-client");
 jest.mock("../../lib/availability", () => ({
   createApiKeyAvailability: () => ({
     get: () => Promise.resolve({ available: true }),
-    subscribe() {
-      return () => {
-        // noop
-      };
+    subscribe: () => () => {
+      // noop
     },
   }),
 }));


### PR DESCRIPTION
Sixth ratchet from #279.

This phase targeted the "trivial style batch" (`prefer-short-arrow-method`, `prefer-minimal-ternary`, `prefer-iterator-to-array`), but only one turned out to be cleanly ratchetable — the other two are documented as warnings rather than forced.

## Ratcheted: `prefer-short-arrow-method` (1 site)
- `irrelevant-sections-redact.test.ts` — a `subscribe() { return () => {…} }` method-with-single-return in a `jest.mock` factory, rewritten as an arrow property.

## Kept as warnings (reasons in `eslint.config.js` + #279)
- **`prefer-minimal-ternary`** — 2 of 3 sites rewrite cleanly, but `confirmshame-sanitize`'s `instanceof`-narrowed ternary is a trilemma: the factored `(cond ? f : g)(x)` form widens the argument and breaks narrowing (typecheck error), while an `if`/`else` trips `unicorn/prefer-ternary`. Only a disable would satisfy it, so not worth forcing.
- **`prefer-iterator-to-array`** — runtime supports `Iterator#toArray()` (Chrome 148 / Node 24), but it isn't typed under the current `lib: ES2023`; enabling it needs `esnext.iterator` added to tsconfig — a separate decision, not a ratchet.

## Verification
- `bun run typecheck` clean
- `bun run check` exit 0 (rule now errors; 0 violations)
- `bun run test` — 2059/2059 pass

Refs #279