### PR TITLE
Ratchet unicorn/prefer-iterator-to-array to error

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -217,11 +217,6 @@ export default tseslint.config(
       // narrowing, while an `if`/`else` trips `prefer-ternary`. Would need a
       // disable, so kept as warn; tracked in #279.
       "unicorn/prefer-minimal-ternary": "warn",
-      // prefer-iterator-to-array needs `esnext.iterator` in tsconfig `lib`
-      // (runtime supports `Iterator#toArray()` at our Chrome 148 / Node 24
-      // targets, but it isn't typed under the current `ES2023` lib) — tracked
-      // in #279.
-      "unicorn/prefer-iterator-to-array": "warn",
       "unicorn/no-incorrect-query-selector": "warn",
       "unicorn/no-top-level-side-effects": "warn",
       // Partially autofixable — fixable instances are corrected in-tree; the

--- a/extension/src/lib/background/tab-tracker.ts
+++ b/extension/src/lib/background/tab-tracker.ts
@@ -282,7 +282,9 @@ export function createTabTracker(): TabTracker {
       return a.ruleId.localeCompare(b.ruleId);
     });
     const detectionEntries = tabDetections.get(tabId);
-    const detections = detectionEntries ? [...detectionEntries.values()] : [];
+    const detections = detectionEntries
+      ? detectionEntries.values().toArray()
+      : [];
     return { entries, detections };
   }
 

--- a/extension/src/rules/disguised-ad-flag.ts
+++ b/extension/src/rules/disguised-ad-flag.ts
@@ -431,7 +431,7 @@ function collectCandidates(root: ParentNode): Candidate[] {
       });
     }
   }
-  return filterToOutermost([...byArticle.values()], (c) => c.article);
+  return filterToOutermost(byArticle.values().toArray(), (c) => c.article);
 }
 
 function hideCandidate(candidate: Candidate): void {

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2023",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "ESNext.Iterator", "DOM", "DOM.Iterable"],
     "types": ["chrome", "bun"],
     "jsx": "react-jsx",
     "strict": true,


### PR DESCRIPTION
Seventh ratchet from #279 (was stacked on #285; now targets `main` since #285 merged).

Unblocks the rule #285 deferred. `Iterator#toArray()` already runs at our targets (Chrome 148 / Node 24) — only the type lib was hiding it.

## Changes
- `tsconfig.json`: add `ESNext.Iterator` to `lib` so iterator-helper methods are typed. Type-only (`lib` has no emit impact); both `tsconfig.test.json` / `tsconfig.eslint.json` extend the base without overriding `lib`, so it propagates.
- `tab-tracker.ts`, `disguised-ad-flag.ts`: `[...map.values()]` → `map.values().toArray()`.
- `eslint.config.js`: removed from the warn list (and its deferral comment) → reverts to unicorn/recommended default (`error`).

## Verification
- `bun run typecheck` clean (toArray now typed)
- `bun run check` exit 0 (rule now errors; 0 violations)
- `bun run test` — 2059/2059 pass
- `bun run build` succeeds (type-stripped; `lib` has no emit impact)

Refs #279