### PR TITLE
Disable unicorn/no-this-outside-of-class

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -197,10 +197,17 @@ export default tseslint.config(
       "unicorn/prefer-https": "off",
       "unicorn/require-css-escape": "off",
 
+      // Off — fires only on legitimate, unavoidable `this`-outside-a-class:
+      // native-prototype monkeypatches (`Element.prototype.attachShadow =
+      // function (this: Element) {…}`), `defineProperty` get/set accessors,
+      // page-world `executeScript` entry fns (`this: Window`), and
+      // webext-messaging handlers — none rewritable as class methods. Every
+      // hit would need a disable, so the rule is pure noise here. See #279.
+      "unicorn/no-this-outside-of-class": "off",
+
       // Warn — ratchet to error in #279:
       "unicorn/prefer-scoped-selector": "warn",
       "unicorn/prefer-await": "warn",
-      "unicorn/no-this-outside-of-class": "warn",
       "unicorn/no-break-in-nested-loop": "warn",
       "unicorn/no-computed-property-existence-check": "warn",
       "unicorn/max-nested-calls": "warn",


### PR DESCRIPTION
From #279. This rule only fires on legitimate, unavoidable `this`-outside-a-class in this codebase, so it's turned off rather than left as ~30 standing warnings.

## Why off, not ratcheted
All 30 hits are `this` in standalone functions that *must* use the dynamic receiver and can't be class methods:
- **Native-prototype monkeypatches** — `Element.prototype.attachShadow = function (this: Element) {…}` and friends (shadow-root interception, defenses)
- **`defineProperty` get/set accessors** — `get(this: object) {…}` (jsdom test polyfills)
- **Page-world `executeScript` entry fns** — `function install…(this: Window)`
- **webext-messaging handlers** — `getTabUrl(this: MessengerMeta) {…}` (the library's calling convention)

None can be rewritten as a class, so enabling it would mean ~30 inline disables across the most security-sensitive interception code. Pure noise → off.

## Change
- `eslint.config.js`: `no-this-outside-of-class` `warn` → `off`, grouped with the other disabled rules, with rationale.

## Verification
- `bun run check` exit 0
- Drops ~30 standing warnings (eslint warnings: ~298 → 268)

Refs #279