### PR TITLE
Re-enable no-incorrect-query-selector and require-array-sort-compare

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -213,11 +213,6 @@ export default tseslint.config(
       //     `if (states[rule.id])`, `targetMask[i]`), not existence checks —
       //     `Object.hasOwn` would change meaning, and the rule has no option to
       //     narrow scope.
-      //   require-array-sort-compare wants a compare fn on every `.sort()`, but
-      //     every site sorts strings (rule ids, permission names) where the
-      //     default lexicographic order is already correct.
-      //   no-incorrect-query-selector's only hit is `querySelectorAll("#id")`
-      //     used deliberately to count copies (`toHaveLength`).
       //   prefer-await flags the fire-and-forget `void promise.then/.catch()`
       //     idiom (our `no-floating-promises` convention) in void fns, React
       //     effects, event-listener/`setTimeout` callbacks, and classic-script
@@ -225,10 +220,18 @@ export default tseslint.config(
       //   no-top-level-side-effects's only hit is a deliberate, documented
       //     module-load `registerMethods({…})`.
       "unicorn/no-computed-property-existence-check": "off",
-      "unicorn/require-array-sort-compare": "off",
-      "unicorn/no-incorrect-query-selector": "off",
       "unicorn/prefer-await": "off",
       "unicorn/no-top-level-side-effects": "off",
+
+      // Enforced (recommended `error`). Dynamically-built arrays pass an
+      // explicit comparator; the only sites carrying a scoped `eslint-disable`
+      // are where the rule can't be satisfied cleanly:
+      //   require-array-sort-compare — compile-time-constant catalog lists
+      //     (`RULE_IDS`, `Object.keys(RULE_DEFAULTS)`, …) sorted only to
+      //     compare order-independently in tests; non-constant arrays
+      //     (readdir results, computed diffs) get a `localeCompare` comparator.
+      //   no-incorrect-query-selector — a deliberate `querySelectorAll("#id")`
+      //     used to assert the element count.
 
       // Warn — ratchet to error in #279:
       "unicorn/prefer-scoped-selector": "warn",

--- a/extension/scripts/build-site-data.ts
+++ b/extension/scripts/build-site-data.ts
@@ -61,7 +61,7 @@ interface WarningBlock {
 function loadSites(): ParsedSiteFile[] {
   const entries = readdirSync(SITES_DIR)
     .filter((name) => name.endsWith(".yaml") || name.endsWith(".yml"))
-    .toSorted();
+    .toSorted((a, b) => a.localeCompare(b));
   const errors: string[] = [];
   const parsed: ParsedSiteFile[] = [];
 

--- a/extension/scripts/check-background-purity.ts
+++ b/extension/scripts/check-background-purity.ts
@@ -49,7 +49,10 @@ function extractTopLevelRuleLabel(source: string): string | null {
 
 function collectCanaries(): Canary[] {
   const canaries: Canary[] = [];
-  for (const name of readdirSync(RULES_DIR).toSorted()) {
+  const ruleFiles = readdirSync(RULES_DIR).toSorted((a, b) =>
+    a.localeCompare(b),
+  );
+  for (const name of ruleFiles) {
     if (!name.endsWith(".ts")) {
       continue;
     }

--- a/extension/scripts/manifest-permission-diff.ts
+++ b/extension/scripts/manifest-permission-diff.ts
@@ -44,8 +44,12 @@ function delta(before: readonly string[], after: readonly string[]): Delta {
   const beforeSet = new Set(before);
   const afterSet = new Set(after);
   return {
-    added: [...afterSet].filter((value) => !beforeSet.has(value)).toSorted(),
-    removed: [...beforeSet].filter((value) => !afterSet.has(value)).toSorted(),
+    added: [...afterSet]
+      .filter((value) => !beforeSet.has(value))
+      .toSorted((a, b) => a.localeCompare(b)),
+    removed: [...beforeSet]
+      .filter((value) => !afterSet.has(value))
+      .toSorted((a, b) => a.localeCompare(b)),
   };
 }
 

--- a/extension/src/lib/__tests__/placeholder.test.ts
+++ b/extension/src/lib/__tests__/placeholder.test.ts
@@ -122,6 +122,9 @@ describe("reveal click flow", () => {
     }).not.toThrow();
 
     // Still exactly one copy of the original target in the DOM.
+    // querySelectorAll (not getElementById) is deliberate: we're asserting the
+    // element *count*, which getElementById can't express.
+    // eslint-disable-next-line unicorn/no-incorrect-query-selector -- counting matches
     expect(document.querySelectorAll("#target")).toHaveLength(1);
   });
 

--- a/extension/src/rules/__tests__/catalog.test.ts
+++ b/extension/src/rules/__tests__/catalog.test.ts
@@ -41,7 +41,9 @@ describe("rule catalog invariants", () => {
   });
 
   it("exposes the same id set via RULE_IDS as RULES", () => {
+    // eslint-disable-next-line unicorn/require-array-sort-compare -- string sort; default lexicographic order is intended
     expect([...RULE_IDS].toSorted()).toEqual(
+      // eslint-disable-next-line unicorn/require-array-sort-compare -- string sort; default lexicographic order is intended
       RULES.map((rule) => rule.id).toSorted(),
     );
   });
@@ -60,7 +62,9 @@ describe("rule catalog invariants", () => {
   // test catches the case where a rule is registered in `rules/index.ts`
   // without a corresponding metadata entry (or vice versa).
   it("declares a default for every rule and no extras", () => {
+    // eslint-disable-next-line unicorn/require-array-sort-compare -- string sort; default lexicographic order is intended
     const defaultsKeys = Object.keys(RULE_DEFAULTS).toSorted();
+    // eslint-disable-next-line unicorn/require-array-sort-compare -- string sort; default lexicographic order is intended
     expect(defaultsKeys).toEqual([...RULE_IDS].toSorted());
   });
 
@@ -94,6 +98,7 @@ describe("rule catalog invariants", () => {
       (id, index) => grouped.indexOf(id) !== index,
     );
     expect(duplicates).toEqual([]);
+    // eslint-disable-next-line unicorn/require-array-sort-compare -- string sort; default lexicographic order is intended
     expect([...grouped].toSorted()).toEqual([...RULE_IDS].toSorted());
   });
 
@@ -108,7 +113,9 @@ describe("rule catalog invariants", () => {
   // so background.js purity isn't violated by the strings) — this check is
   // the canary for that drift.
   it("every rule has a popup label", () => {
+    // eslint-disable-next-line unicorn/require-array-sort-compare -- string sort; default lexicographic order is intended
     const labelIds = Object.keys(RULE_LABELS).toSorted();
+    // eslint-disable-next-line unicorn/require-array-sort-compare -- string sort; default lexicographic order is intended
     expect(labelIds).toEqual([...RULE_IDS].toSorted());
     const blank = Object.entries(RULE_LABELS).filter(
       ([, value]) => typeof value !== "string" || value.length === 0,

--- a/extension/src/rules/__tests__/site-data.test.ts
+++ b/extension/src/rules/__tests__/site-data.test.ts
@@ -23,7 +23,7 @@ const SITES_DIR = join(__dirname, "..", "..", "..", "data", "sites");
 function listSiteFiles(): string[] {
   return readdirSync(SITES_DIR)
     .filter((name) => name.endsWith(".yaml") || name.endsWith(".yml"))
-    .toSorted();
+    .toSorted((a, b) => a.localeCompare(b));
 }
 
 describe("site data YAML files", () => {


### PR DESCRIPTION
Reverses the blanket disable from #288 for these two rules now that we have a clean way to handle each site.

## `no-incorrect-query-selector` → error
One site: `placeholder.test.ts` uses `querySelectorAll("#target")` deliberately to assert the match **count** (`toHaveLength(1)`), which `getElementById` can't express. Scoped inline disable with rationale.

## `require-array-sort-compare` → error
The distinction is constant vs non-constant arrays:

**Non-constant arrays now pass an explicit comparator** `(a, b) => a.localeCompare(b)` (the appropriate fix, not a suppression):
- `build-site-data.ts`, `check-background-purity.ts`, `site-data.test.ts` — `readdirSync` results
- `manifest-permission-diff.ts` — computed permission-set diffs

**Compile-time-constant catalog lists keep a scoped inline disable** — `catalog.test.ts` sorts `RULE_IDS`, `Object.keys(RULE_DEFAULTS)`, etc. only to compare set membership order-independently; the default order is fine and a comparator would add nothing.

Codegen output (`site-data.generated.ts`) is unchanged — `localeCompare` matches the previous default order for these filenames, so no generated-file drift.

## Verification
- `bun run check` exit 0 (both rules error; 0 violations; `no-unused-disable` clean)
- `bun run typecheck` clean
- `bun run test` — 2059/2059 pass
- `bun run build` succeeds, generated file unchanged

Refs #279