### PR TITLE
Ratchet unicorn/prefer-minimal-ternary to error

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -243,12 +243,6 @@ export default tseslint.config(
       // no-global-object-property-assignment stays at its recommended `error`
       // for production code; it's disabled only for tests (which legitimately
       // assign globals to set up mocks) in the test-files block below.
-      // prefer-minimal-ternary: 2 of 3 sites rewrite cleanly, but
-      // confirmshame-sanitize's `instanceof`-narrowed ternary can't satisfy it
-      // — factoring the call (`(cond ? f : g)(x)`) widens the arg and breaks
-      // narrowing, while an `if`/`else` trips `prefer-ternary`. Would need a
-      // disable, so kept as warn; tracked in #279.
-      "unicorn/prefer-minimal-ternary": "warn",
       // Partially autofixable — fixable instances are corrected in-tree; the
       // remainder warn until handled in #279.
       "unicorn/no-unnecessary-global-this": "warn",

--- a/extension/src/lib/log.ts
+++ b/extension/src/lib/log.ts
@@ -32,11 +32,7 @@ function emit(
     return;
   }
   const sink =
-    level === "warn"
-      ? console.warn
-      : level === "error"
-        ? console.error
-        : console.log;
+    console[level === "warn" ? "warn" : level === "error" ? "error" : "log"];
   if (details === undefined) {
     sink(prefix, message);
   } else {

--- a/extension/src/lib/page-world-hook.ts
+++ b/extension/src/lib/page-world-hook.ts
@@ -109,7 +109,7 @@ export function createPageWorldHook(
     if (target === current) {
       return;
     }
-    await (target ? register() : unregister());
+    await (target ? register : unregister)();
   }
 
   return {

--- a/extension/src/rules/confirmshame-sanitize.ts
+++ b/extension/src/rules/confirmshame-sanitize.ts
@@ -234,7 +234,12 @@ function neutralize(element: HTMLElement): boolean {
   return traceMutation(
     { ruleId: RULE_ID, kind: "sanitize", target: element },
     () => {
+      // Can't satisfy prefer-minimal-ternary here: factoring the call into
+      // `(cond ? rewriteInput : rewriteButtonLike)(element)` widens the
+      // argument back to Element and loses the `instanceof` narrowing that
+      // `rewriteInput` needs; an `if`/`else` would trip `prefer-ternary`.
       const changed =
+        // eslint-disable-next-line unicorn/prefer-minimal-ternary -- instanceof narrowing
         element instanceof HTMLInputElement
           ? rewriteInput(element)
           : rewriteButtonLike(element);


### PR DESCRIPTION
From #279. Two of the three sites factor the common part out of the ternary; the third keeps it with a scoped disable.

## Changes
- `log.ts` — `cond ? console.warn : cond2 ? console.error : console.log` → `console[cond ? "warn" : cond2 ? "error" : "log"]` (the varying part is the method name).
- `page-world-hook.ts` — `await (target ? register() : unregister())` → `await (target ? register : unregister)()` (factor out the call).
- `confirmshame-sanitize.ts` — **scoped disable.** Factoring `(element instanceof HTMLInputElement ? rewriteInput : rewriteButtonLike)(element)` widens the argument back to `Element` and loses the narrowing `rewriteInput` requires (typecheck error), while an `if`/`else` would trip `unicorn/prefer-ternary`. The ternary stays, with a rationale comment + inline disable.
- `eslint.config.js` — removed from the warn list → reverts to unicorn/recommended default (`error`).

## Verification
- `bun run check` exit 0 (rule errors; 0 violations; `no-unused-disable` clean)
- `bun run typecheck` clean
- `bun run test` — 2059/2059 pass

Refs #279