### PR TITLE
Ratchet unicorn/no-unreadable-new-expression to error

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -238,7 +238,6 @@ export default tseslint.config(
       "unicorn/no-break-in-nested-loop": "warn",
       "unicorn/max-nested-calls": "warn",
       "unicorn/prefer-number-coercion": "warn",
-      "unicorn/no-unreadable-new-expression": "warn",
       "unicorn/prefer-uint8array-base64": "warn",
       // no-global-object-property-assignment stays at its recommended `error`
       // for production code; it's disabled only for tests (which legitimately

--- a/extension/scripts/build-icons.ts
+++ b/extension/scripts/build-icons.ts
@@ -35,11 +35,10 @@ export function generateIcons(): number {
     }
     const svg = readFileSync(source);
     for (const size of sizes) {
-      const png = new Resvg(svg, {
+      const renderer = new Resvg(svg, {
         fitTo: { mode: "width", value: size },
-      })
-        .render()
-        .asPng();
+      });
+      const png = renderer.render().asPng();
       writeFileSync(join(ICONS, `${prefix}-${size}.png`), png);
       written += 1;
     }

--- a/extension/src/lib/__tests__/checkout-checkbox-defense-source.test.ts
+++ b/extension/src/lib/__tests__/checkout-checkbox-defense-source.test.ts
@@ -182,7 +182,8 @@ describe("parity with the isolated-world rule", () => {
     const checkbox = document.querySelector("#t") as HTMLInputElement;
     checkbox.setAttribute(CLEARED_ATTR, "");
     const originalHref = location.href;
-    history.replaceState({}, "", new URL(url).pathname);
+    const parsed = new URL(url);
+    history.replaceState({}, "", parsed.pathname);
     try {
       checkbox.checked = true;
       expect(checkbox.checked).toBe(false);
@@ -204,7 +205,8 @@ describe("parity with the isolated-world rule", () => {
     const checkbox = document.querySelector("#t") as HTMLInputElement;
     checkbox.setAttribute(CLEARED_ATTR, "");
     const originalHref = location.href;
-    history.replaceState({}, "", new URL(url).pathname);
+    const parsed = new URL(url);
+    history.replaceState({}, "", parsed.pathname);
     try {
       checkbox.checked = true;
       expect(checkbox.checked).toBe(true);

--- a/extension/src/lib/__tests__/dump-trace-bridge-source.test.ts
+++ b/extension/src/lib/__tests__/dump-trace-bridge-source.test.ts
@@ -193,7 +193,8 @@ describe("installDumpTraceBridge", () => {
     // queued dispatch into this case); filter the snapshot to ids that
     // appear at least once, then confirm cardinality and uniqueness.
     expect(seen.length).toBeGreaterThanOrEqual(3);
-    expect(new Set(seen).size).toBe(seen.length);
+    const uniqueSeen = new Set(seen);
+    expect(uniqueSeen.size).toBe(seen.length);
     window.removeEventListener("message", interceptor);
   });
 });

--- a/extension/src/lib/__tests__/page-world-hooks.test.ts
+++ b/extension/src/lib/__tests__/page-world-hooks.test.ts
@@ -32,7 +32,8 @@ jest.mock("abort-utils", () => ({
       // noop
     }
     get signal(): AbortSignal {
-      return new AbortController().signal;
+      const controller = new AbortController();
+      return controller.signal;
     }
   },
   onAbort: (): (() => void) => () => {

--- a/extension/src/lib/checkout-checkbox-defense-source.ts
+++ b/extension/src/lib/checkout-checkbox-defense-source.ts
@@ -55,7 +55,8 @@ export function installCheckoutCheckboxDefense(this: Window): void {
 
   function isCheckoutHref(href: string): boolean {
     try {
-      return CHECKOUT_PATH_RE.test(new URL(href).pathname);
+      const parsed = new URL(href);
+      return CHECKOUT_PATH_RE.test(parsed.pathname);
     } catch {
       return false;
     }

--- a/extension/src/popup/SiteDisableSection.tsx
+++ b/extension/src/popup/SiteDisableSection.tsx
@@ -52,7 +52,8 @@ export function SiteDisableSection({
 
   let host = "this site";
   try {
-    host = new URL(activeTabUrl).host;
+    const parsed = new URL(activeTabUrl);
+    host = parsed.host;
   } catch {
     // Should not happen — isContentSchemeUrl already parsed it. Fall through
     // to the generic copy.

--- a/extension/src/popup/use-tab-debug-trace.ts
+++ b/extension/src/popup/use-tab-debug-trace.ts
@@ -89,7 +89,8 @@ export function useTabDebugTrace(tabId: number | null): TabDebugTrace {
     const blob = new Blob([payload], {
       type: "application/x-ndjson;charset=utf-8",
     });
-    const timestamp = new Date()
+    const now = new Date();
+    const timestamp = now
       .toISOString()
       .replaceAll(/[.:]/g, "-")
       .replaceAll("T", "_")

--- a/extension/src/rules/__tests__/catalog.test.ts
+++ b/extension/src/rules/__tests__/catalog.test.ts
@@ -16,7 +16,8 @@ jest.mock("abort-utils", () => ({
       // noop
     }
     get signal(): AbortSignal {
-      return new AbortController().signal;
+      const controller = new AbortController();
+      return controller.signal;
     }
   },
   onAbort: (): (() => void) => () => {
@@ -104,7 +105,8 @@ describe("rule catalog invariants", () => {
 
   it("group ids are unique", () => {
     const ids = RULE_GROUPS.map((group) => group.id);
-    expect(new Set(ids).size).toBe(ids.length);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
   });
 
   // Popup's per-rule activity section looks up labels via RULE_LABELS. Keep

--- a/extension/src/rules/hidden-affiliate-sanitize.ts
+++ b/extension/src/rules/hidden-affiliate-sanitize.ts
@@ -192,7 +192,8 @@ export function shouldClearName(name: string): boolean {
 
 function isKillSwitchedHost(href: string): boolean {
   try {
-    return HOST_KILL_SWITCH.has(new URL(href).hostname);
+    const parsed = new URL(href);
+    return HOST_KILL_SWITCH.has(parsed.hostname);
   } catch {
     return false;
   }

--- a/extension/src/rules/hidden-fee-annotate.ts
+++ b/extension/src/rules/hidden-fee-annotate.ts
@@ -415,7 +415,8 @@ export function countPricedRows(container: Element): number {
 
 function isDenylistedHost(href: string): boolean {
   try {
-    return HOST_DENYLIST.has(new URL(href).hostname);
+    const parsed = new URL(href);
+    return HOST_DENYLIST.has(parsed.hostname);
   } catch {
     return false;
   }

--- a/extension/src/rules/link-spoof-annotate.ts
+++ b/extension/src/rules/link-spoof-annotate.ts
@@ -89,7 +89,8 @@ export interface SpoofTriggers {
 // the input on URL-parse failure (e.g. invalid characters).
 function toPunycodeHost(domain: string): string {
   try {
-    return new URL(`https://${domain}/`).hostname;
+    const parsed = new URL(`https://${domain}/`);
+    return parsed.hostname;
   } catch {
     return domain;
   }


### PR DESCRIPTION
From #279 (was stacked on #290; targets `main` now that #290 merged).

Extract the `new X(...)` into a local in all 13 sites so a member is never accessed directly off a `new` expression.

**Used a local variable, not parens:** I tested `(new URL(x)).hostname` — Biome's formatter strips the "redundant" parens back to `new URL(x).hostname`, which re-trips the rule. A local is formatter-stable and is the more readable form the rule is after.

## Sites
- URL parsing — `new URL(x).prop` → `const parsed = new URL(x); … parsed.prop`: `hidden-affiliate-sanitize`, `hidden-fee-annotate`, `link-spoof-annotate`, `checkout-checkbox-defense-source` (+ its test ×2), `SiteDisableSection`
- `AbortController().signal` / `new Set(...).size` / `new Date().toISOString()…` in tests + `use-tab-debug-trace` — same hoist
- `build-icons.ts` — `new Resvg(...).render().asPng()` → hoisted `renderer`

All behavior-preserving (purely moving the construction into a named local).

## Verification
- `bun run check` exit 0 (rule errors; 0 violations)
- `bun run typecheck` clean
- `bun run test` — 2059/2059 pass

Refs #279