### PR TITLE
Ratchet unicorn/no-unnecessary-global-this to error (off in tests)

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -242,10 +242,6 @@ export default tseslint.config(
       // no-global-object-property-assignment stays at its recommended `error`
       // for production code; it's disabled only for tests (which legitimately
       // assign globals to set up mocks) in the test-files block below.
-      // Partially autofixable — fixable instances are corrected in-tree; the
-      // remainder warn until handled in #279.
-      "unicorn/no-unnecessary-global-this": "warn",
-
       // Allow underscore-prefixed unused parameters (e.g. `_root` for the
       // Rule#apply signature when a rule ignores the argument).
       "@typescript-eslint/no-unused-vars": [
@@ -280,6 +276,10 @@ export default tseslint.config(
       // Tests assign onto global objects to install mocks / stubs; the rule
       // stays an error everywhere else.
       "unicorn/no-global-object-property-assignment": "off",
+      // Tests reach for `globalThis.*` deliberately — overriding globals for
+      // mocks (`globalThis.MutationObserver = …`) and dispatching events /
+      // reading computed style against the jsdom global. Enforced in prod.
+      "unicorn/no-unnecessary-global-this": "off",
       // Jest matchers and mock patterns routinely pass methods by reference.
       "@typescript-eslint/unbound-method": "off",
 

--- a/extension/src/lib/placeholder.ts
+++ b/extension/src/lib/placeholder.ts
@@ -71,7 +71,7 @@ export function pickPaletteFromAncestor(
 ): PlaceholderPalette {
   let node: Element | null = start;
   while (node) {
-    const bg = globalThis.getComputedStyle(node).backgroundColor;
+    const bg = getComputedStyle(node).backgroundColor;
     const brightness = parseBackgroundBrightness(bg);
     if (brightness !== null) {
       return brightness < 0.5 ? "dark" : "light";
@@ -208,7 +208,7 @@ export function replaceWithBlockPlaceholder(
   label: string,
 ): HTMLDivElement {
   const rect = element.getBoundingClientRect();
-  const computed = globalThis.getComputedStyle(element);
+  const computed = getComputedStyle(element);
 
   // Outer container is a non-interactive <div> so the inner reveal button can
   // use position: sticky (which doesn't work as a child of <button>). Click

--- a/extension/src/lib/route-change.ts
+++ b/extension/src/lib/route-change.ts
@@ -56,8 +56,8 @@ function install(): void {
   if (navigation) {
     navigation.addEventListener("navigatesuccess", emit);
   }
-  globalThis.addEventListener("popstate", emit);
-  globalThis.addEventListener("hashchange", emit);
+  addEventListener("popstate", emit);
+  addEventListener("hashchange", emit);
 }
 
 // Listener is called once per detected URL change. The same listener
@@ -81,8 +81,8 @@ export function __resetRouteChangeForTesting(): void {
     if (navigation) {
       navigation.removeEventListener("navigatesuccess", emit);
     }
-    globalThis.removeEventListener("popstate", emit);
-    globalThis.removeEventListener("hashchange", emit);
+    removeEventListener("popstate", emit);
+    removeEventListener("hashchange", emit);
   }
   listeners.clear();
   installed = false;

--- a/extension/src/lib/yielding-text-walk.ts
+++ b/extension/src/lib/yielding-text-walk.ts
@@ -66,7 +66,7 @@ export interface WalkTextNodesChunkedOptions {
 function defaultYieldStrategy(): Promise<void> {
   if (typeof requestIdleCallback === "function") {
     return new Promise<void>((resolve) => {
-      globalThis.requestIdleCallback(() => {
+      requestIdleCallback(() => {
         resolve();
       });
     });

--- a/extension/src/popup/use-tab-debug-trace.ts
+++ b/extension/src/popup/use-tab-debug-trace.ts
@@ -54,12 +54,12 @@ export function useTabDebugTrace(tabId: number | null): TabDebugTrace {
       }
     };
     void poll();
-    const intervalId = globalThis.setInterval(() => {
+    const intervalId = setInterval(() => {
       void poll();
     }, POLL_INTERVAL_MS);
     return () => {
       cancelled = true;
-      globalThis.clearInterval(intervalId);
+      clearInterval(intervalId);
     };
   }, [tabId]);
 

--- a/extension/src/popup/use-tab-pause.ts
+++ b/extension/src/popup/use-tab-pause.ts
@@ -55,11 +55,11 @@ export function useTabPause(tabId: number | null): TabPauseState {
   }, [tabId]);
 
   useEffect(() => {
-    const intervalId = globalThis.setInterval(() => {
+    const intervalId = setInterval(() => {
       setNow(Date.now());
     }, TICK_INTERVAL_MS);
     return () => {
-      globalThis.clearInterval(intervalId);
+      clearInterval(intervalId);
     };
   }, []);
 

--- a/extension/src/rules/__tests__/hidden-fee-annotate.test.ts
+++ b/extension/src/rules/__tests__/hidden-fee-annotate.test.ts
@@ -296,7 +296,6 @@ describe("findOrderSummaryAncestor", () => {
     // the labelledby resolution path can execute. Identity escape is fine
     // here — the test only inserts known-safe id values. Read via `globalThis`
     // so the absent global reads as `undefined` instead of throwing.
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this -- global may be undefined here
     const previousCss = (globalThis as { CSS?: unknown }).CSS;
     (globalThis as { CSS?: { escape: (input: string) => string } }).CSS = {
       escape: (input: string) => input,

--- a/extension/src/rules/cookie-banner-hide.ts
+++ b/extension/src/rules/cookie-banner-hide.ts
@@ -21,7 +21,7 @@ function isOverlay(element: HTMLElement): boolean {
   if (role && OVERLAY_ROLES.has(role)) {
     return true;
   }
-  const position = globalThis.getComputedStyle(element).position;
+  const position = getComputedStyle(element).position;
   return OVERLAY_POSITIONS.has(position);
 }
 

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -747,7 +747,7 @@ export function __resetColorProbeForTesting(): void {
 function effectiveBackgroundColor(element: Element): RGB | null {
   let current: Element | null = element;
   while (current) {
-    const style = globalThis.getComputedStyle(current);
+    const style = getComputedStyle(current);
     const bg = parseColor(style.backgroundColor);
     if (!bg) {
       return null;
@@ -832,7 +832,7 @@ function findCandidates(root: ParentNode): Candidate[] {
     if (!hasNonemptyText(element)) {
       continue;
     }
-    const style = globalThis.getComputedStyle(element);
+    const style = getComputedStyle(element);
     if (hasStructuralSrOnlyPattern(style)) {
       continue;
     }

--- a/extension/src/rules/irrelevant-sections-redact.ts
+++ b/extension/src/rules/irrelevant-sections-redact.ts
@@ -105,7 +105,7 @@ function checkHideable(element: Element): string | null {
   }
 
   // Sticky / fixed elements leave a layout hole behind if replaced.
-  const position = globalThis.getComputedStyle(element).position;
+  const position = getComputedStyle(element).position;
   if (position === "fixed" || position === "sticky") {
     return `position-${position}`;
   }

--- a/extension/src/rules/newsletter-modal-hide.ts
+++ b/extension/src/rules/newsletter-modal-hide.ts
@@ -27,7 +27,7 @@ const NEWSLETTER_TEXT =
 const MIN_VIEWPORT_AREA_RATIO = 0.25;
 
 function looksLikeNewsletterModal(element: HTMLElement): boolean {
-  const style = globalThis.getComputedStyle(element);
+  const style = getComputedStyle(element);
   if (style.position !== "fixed" && style.position !== "sticky") {
     return false;
   }

--- a/extension/src/rules/svg-sprite-strip.ts
+++ b/extension/src/rules/svg-sprite-strip.ts
@@ -65,7 +65,7 @@ function isHidden(svg: SVGSVGElement): boolean {
   if (svg.getAttribute("aria-hidden") === "true") {
     return true;
   }
-  const style = globalThis.getComputedStyle(svg);
+  const style = getComputedStyle(svg);
   if (style.display === "none") {
     return true;
   }


### PR DESCRIPTION
From #279. Enforce the rule in production code; disable it in tests (same pattern as `no-global-object-property-assignment` in #283), since tests legitimately use `globalThis.*` for mocking.

## Production: drop the redundant `globalThis.` prefix
The #276 autofix already converted 76 property *reads*; it leaves method *calls* alone because dropping the object could in theory change `this` (safe for these standard globals). Converted the production call sites:
- `getComputedStyle` — `placeholder`, `cookie-banner-hide`, `hidden-text-strip`, `newsletter-modal-hide`, `svg-sprite-strip`, `irrelevant-sections-redact`
- `addEventListener`/`removeEventListener` — `route-change.ts`
- `setInterval`/`clearInterval` — `use-tab-debug-trace`, `use-tab-pause`
- `requestIdleCallback` — `yielding-text-walk.ts`

## Tests: rule disabled
Added `unicorn/no-unnecessary-global-this: off` to the `src/**/__tests__/**` override. Tests deliberately reach for `globalThis.*` — overriding globals for mocks (`globalThis.MutationObserver = …`), dispatching navigation/scroll events, and reading computed style against the jsdom global. So:
- The test call sites keep `globalThis.dispatchEvent(…)` / `getComputedStyle(…)` (no churn).
- A now-redundant inline disable in `hidden-fee-annotate.test.ts` is removed.

(`src/__test-mocks__/chrome-mv3-extras.ts` sits outside the `__tests__` glob, so the rule still applies there — it keeps its one justified inline disable.)

## Verification
- `bun run check` exit 0 (rule errors in prod; 0 violations; no unused-disable warnings)
- `bun run typecheck` clean
- `bun run test` — 2059/2059 pass

Refs #279