### PR TITLE
Extend no-unnecessary-global-this test exclusion to __test-mocks__

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -267,7 +267,12 @@ export default tseslint.config(
     },
   },
   {
-    files: ["src/**/__tests__/**/*.{ts,tsx}"],
+    files: [
+      "src/**/__tests__/**/*.{ts,tsx}",
+      // `__test-mocks__` is test infrastructure (loaded via Jest setupFiles);
+      // it gets the same relaxations — same grouping tsconfig.test.json uses.
+      "src/__test-mocks__/**/*.{ts,tsx}",
+    ],
     plugins: { jest },
     rules: {
       // Tests legitimately use literal nulls and many small `for` loops.

--- a/extension/src/__test-mocks__/chrome-mv3-extras.ts
+++ b/extension/src/__test-mocks__/chrome-mv3-extras.ts
@@ -16,10 +16,7 @@ interface ChromeScriptingMock {
   getRegisteredContentScripts: jest.Mock;
 }
 
-// The cast adds the `scripting` namespace the mock lib's chrome types omit;
-// dropping the `globalThis` here (as unicorn/no-unnecessary-global-this would)
-// strips the cast and leaves `ChromeScriptingMock` unused / untypeable.
-// eslint-disable-next-line unicorn/no-unnecessary-global-this -- deliberate typed assignment
+// The cast adds the `scripting` namespace the mock lib's chrome types omit.
 (
   globalThis as unknown as { chrome: { scripting: ChromeScriptingMock } }
 ).chrome.scripting = {


### PR DESCRIPTION
Follow-up to #292.

#292 disabled `unicorn/no-unnecessary-global-this` for `src/**/__tests__/**`, but `__test-mocks__` is also test infrastructure (loaded via Jest `setupFiles`) that deliberately uses `globalThis.*` — e.g. `globalThis.chrome.scripting = …` to install the MV3 scripting mock the lib's types omit.

## Changes
- `eslint.config.js`: add `src/__test-mocks__/**/*.{ts,tsx}` to the test-files override (the same grouping `tsconfig.test.json` already uses for these files).
- `chrome-mv3-extras.ts`: drop the now-redundant inline `eslint-disable` (the rule no longer applies there).

## Verification
- `bun run check` exit 0 (no violations, no unused-disable warnings)
- `bun run test` — 2059/2059 pass

Refs #279