### PR TITLE
Disable unicorn/max-nested-calls

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -222,6 +222,12 @@ export default tseslint.config(
       "unicorn/no-computed-property-existence-check": "off",
       "unicorn/prefer-await": "off",
       "unicorn/no-top-level-side-effects": "off",
+      //   max-nested-calls — the call-depth cap doesn't fit the two places we
+      //     nest deeply on purpose: zod schema builders
+      //     (`z.record(z.string(), z.union([z.string(), z.number()]))`) and
+      //     fast-check generators (`fc.array(fc.tuple(fc.nat(…), …))`). Both
+      //     are idiomatic and read better nested than split into temporaries.
+      "unicorn/max-nested-calls": "off",
 
       // Enforced (recommended `error`). Dynamically-built arrays pass an
       // explicit comparator; the only sites carrying a scoped `eslint-disable`
@@ -236,7 +242,6 @@ export default tseslint.config(
       // Warn — ratchet to error in #279:
       "unicorn/prefer-scoped-selector": "warn",
       "unicorn/no-break-in-nested-loop": "warn",
-      "unicorn/max-nested-calls": "warn",
       "unicorn/prefer-number-coercion": "warn",
       "unicorn/prefer-uint8array-base64": "warn",
       // no-global-object-property-assignment stays at its recommended `error`


### PR DESCRIPTION
From #279. The call-depth cap (max 3) fires only on the two patterns this repo nests deeply *on purpose*, both of which read better nested than split into temporaries — so it's turned off rather than left as standing warnings (same call as the other ill-fitting rules in #287/#288).

## Why off
All 16 hits are one of:
- **zod schema builders** — `z.record(z.string(), z.union([z.string(), z.number()]))` in `message-schemas.ts`. Splitting these into intermediate schema consts is more awkward than the inline builder.
- **fast-check generators** in property tests — `fc.array(fc.tuple(fc.nat(20), fc.integer({ min: 1, max: 20 })))` etc. Deeply-nested combinators are the idiomatic, readable form.

Neither has a clean path to `error`. Disabled with a rationale comment alongside the other rules that don't fit this codebase.

## Change
- `eslint.config.js`: `max-nested-calls` `warn` → `off`.

## Verification
- `bun run check` exit 0 (no violations)

Refs #279