### PR TITLE
Disable unicorn/prefer-uint8array-base64

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -229,6 +229,20 @@ export default tseslint.config(
       //     are idiomatic and read better nested than split into temporaries.
       "unicorn/max-nested-calls": "off",
 
+      // Off — blocked by the test runtime, not the codebase. The suggested
+      // `Uint8Array.fromBase64()`/`#toBase64()` are present in our Chrome
+      // target (133+; manifest requires 148) and in Bun (the build script),
+      // but Node 24 — which runs Jest/jsdom in CI — only exposes them behind
+      // the experimental `--js-base-64` flag, so they're absent under test.
+      // The 8 sites include two security-relevant decode paths
+      // (`encoded-payload-redact.ts`, `encoded-fixture.ts`) plus their
+      // fixtures; rewriting them would either break the suite or force an
+      // atob/btoa-based polyfill into jsdom — which would then exercise the
+      // shim, not Chrome's native impl, masking any prod divergence on a
+      // decode path. Not worth it for a stylistic rule. Revisit once Node
+      // ships these unflagged. See #279.
+      "unicorn/prefer-uint8array-base64": "off",
+
       // Enforced (recommended `error`). Dynamically-built arrays pass an
       // explicit comparator; the only sites carrying a scoped `eslint-disable`
       // are where the rule can't be satisfied cleanly:
@@ -243,7 +257,6 @@ export default tseslint.config(
       "unicorn/prefer-scoped-selector": "warn",
       "unicorn/no-break-in-nested-loop": "warn",
       "unicorn/prefer-number-coercion": "warn",
-      "unicorn/prefer-uint8array-base64": "warn",
       // no-global-object-property-assignment stays at its recommended `error`
       // for production code; it's disabled only for tests (which legitimately
       // assign globals to set up mocks) in the test-files block below.


### PR DESCRIPTION
Part of the #279 unicorn ratchet. This row turns out **not** to be a clean ratchet — it's blocked by the test runtime, not the codebase.

## Why off, not error

The suggested `Uint8Array.fromBase64()` / `Uint8Array#toBase64()`:

| Runtime | Has the API? |
|---------|--------------|
| Chrome target (133+; `manifest.json` requires 148) | ✅ |
| Bun (the `build-injection-patterns.ts` build script) | ✅ |
| **Node 24 (Jest/jsdom in CI)** | ❌ — gated behind the experimental `--js-base-64` flag, off by default |

The 8 sites include two security-relevant decode paths — `encoded-payload-redact.ts` and `encoded-fixture.ts` — plus their test fixtures. Rewriting them would either:

- break the Jest suite (the methods don't exist under Node 24), or
- require polyfilling an `atob`/`btoa`-based shim into jsdom — which would then exercise *the shim*, not Chrome's native implementation, masking any prod divergence on a decode path (loose vs. strict last-chunk handling, base64url alphabet, whitespace). That's a new blind spot on exactly the code that least wants one.

Adding that risk for a **stylistic** rule isn't worth it. Turning it off (rather than leaving a standing `warn`) matches the project convention for intentional/blocked rules (#287, #288, #294). Revisit once Node ships these methods unflagged.

## Changes

- `extension/eslint.config.js`: move `unicorn/prefer-uint8array-base64` from `warn` to `off` with the rationale above.

## Verification

- `bun run check` passes (biome + tsc + eslint, exit 0); 0 errors, and the remaining warnings are only the other three #279 candidates (`prefer-scoped-selector` ×64, `no-break-in-nested-loop` ×27, `prefer-number-coercion` ×15).

I'll update the issue #279 table to move this row into the "Not worth ratcheting" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)