### PR TITLE
Ratchet unicorn/prefer-number-coercion to error

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -252,11 +252,18 @@ export default tseslint.config(
       //     (readdir results, computed diffs) get a `localeCompare` comparator.
       //   no-incorrect-query-selector — a deliberate `querySelectorAll("#id")`
       //     used to assert the element count.
+      //   prefer-number-coercion — `Number()` replaces `parseInt(x, 10)` /
+      //     `parseFloat(x)` only where the input is a bare numeric token (a
+      //     `\d`-anchored regex capture, `String(i)`); the two scoped
+      //     disables in `hidden-text-strip.ts` are where `parseFloat`'s
+      //     leading-numeric parse is load-bearing: unit-suffixed CSS
+      //     durations (`"0.5s"`) and a possibly-`""` computed `opacity`,
+      //     both of which `Number()` would mis-coerce.
+      "unicorn/prefer-number-coercion": "error",
 
       // Warn — ratchet to error in #279:
       "unicorn/prefer-scoped-selector": "warn",
       "unicorn/no-break-in-nested-loop": "warn",
-      "unicorn/prefer-number-coercion": "warn",
       // no-global-object-property-assignment stays at its recommended `error`
       // for production code; it's disabled only for tests (which legitimately
       // assign globals to set up mocks) in the test-files block below.

--- a/extension/src/lib/__tests__/text-walk-shadow.property.test.ts
+++ b/extension/src/lib/__tests__/text-walk-shadow.property.test.ts
@@ -295,10 +295,7 @@ describe("walkTextNodes — shadow coverage", () => {
           // inside a closed wrapper, every nested open shadow is
           // still unreachable to the production walker, so its text
           // is in the exclusion set too.
-          const index = Number.parseInt(
-            (element as HTMLElement).dataset.index ?? "-1",
-            10,
-          );
+          const index = Number((element as HTMLElement).dataset.index ?? "-1");
           if (index >= 0) {
             const shadow = built.shadowsByIndex[index];
             if (shadow) {

--- a/extension/src/rules/countdown-timer-redact.ts
+++ b/extension/src/rules/countdown-timer-redact.ts
@@ -63,10 +63,10 @@ const UNIT_MULTIPLIERS: ReadonlyArray<readonly [RegExp, number]> = [
 export function parseTotalSeconds(text: string): number | null {
   const colon = /(?<!\d)(\d{1,3}):([0-5]\d)(?::([0-5]\d))?(?!\d)/.exec(text);
   if (colon) {
-    const a = Number.parseInt(colon[1] ?? "0", 10);
-    const b = Number.parseInt(colon[2] ?? "0", 10);
+    const a = Number(colon[1] ?? "0");
+    const b = Number(colon[2] ?? "0");
     if (colon[3] !== undefined) {
-      const c = Number.parseInt(colon[3], 10);
+      const c = Number(colon[3]);
       return a * 3600 + b * 60 + c;
     }
     return a * 60 + b;
@@ -77,7 +77,7 @@ export function parseTotalSeconds(text: string): number | null {
   for (const [pattern, multiplier] of UNIT_MULTIPLIERS) {
     const match = text.match(pattern);
     if (match?.[1] !== undefined) {
-      total += Number.parseInt(match[1], 10) * multiplier;
+      total += Number(match[1]) * multiplier;
       found = true;
     }
   }

--- a/extension/src/rules/hidden-text-strip.ts
+++ b/extension/src/rules/hidden-text-strip.ts
@@ -193,7 +193,7 @@ function parsePixelLength(value: string): number | null {
   if (!match?.[1]) {
     return null;
   }
-  return Number.parseFloat(match[1]);
+  return Number(match[1]);
 }
 
 // Pick the first non-empty value from a list of computed-style reads.
@@ -285,6 +285,11 @@ function hasNonzeroDuration(value: string | null | undefined): boolean {
   if (!value) {
     return false;
   }
+  // parseFloat, not Number: the computed `transition-duration` /
+  // `animation-duration` values carry a unit suffix (`"0.5s"`, `"150ms"`,
+  // or a comma-separated list), and `Number("0.5s")` is `NaN` — which would
+  // make every non-zero duration read as zero and silently disable the check.
+  // eslint-disable-next-line unicorn/prefer-number-coercion -- unit suffix; Number() would yield NaN
   const numeric = Number.parseFloat(value);
   return Number.isFinite(numeric) && numeric > 0;
 }
@@ -297,7 +302,7 @@ function shorthandHasNonzeroDuration(shorthand: string): boolean {
   DURATION_TOKEN_PATTERN.lastIndex = 0;
   let match: RegExpExecArray | null = DURATION_TOKEN_PATTERN.exec(shorthand);
   while (match !== null) {
-    if (Number.parseFloat(match[1] ?? "") > 0) {
+    if (Number(match[1] ?? "") > 0) {
       return true;
     }
     match = DURATION_TOKEN_PATTERN.exec(shorthand);
@@ -434,7 +439,7 @@ function isCollapsedTransform(transform: string): boolean {
   }
   const matrix = /^matrix\(([^)]+)\)$/.exec(transform);
   if (matrix?.[1]) {
-    const parts = matrix[1].split(",").map((s) => Number.parseFloat(s.trim()));
+    const parts = matrix[1].split(",").map((s) => Number(s.trim()));
     if (
       parts.length >= 4 &&
       (Math.abs(parts[0] ?? 1) < 1e-6 || Math.abs(parts[3] ?? 1) < 1e-6)
@@ -444,9 +449,7 @@ function isCollapsedTransform(transform: string): boolean {
   }
   const matrix3d = /^matrix3d\(([^)]+)\)$/.exec(transform);
   if (matrix3d?.[1]) {
-    const parts = matrix3d[1]
-      .split(",")
-      .map((s) => Number.parseFloat(s.trim()));
+    const parts = matrix3d[1].split(",").map((s) => Number(s.trim()));
     // matrix3d is column-major 4×4; scale-x lives at m11 (index 0),
     // scale-y at m22 (index 5).
     if (
@@ -479,6 +482,11 @@ function detectHiddenByCss(
     };
   }
   if (
+    // parseFloat, not Number: an unset computed `opacity` comes back as `""`
+    // (notably under jsdom), and `Number("") === 0` would flag every such
+    // element as opacity-0 and redact it. `parseFloat("")` is `NaN`, so only a
+    // genuine `0`/`0.0` opacity matches here.
+    // eslint-disable-next-line unicorn/prefer-number-coercion -- "" opacity; Number("") === 0 false-positives
     Number.parseFloat(style.opacity) === 0 &&
     !hasOpacityAnimationInFlight(style)
   ) {
@@ -651,10 +659,10 @@ function parseColorViaRegex(value: string): RGBA | null {
   if (!match?.[1] || !match[2] || !match[3]) {
     return null;
   }
-  const r = Number.parseFloat(match[1]);
-  const g = Number.parseFloat(match[2]);
-  const b = Number.parseFloat(match[3]);
-  const a = match[4] === undefined ? 1 : Number.parseFloat(match[4]);
+  const r = Number(match[1]);
+  const g = Number(match[2]);
+  const b = Number(match[3]);
+  const a = match[4] === undefined ? 1 : Number(match[4]);
   if ([r, g, b, a].some((n) => Number.isNaN(n))) {
     return null;
   }


### PR DESCRIPTION
Part of the #279 unicorn ratchet (follow-up to #295, now merged).

This is the "needs care — not semantically equivalent" candidate (`parseInt`/`parseFloat` → `Number()`), so each of the 15 sites was verified individually rather than batch-autofixed.

## Converted to `Number()` (13 sites — provably equivalent)

All read a **bare numeric token**, so whole-string coercion matches the leading-numeric parse exactly:

- `countdown-timer-redact.ts` (66/67/69/80) — `\d`-anchored colon/unit regex captures (`\d{1,3}`, `[0-5]\d`, `\d+`).
- `hidden-text-strip.ts`:
  - the `px`-stripped capture `(-?\d+(?:\.\d+)?)`.
  - duration token capture `(\d*\.?\d+)` (unit is a separate group).
  - `matrix()`/`matrix3d()` components (browser-normalized unitless numbers; `Number` handles scientific notation identically).
  - rgb channels + alpha, guarded non-empty `(\d+(?:\.\d+)?)` / `([\d.]+)`; the `Number.isNaN` guard right below makes `Number()`'s stricter rejection intentional.
- `text-walk-shadow.property.test.ts` — `dataset.index`, always set via `String(i)`.

## Kept `parseFloat` behind a scoped disable (2 sites — semantics load-bearing)

In `hidden-text-strip.ts`, `parseFloat`'s "parse the leading number, ignore the rest" is the point:

- **`hasNonzeroDuration`** reads computed `transition-duration`/`animation-duration`, which carry a unit suffix (`"0.5s"`, `"150ms"`). `Number("0.5s")` is `NaN` → every non-zero duration would read as zero and silently disable the hidden-text duration check.
- **`opacity-0` check** reads computed `opacity`, which comes back `""` when unset (notably under jsdom). `Number("") === 0` would flag and redact every such element; `parseFloat("")` is `NaN`, so only a genuine `0` matches.

Each carries an inline comment + `eslint-disable-next-line … -- <reason>`.

## Verification

- `bun run check` clean (biome + tsc + eslint, exit 0); `unicorn/prefer-number-coercion` now `error` with 0 violations.
- Full suite: **2059 tests pass** (incl. the hidden-text-strip / countdown / shadow-walk property tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)