### PR TITLE
Disable unicorn/prefer-scoped-selector (#279)

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -261,8 +261,25 @@ export default tseslint.config(
       //     both of which `Number()` would mis-coerce.
       "unicorn/prefer-number-coercion": "error",
 
+      // Off — the rule's `:scope` rewrite is unsound for this codebase's
+      // dominant receiver type. It assumes the query receiver is an Element,
+      // where `el.querySelectorAll("foo")` and `el.querySelectorAll(":scope
+      // foo")` are equivalent. But our shadow-piercing scanners take
+      // `root: ParentNode` and run against `Document`, `ShadowRoot`, and
+      // `DocumentFragment` receivers at runtime — where `:scope` is NOT
+      // equivalent: it matches nothing on a ShadowRoot/DocumentFragment
+      // (so `:scope *`/`:scope noscript` silently return empty) and excludes
+      // `<html>` on a Document. Mechanically applying the suggestion would
+      // silently disable defenses inside shadow DOM (noscript-strip,
+      // hidden-text-strip, unicode-invisibles-strip, trust-badge-annotate,
+      // closed-shadow-root-annotate, …). The Element-receiver sites where
+      // `:scope` *is* safe are all single-compound selectors with no
+      // descendant combinator, so there's no correctness upside there either.
+      // The rule can't narrow to Element receivers or combinator selectors,
+      // so enabling it means breaking shadow-DOM scans or scoped-disabling
+      // ~10+ correct sites. Not worth it. See #279.
+      "unicorn/prefer-scoped-selector": "off",
       // Warn — ratchet to error in #279:
-      "unicorn/prefer-scoped-selector": "warn",
       "unicorn/no-break-in-nested-loop": "warn",
       // no-global-object-property-assignment stays at its recommended `error`
       // for production code; it's disabled only for tests (which legitimately


### PR DESCRIPTION
Part of the eslint-plugin-unicorn ratchet (#279).

## Verdict: turn off, don't ratchet

`unicorn/prefer-scoped-selector` flags 64 sites and wants
`el.querySelector("foo")` → `el.querySelector(":scope foo")`. That rewrite
is only behavior-preserving when the receiver is an **Element**. This
codebase's shadow-piercing scanners take `root: ParentNode` and run against
`Document`, `ShadowRoot`, and `DocumentFragment` receivers at runtime, where
`:scope` is **not** equivalent — verified in jsdom:

| Receiver | `qsa("*")` | `qsa(":scope *")` |
|---|---|---|
| Element | 4 | 4 ✓ |
| Document | 10 | 9 (drops `<html>`) |
| **ShadowRoot** | **3** | **0 — silently empty** |
| **DocumentFragment** | **1** | **0 — silently empty** |

`:scope noscript` on a ShadowRoot → 0 (vs 1); comma-lists break partially
(`:scope p, span` → 1 vs 2). So mechanically applying the rule's suggestion
would **silently disable defenses inside shadow DOM** — `noscript-strip`,
`hidden-text-strip`, `unicode-invisibles-strip`, `trust-badge-annotate`,
`closed-shadow-root-annotate`, and others that scan `root: ParentNode`.

The Element-receiver sites where `:scope` *is* safe are all single-compound
selectors (`*`, `a[href]`, `img, picture`) with no descendant combinator, so
there's no correctness upside there either. The rule can't narrow to Element
receivers or to combinator-bearing selectors, so it goes `off` (per the
"disable no-plan rules, don't leave noisy warnings" convention) rather than
staying `warn`.

Config-only change; no source edits. `bun run check` (0 errors) and
`typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)