### PR TITLE
Document why consistent-boolean-name stays off (#279)

### DIFF
--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -303,14 +303,22 @@ export default tseslint.config(
       // above). The cleanly autofixable ones (prefer-boolean-return,
       // prefer-continue, prefer-else-if, prefer-hoisting-branch-code,
       // prefer-promise-with-resolvers) are fixed in-tree and stay at their
-      // recommended `error`. The five below fire only on intentional patterns
-      // or false positives, so they have no path to `error`; disabled rather
-      // than left as warning noise, investigated under #279:
-      //   consistent-boolean-name flags ~130 booleans without an is/has/…
-      //     prefix. Its autofix only reaches ~half (renames that don't collide)
-      //     and coins awkward compound names (`isMockHasBuiltInKey`); the rest
-      //     would need a mass manual rename across ~50 files. A rename-only
-      //     ratchet, not a bump concern.
+      // recommended `error`. The five below fire only on intentional patterns,
+      // false positives, or established conventions, so they have no clean path
+      // to `error`; disabled rather than left as warning noise, investigated
+      // under #279:
+      //   consistent-boolean-name flags ~130 boolean bindings without an
+      //     is/has/… prefix. ~23 are genuine plain-variable wins
+      //     (`enabled` → `isEnabled`, `hidden` → `isHidden`), but the rule also
+      //     enforces the prefix on boolean-returning FUNCTIONS and offers no
+      //     option to check variables only. That collides with this codebase's
+      //     deliberate predicate-verb naming (`matchesDenylist`,
+      //     `containsInjection`, `looksLikeNewsletterModal`, `passesLuhn`,
+      //     `overlapsAny`) — ~35 helpers whose current names read better than
+      //     any `is`/`has` form, and which `prefixes`-allowlisting every verb
+      //     stem would only neuter the rule to allow. It also flags
+      //     SCREAMING_CASE `*_ENABLED_DEFAULT` constants, where the convention
+      //     doesn't map. Net: not worth enabling as shipped.
       //   no-top-level-assignment-in-function flags our module-singleton
       //     lazy-init idiom — a top-level `let` (unsubscribe handle,
       //     `listenerAttached` guard) assigned from inside the init/teardown


### PR DESCRIPTION
## What

Records the outcome of investigating `unicorn/consistent-boolean-name` as the next ratchet candidate under #279. The rule **stays `off`** — this only replaces its config rationale with the real reason it isn't worth enabling.

## Why

`consistent-boolean-name` was the strongest-looking candidate among the rules disabled in the v68 bump: it flags ~130 boolean bindings that lack an `is`/`has`/… prefix, and ~23 of those are genuine plain-variable wins (`enabled → isEnabled`, `hidden → isHidden`, `paused → isPaused`, `topFrame → isTopFrame`).

Digging into the other ~107 sites, though:

- The rule **also enforces the prefix on boolean-returning functions**, and there is **no option to check variables only** (`checkProperties` only toggles properties/methods; functions are always evaluated).
- That collides with this codebase's deliberate predicate-verb naming — ~35 helpers like `matchesDenylist`, `containsInjection` (×6 security rules), `looksLikeNewsletterModal`, `passesLuhn`, `overlapsAny`, `sameRegistrableDomain`. Forcing `is`/`has` on these is a **downgrade**, and `prefixes`-allowlisting every verb stem (`matches`, `contains`, `looks`, `passes`, …) would just neuter the rule.
- It also flags SCREAMING_CASE `*_ENABLED_DEFAULT` constants, where the convention doesn't map.

So it belongs in the same "not worth enabling as shipped" bucket as the other four v68 rules, not on the ratchet path. Documenting that here so the investigation isn't repeated.

## Change

Comment-only update to `extension/eslint.config.js`. No behavior change — the rule was and stays `off`. `bun run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)