### PR TITLE
Chore(deps-dev): Bump eslint-plugin-unicorn from 68 to 70 in /extension and /demo-site

### DIFF
--- a/demo-site/bun.lock
+++ b/demo-site/bun.lock
@@ -17,7 +17,7 @@
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^6.0.3",
         "eslint": "^10.6.0",
-        "eslint-plugin-unicorn": "^68.0.0",
+        "eslint-plugin-unicorn": "^70.0.0",
         "globals": "^17.7.0",
         "stylelint": "^17.14.0",
         "stylelint-config-standard": "^40.0.0",
@@ -202,25 +202,25 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.62.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.62.1", "@typescript-eslint/type-utils": "8.62.1", "@typescript-eslint/utils": "8.62.1", "@typescript-eslint/visitor-keys": "8.62.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.62.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.63.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.63.0", "@typescript-eslint/type-utils": "8.63.0", "@typescript-eslint/utils": "8.63.0", "@typescript-eslint/visitor-keys": "8.63.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.63.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.62.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.62.1", "@typescript-eslint/types": "8.62.1", "@typescript-eslint/typescript-estree": "8.62.1", "@typescript-eslint/visitor-keys": "8.62.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.63.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.63.0", "@typescript-eslint/types": "8.63.0", "@typescript-eslint/typescript-estree": "8.63.0", "@typescript-eslint/visitor-keys": "8.63.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.62.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.62.1", "@typescript-eslint/types": "^8.62.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.63.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.63.0", "@typescript-eslint/types": "^8.63.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.62.1", "", { "dependencies": { "@typescript-eslint/types": "8.62.1", "@typescript-eslint/visitor-keys": "8.62.1" } }, "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.63.0", "", { "dependencies": { "@typescript-eslint/types": "8.63.0", "@typescript-eslint/visitor-keys": "8.63.0" } }, "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.62.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.63.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.62.1", "", { "dependencies": { "@typescript-eslint/types": "8.62.1", "@typescript-eslint/typescript-estree": "8.62.1", "@typescript-eslint/utils": "8.62.1", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.63.0", "", { "dependencies": { "@typescript-eslint/types": "8.63.0", "@typescript-eslint/typescript-estree": "8.63.0", "@typescript-eslint/utils": "8.63.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.62.1", "", {}, "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.63.0", "", {}, "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.62.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.62.1", "@typescript-eslint/tsconfig-utils": "8.62.1", "@typescript-eslint/types": "8.62.1", "@typescript-eslint/visitor-keys": "8.62.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.63.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.63.0", "@typescript-eslint/tsconfig-utils": "8.63.0", "@typescript-eslint/types": "8.63.0", "@typescript-eslint/visitor-keys": "8.63.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.62.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.62.1", "@typescript-eslint/types": "8.62.1", "@typescript-eslint/typescript-estree": "8.62.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.63.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.63.0", "@typescript-eslint/types": "8.63.0", "@typescript-eslint/typescript-estree": "8.63.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.62.1", "", { "dependencies": { "@typescript-eslint/types": "8.62.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.63.0", "", { "dependencies": { "@typescript-eslint/types": "8.63.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg=="],
 
@@ -306,7 +306,7 @@
 
     "eslint": ["eslint@10.6.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg=="],
 
-    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@68.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "@eslint-community/eslint-utils": "^4.9.1", "browserslist": "^4.28.2", "change-case": "^5.4.4", "ci-info": "^4.4.0", "core-js-compat": "^3.49.0", "detect-indent": "^7.0.2", "find-up-simple": "^1.0.1", "globals": "^17.6.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regjsparser": "^0.13.1", "semver": "^7.8.4", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=10.4" } }, "sha512-mHYWvX948Q4H3bGc39bsNMxD/leOuNI+Iws9NVsoSz5VA7EGP86wnz7mZ/SPSvRhefT8L4hd8DHfDuGC+lIoCQ=="],
+    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@70.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "@eslint-community/eslint-utils": "^4.9.1", "browserslist": "^4.28.2", "change-case": "^5.4.4", "ci-info": "^4.4.0", "core-js-compat": "^3.49.0", "detect-indent": "^7.0.2", "find-up-simple": "^1.0.1", "globals": "^17.6.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regjsparser": "^0.13.1", "semver": "^7.8.4", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=10.4" } }, "sha512-uAF9xMcVvvhTfvusCgogJ1wh4To3q2KhVMw3i1Apf/ILTbxsCjscvraAZACsEurb7no2fdXblD3whcbVnjw5zg=="],
 
     "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 
@@ -496,7 +496,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
@@ -592,7 +592,7 @@
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "typescript-eslint": ["typescript-eslint@8.62.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.62.1", "@typescript-eslint/parser": "8.62.1", "@typescript-eslint/typescript-estree": "8.62.1", "@typescript-eslint/utils": "8.62.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw=="],
+    "typescript-eslint": ["typescript-eslint@8.63.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.63.0", "@typescript-eslint/parser": "8.63.0", "@typescript-eslint/typescript-estree": "8.63.0", "@typescript-eslint/utils": "8.63.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ=="],
 
     "unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
 
@@ -602,7 +602,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "vite": ["vite@8.1.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.16", "rolldown": "~1.1.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA=="],
+    "vite": ["vite@8.1.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.16", "rolldown": "~1.1.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -657,6 +657,8 @@
     "table/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "table/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "vite/postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
 

--- a/demo-site/package.json
+++ b/demo-site/package.json
@@ -26,7 +26,7 @@
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^6.0.3",
     "eslint": "^10.6.0",
-    "eslint-plugin-unicorn": "^68.0.0",
+    "eslint-plugin-unicorn": "^70.0.0",
     "globals": "^17.7.0",
     "stylelint": "^17.14.0",
     "stylelint-config-standard": "^40.0.0",

--- a/extension/bun.lock
+++ b/extension/bun.lock
@@ -35,7 +35,7 @@
         "eslint-plugin-import-x": "^4.17.0",
         "eslint-plugin-jest": "^29.15.3",
         "eslint-plugin-react-hooks": "^7.1.1",
-        "eslint-plugin-unicorn": "68.0.0",
+        "eslint-plugin-unicorn": "70.0.0",
         "fake-indexeddb": "^6.2.5",
         "fast-check": "^4.8.0",
         "globals": "17.7.0",
@@ -668,7 +668,7 @@
 
     "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
 
-    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@68.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "@eslint-community/eslint-utils": "^4.9.1", "browserslist": "^4.28.2", "change-case": "^5.4.4", "ci-info": "^4.4.0", "core-js-compat": "^3.49.0", "detect-indent": "^7.0.2", "find-up-simple": "^1.0.1", "globals": "^17.6.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regjsparser": "^0.13.1", "semver": "^7.8.4", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=10.4" } }, "sha512-mHYWvX948Q4H3bGc39bsNMxD/leOuNI+Iws9NVsoSz5VA7EGP86wnz7mZ/SPSvRhefT8L4hd8DHfDuGC+lIoCQ=="],
+    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@70.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "@eslint-community/eslint-utils": "^4.9.1", "browserslist": "^4.28.2", "change-case": "^5.4.4", "ci-info": "^4.4.0", "core-js-compat": "^3.49.0", "detect-indent": "^7.0.2", "find-up-simple": "^1.0.1", "globals": "^17.6.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "regjsparser": "^0.13.1", "semver": "^7.8.4", "strip-indent": "^4.1.1" }, "peerDependencies": { "eslint": ">=10.4" } }, "sha512-uAF9xMcVvvhTfvusCgogJ1wh4To3q2KhVMw3i1Apf/ILTbxsCjscvraAZACsEurb7no2fdXblD3whcbVnjw5zg=="],
 
     "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 
@@ -1385,8 +1385,6 @@
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "eslint-plugin-jest/@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
-
-    "eslint-plugin-unicorn/globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
 
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 

--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -341,6 +341,22 @@ export default tseslint.config(
       "unicorn/no-nonstandard-builtin-properties": "off",
       "unicorn/no-unreadable-for-of-expression": "off",
 
+      // eslint-plugin-unicorn 70 turned on four more recommended rules. All
+      // four were resolvable cleanly in-tree, so none needs an override — they
+      // stay at their recommended `error`:
+      //   prefer-dom-node-replace-children — autofixed the `el.innerHTML = ""`
+      //     DOM-reset idiom (test beforeEach teardown, ~150 sites) to
+      //     `el.replaceChildren()`.
+      //   prefer-simplified-conditions — autofixed two De Morgan negations
+      //     (`!(a && !b)` → `!a || b`) in rule-engine/schema-trust-sanitize.
+      //   prefer-toggle-attribute — the one hit was an if/else setAttribute("",
+      //     "")/removeAttribute pair on `checked`; rewritten as
+      //     `toggleAttribute("checked", element.checked)`.
+      //   no-unnecessary-array-flat-map — the one hit was a
+      //     `flatMap(x => cond ? [v] : [])` filter-map fusion; rewritten as
+      //     `.map().filter(x => x !== undefined).map()`, which the inferred
+      //     type predicate (TS 6) narrows without a non-null assertion.
+
       // no-global-object-property-assignment stays at its recommended `error`
       // for production code; it's disabled only for tests (which legitimately
       // assign globals to set up mocks) in the test-files block below.

--- a/extension/package.json
+++ b/extension/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-import-x": "^4.17.0",
     "eslint-plugin-jest": "^29.15.3",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-unicorn": "68.0.0",
+    "eslint-plugin-unicorn": "70.0.0",
     "fake-indexeddb": "^6.2.5",
     "fast-check": "^4.8.0",
     "globals": "17.7.0",

--- a/extension/src/lib/__tests__/checkout-checkbox-defense-source.test.ts
+++ b/extension/src/lib/__tests__/checkout-checkbox-defense-source.test.ts
@@ -18,7 +18,7 @@ beforeAll(() => {
 });
 
 afterEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("installCheckoutCheckboxDefense — prototype wrap", () => {

--- a/extension/src/lib/__tests__/css-hide-stylesheet.property.test.ts
+++ b/extension/src/lib/__tests__/css-hide-stylesheet.property.test.ts
@@ -27,8 +27,8 @@ const STYLE_ID = "abs-css-hide-property-test";
 const SELECTORS = [".prop-test-target"] as const;
 
 beforeEach(() => {
-  document.head.innerHTML = "";
-  document.body.innerHTML = "";
+  document.head.replaceChildren();
+  document.body.replaceChildren();
   __resetShadowRootsForTesting();
   installShadowRootHook();
 });
@@ -64,8 +64,8 @@ function stylesById(): HTMLStyleElement[] {
 function run(ops: ReadonlyArray<{ kind: string }>): {
   activeHandles: Array<{ remove: () => void }>;
 } {
-  document.head.innerHTML = "";
-  document.body.innerHTML = "";
+  document.head.replaceChildren();
+  document.body.replaceChildren();
   __resetShadowRootsForTesting();
   installShadowRootHook();
 

--- a/extension/src/lib/__tests__/placeholder-adaptive-palette.test.ts
+++ b/extension/src/lib/__tests__/placeholder-adaptive-palette.test.ts
@@ -20,7 +20,7 @@ const RULE_ID = "footer-redact" as RuleId;
 const PII_RULE_ID = "pii-redact" as RuleId;
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   document.body.removeAttribute("style");
   // Default to off so the cache state of one test doesn't leak into the
   // next. Each test that needs the toggle on flips it explicitly.

--- a/extension/src/lib/__tests__/placeholder.test.ts
+++ b/extension/src/lib/__tests__/placeholder.test.ts
@@ -24,7 +24,7 @@ const RULE_ID = "footer-redact" as RuleId;
 const PII_RULE_ID = "pii-redact" as RuleId;
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("replaceWithBlockPlaceholder", () => {

--- a/extension/src/lib/__tests__/rule-count.test.ts
+++ b/extension/src/lib/__tests__/rule-count.test.ts
@@ -60,7 +60,7 @@ let stop: (() => void) | null = null;
 
 beforeEach(() => {
   jest.useFakeTimers();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   stub = installDebugTraceStub();
 });
 

--- a/extension/src/lib/__tests__/scan-rule.test.ts
+++ b/extension/src/lib/__tests__/scan-rule.test.ts
@@ -26,7 +26,7 @@ async function flushWatcher(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   __resetSubtreeWatcherForTesting();
   __resetRouteChangeForTesting();
   jest.useFakeTimers();

--- a/extension/src/lib/__tests__/segment-tracker.test.ts
+++ b/extension/src/lib/__tests__/segment-tracker.test.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
   __resetRouteChangeForTesting();
   __resetSubtreeWatcherForTesting();
   __resetSegmentTrackerForTesting();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   history.replaceState(null, "", "/initial");
   stub = installDebugTraceStub();
   stub.setEnabled(true);

--- a/extension/src/lib/__tests__/selector-hide-rule.property.test.ts
+++ b/extension/src/lib/__tests__/selector-hide-rule.property.test.ts
@@ -114,14 +114,14 @@ function freshRule() {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("scan() outermost-match (property)", () => {
   it("places exactly one placeholder per outermost match", () => {
     fc.assert(
       fc.property(treeWithMask, (input) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const { root, candidates } = realize(input);
         document.body.append(root);
 
@@ -139,7 +139,7 @@ describe("scan() outermost-match (property)", () => {
   it("removes every original target from the DOM after scan", () => {
     fc.assert(
       fc.property(treeWithMask, (input) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const { root } = realize(input);
         document.body.append(root);
 
@@ -157,7 +157,7 @@ describe("scan() outermost-match (property)", () => {
   it("does not place a placeholder that is itself a descendant of another placeholder", () => {
     fc.assert(
       fc.property(treeWithMask, (input) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const { root } = realize(input);
         document.body.append(root);
 
@@ -182,7 +182,7 @@ describe("scan() outermost-match (property)", () => {
   it("is idempotent: applying twice yields the same placeholder count", () => {
     fc.assert(
       fc.property(treeWithMask, (input) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const { root } = realize(input);
         document.body.append(root);
 
@@ -294,7 +294,7 @@ describe("processed-WeakSet idempotence under apply N times (property)", () => {
   it("DOM after apply once == DOM after apply N (placeholder mode)", () => {
     fc.assert(
       fc.property(scenarioArb, (scenario) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const { root } = buildMarkedTree(scenario);
         document.body.append(root);
 
@@ -322,7 +322,7 @@ describe("processed-WeakSet idempotence under apply N times (property)", () => {
   it("DOM after apply once == DOM after apply N (removeEntirely mode)", () => {
     fc.assert(
       fc.property(scenarioArb, (scenario) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const { root } = buildMarkedTree(scenario);
         document.body.append(root);
 

--- a/extension/src/lib/__tests__/selector-hide-rule.test.ts
+++ b/extension/src/lib/__tests__/selector-hide-rule.test.ts
@@ -21,7 +21,7 @@ const RULE_ID = "footer-redact" as RuleId;
 const HIDE_LABEL = "[hidden — click to reveal]";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   // Reset the shared dispatcher / watcher / route-change subscription so
   // tests that build watchSubtrees=true rules don't leak registrations
   // across cases.

--- a/extension/src/lib/__tests__/selector-token-index.property.test.ts
+++ b/extension/src/lib/__tests__/selector-token-index.property.test.ts
@@ -137,7 +137,7 @@ const RULE_NEWSLETTER = "newsletter-modal-hide" as RuleId;
 const RULE_FALLBACK = "ads-hide" as RuleId;
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   __resetSelectorTokenIndexForTesting();
   __resetSubtreeWatcherForTesting();
 });

--- a/extension/src/lib/__tests__/selector-token-index.test.ts
+++ b/extension/src/lib/__tests__/selector-token-index.test.ts
@@ -28,7 +28,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
   __resetSelectorTokenIndexForTesting();
   __resetSubtreeWatcherForTesting();

--- a/extension/src/lib/__tests__/shadow-root-probe-source.property.test.ts
+++ b/extension/src/lib/__tests__/shadow-root-probe-source.property.test.ts
@@ -73,7 +73,7 @@ describe("installShadowRootProbe — property: event tally matches op tally", ()
     fc.assert(
       fc.property(sequenceArb, ({ hostCount, ops }) => {
         resetProbe();
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         installShadowRootProbe.call(globalThis as unknown as Window);
 
         const hosts = Array.from({ length: hostCount }, () => {
@@ -152,7 +152,7 @@ describe("installShadowRootProbe — property: discover target equals receiver",
     fc.assert(
       fc.property(fc.integer({ min: 1, max: 8 }), (count) => {
         resetProbe();
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         installShadowRootProbe.call(globalThis as unknown as Window);
 
         const hosts = Array.from({ length: count }, () => {

--- a/extension/src/lib/__tests__/shadow-root-probe-source.test.ts
+++ b/extension/src/lib/__tests__/shadow-root-probe-source.test.ts
@@ -72,7 +72,7 @@ function restorePrototypes(): void {
 beforeEach(() => {
   resetProbeFlag();
   restorePrototypes();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterAll(() => {

--- a/extension/src/lib/__tests__/shadow-roots.property.test.ts
+++ b/extension/src/lib/__tests__/shadow-roots.property.test.ts
@@ -35,7 +35,7 @@ import {
 const THROTTLE_MS = 250;
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   __resetShadowRootsForTesting();
   __resetRouteChangeForTesting();
   __resetSubtreeWatcherForTesting();
@@ -179,7 +179,7 @@ describe("shadow-root tracker — closed-root isolation", () => {
   it("getOpenShadowRoots only ever contains open roots, for any random tree", () => {
     fc.assert(
       fc.property(flatTreeArb, (tree) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         __resetShadowRootsForTesting();
         const built = buildTree(tree);
         document.body.append(built.root);
@@ -213,7 +213,7 @@ describe("shadow-root tracker — closed-root isolation", () => {
   it("the tracker size equals the number of nodes with open shadows", () => {
     fc.assert(
       fc.property(flatTreeArb, (tree) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         __resetShadowRootsForTesting();
         const built = buildTree(tree);
         document.body.append(built.root);
@@ -263,7 +263,7 @@ describe("discoverShadowRootsIn — set-idempotence", () => {
         // many times in one `it`, and any host left behind in body
         // would still be findable by a discoverShadowRootsIn call in
         // a later iteration.
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         __resetShadowRootsForTesting();
         const hosts = Array.from({ length: hostCount }, () => {
           const host = document.createElement("div");
@@ -306,7 +306,7 @@ describe("discoverShadowRootsIn — set-idempotence", () => {
   it("discovery rebuilds every open root reachable from body without crossing closed shadows", () => {
     fc.assert(
       fc.property(flatTreeArb, (tree) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         __resetShadowRootsForTesting();
         const built = buildTree(tree);
         document.body.append(built.root);
@@ -419,7 +419,7 @@ describe("setHTMLUnsafe — open DSD registration property", () => {
   it("registers exactly the open declarative shadows in the parsed HTML", () => {
     fc.assert(
       fc.property(dsdTreeArb, (tree) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         __resetShadowRootsForTesting();
         installShadowRootHook();
 
@@ -491,7 +491,7 @@ describe("subtree watcher — shadow dispatch coverage", () => {
       fc.asyncProperty(flatTreeArb, async (tree) => {
         __resetShadowRootsForTesting();
         __resetSubtreeWatcherForTesting();
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         installShadowRootHook();
 
         const built = buildTree(tree);

--- a/extension/src/lib/__tests__/shadow-roots.test.ts
+++ b/extension/src/lib/__tests__/shadow-roots.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../shadow-roots";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   __resetShadowRootsForTesting();
   installShadowRootHook();
 });

--- a/extension/src/lib/__tests__/shadow-stylesheets.property.test.ts
+++ b/extension/src/lib/__tests__/shadow-stylesheets.property.test.ts
@@ -21,7 +21,7 @@ import {
 import { adoptStylesheetIntoShadowRoots } from "../shadow-stylesheets";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   __resetShadowRootsForTesting();
   installShadowRootHook();
 });
@@ -50,7 +50,7 @@ describe("adoptStylesheetIntoShadowRoots — properties", () => {
   it("sheet membership equals current-open-shadows × active-handles", () => {
     fc.assert(
       fc.property(opSequenceArb, (ops) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         __resetShadowRootsForTesting();
         installShadowRootHook();
 
@@ -130,7 +130,7 @@ describe("adoptStylesheetIntoShadowRoots — properties", () => {
         fc.integer({ min: 1, max: 8 }),
         fc.integer({ min: 1, max: 4 }),
         (shadowCount, adoptCount) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           __resetShadowRootsForTesting();
           installShadowRootHook();
 

--- a/extension/src/lib/__tests__/shadow-stylesheets.test.ts
+++ b/extension/src/lib/__tests__/shadow-stylesheets.test.ts
@@ -16,7 +16,7 @@ import {
 import { adoptStylesheetIntoShadowRoots } from "../shadow-stylesheets";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   __resetShadowRootsForTesting();
   installShadowRootHook();
 });

--- a/extension/src/lib/__tests__/subtree-watcher.test.ts
+++ b/extension/src/lib/__tests__/subtree-watcher.test.ts
@@ -35,7 +35,7 @@ async function flushStorageReads(): Promise<void> {
 }
 
 beforeEach(async () => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
   __resetRouteChangeForTesting();
   __resetSubtreeWatcherForTesting();

--- a/extension/src/lib/__tests__/text-walk-shadow.property.test.ts
+++ b/extension/src/lib/__tests__/text-walk-shadow.property.test.ts
@@ -30,7 +30,7 @@ import {
 import { walkTextNodesChunked } from "../yielding-text-walk";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   __resetShadowRootsForTesting();
   installShadowRootHook();
 });
@@ -226,7 +226,7 @@ describe("walkTextNodes — shadow coverage", () => {
         flatTreeArb,
         fc.integer({ min: 0, max: 6 }),
         (tree, minLength) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           __resetShadowRootsForTesting();
           installShadowRootHook();
           const built = buildTree(tree);
@@ -243,7 +243,7 @@ describe("walkTextNodes — shadow coverage", () => {
   it("collectTextNodesShadowPiercing matches walkTextNodes (same core)", () => {
     fc.assert(
       fc.property(flatTreeArb, (tree) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         __resetShadowRootsForTesting();
         installShadowRootHook();
         const built = buildTree(tree);
@@ -265,7 +265,7 @@ describe("walkTextNodes — shadow coverage", () => {
   it("never returns text living inside a closed shadow root", () => {
     fc.assert(
       fc.property(flatTreeArb, (tree) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         __resetShadowRootsForTesting();
         installShadowRootHook();
         const built = buildTree(tree);
@@ -334,7 +334,7 @@ describe("visibleTextContent — shadow coverage", () => {
   it("concatenates the same reachable text in pre-order for any tree", () => {
     fc.assert(
       fc.property(flatTreeArb, (tree) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         __resetShadowRootsForTesting();
         installShadowRootHook();
         const built = buildTree(tree);
@@ -358,7 +358,7 @@ describe("walkTextNodesChunked — shadow equivalence with walkTextNodes", () =>
   it("union of chunks equals walkTextNodes output across nested shadows (sync)", () => {
     fc.assert(
       fc.property(flatTreeArb, (tree) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         __resetShadowRootsForTesting();
         installShadowRootHook();
         const built = buildTree(tree);
@@ -387,7 +387,7 @@ describe("walkTextNodesChunked — shadow equivalence with walkTextNodes", () =>
         flatTreeArb,
         fc.integer({ min: 1, max: 3 }),
         async (tree, chunkSize) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           __resetShadowRootsForTesting();
           installShadowRootHook();
           const built = buildTree(tree);

--- a/extension/src/lib/__tests__/trace-mutation.test.ts
+++ b/extension/src/lib/__tests__/trace-mutation.test.ts
@@ -32,7 +32,7 @@ function ruleApplicationEvents(): RuleApplicationEvent[] {
 
 beforeEach(() => {
   stub = installDebugTraceStub();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/lib/__tests__/yielding-text-walk.property.test.ts
+++ b/extension/src/lib/__tests__/yielding-text-walk.property.test.ts
@@ -76,7 +76,7 @@ function buildTree(spec: FlatTree): HTMLElement {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("walkTextNodesChunked (property)", () => {
@@ -86,7 +86,7 @@ describe("walkTextNodesChunked (property)", () => {
         flatTreeArb,
         fc.integer({ min: 1, max: 8 }),
         (tree, minLength) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const root = buildTree(tree);
           document.body.append(root);
 
@@ -116,7 +116,7 @@ describe("walkTextNodesChunked (property)", () => {
         fc.integer({ min: 1, max: 4 }),
         fc.integer({ min: 1, max: 8 }),
         async (tree, chunkSize, minLength) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const root = buildTree(tree);
           document.body.append(root);
 
@@ -163,7 +163,7 @@ describe("walkTextNodesChunked (property)", () => {
         flatTreeArb,
         fc.integer({ min: 1, max: 5 }),
         async (tree, chunkSize) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const root = buildTree(tree);
           document.body.append(root);
 

--- a/extension/src/lib/__tests__/yielding-text-walk.test.ts
+++ b/extension/src/lib/__tests__/yielding-text-walk.test.ts
@@ -18,7 +18,7 @@ import { PLACEHOLDER_CLASS } from "../placeholder";
 import { walkTextNodesChunked } from "../yielding-text-walk";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("walkTextNodesChunked — sync fast path", () => {

--- a/extension/src/lib/page-tree.ts
+++ b/extension/src/lib/page-tree.ts
@@ -179,11 +179,7 @@ function setValueAttributesInPlace({
     compressedElement.setAttribute("value", element.value);
     if (element.type === "checkbox" || element.type === "radio") {
       // `checked` is a binary property.
-      if (element.checked) {
-        compressedElement.setAttribute("checked", "");
-      } else {
-        compressedElement.removeAttribute("checked");
-      }
+      compressedElement.toggleAttribute("checked", element.checked);
     }
   } else if (element instanceof HTMLTextAreaElement) {
     // Truncate the same way other text nodes are truncated so a multi-page

--- a/extension/src/lib/page-world-hooks.ts
+++ b/extension/src/lib/page-world-hooks.ts
@@ -131,9 +131,9 @@ export const PAGE_WORLD_HOOKS: readonly PageWorldHookEntry[] = [
 const hooks = PAGE_WORLD_HOOKS.map((entry) => createPageWorldHook(entry));
 
 const injectorsByType = new Map(
-  PAGE_WORLD_HOOKS.flatMap((entry) =>
-    entry.inject ? [[entry.inject.injectType, entry.inject] as const] : [],
-  ),
+  PAGE_WORLD_HOOKS.map((entry) => entry.inject)
+    .filter((inject) => inject !== undefined)
+    .map((inject) => [inject.injectType, inject] as const),
 );
 
 // Start every page-world hook's register/unregister life-cycle. Called once

--- a/extension/src/lib/rule-engine.ts
+++ b/extension/src/lib/rule-engine.ts
@@ -167,7 +167,7 @@ function isApplicableHere(
   // overlays, per-host URL recipes). Running them in subframes would either
   // be a no-op (selectors don't match) or actively harmful (duplicate
   // landmark injection into every iframe's body).
-  return !(rule.topFrameOnly && !topFrame);
+  return !rule.topFrameOnly || topFrame;
 }
 
 function applyEnabled(

--- a/extension/src/rules/__tests__/ads-hide.test.ts
+++ b/extension/src/rules/__tests__/ads-hide.test.ts
@@ -22,8 +22,8 @@ async function flushMutations(): Promise<void> {
 const EASYLIST_STYLE_ID = "abs-ads-hide-easylist";
 
 beforeEach(() => {
-  document.head.innerHTML = "";
-  document.body.innerHTML = "";
+  document.head.replaceChildren();
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/attribute-injection-sanitize.property.test.ts
+++ b/extension/src/rules/__tests__/attribute-injection-sanitize.property.test.ts
@@ -75,7 +75,7 @@ function buildElement(
   attribute: string,
   value: string,
 ): HTMLElement {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   const element = document.createElement(tag);
   element.setAttribute(attribute, value);
   document.body.append(element);
@@ -84,7 +84,7 @@ function buildElement(
 
 afterEach(() => {
   attributeInjectionSanitizeRule.teardown();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("attribute-injection-sanitize (property)", () => {
@@ -126,7 +126,7 @@ describe("attribute-injection-sanitize (property)", () => {
   it("strips value on disabled and hidden inputs, leaves enabled visible inputs alone", () => {
     fc.assert(
       fc.property(ADVERSARIAL, (payload) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const disabled = document.createElement("input");
         disabled.setAttribute("disabled", "");
         disabled.setAttribute("value", payload);

--- a/extension/src/rules/__tests__/attribute-injection-sanitize.test.ts
+++ b/extension/src/rules/__tests__/attribute-injection-sanitize.test.ts
@@ -8,7 +8,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/cart-addon-annotate.test.ts
+++ b/extension/src/rules/__tests__/cart-addon-annotate.test.ts
@@ -13,7 +13,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/chat-widget-hide.test.ts
+++ b/extension/src/rules/__tests__/chat-widget-hide.test.ts
@@ -11,7 +11,7 @@ function expectHidden(element: Element | null): void {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/checkout-checkbox-sanitize.property.test.ts
+++ b/extension/src/rules/__tests__/checkout-checkbox-sanitize.property.test.ts
@@ -27,7 +27,7 @@ beforeAll(() => {
 
 afterEach(() => {
   checkoutCheckboxSanitizeRule.teardown();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("cleared checkbox stays cleared under arbitrary .checked writes", () => {
@@ -51,7 +51,7 @@ describe("cleared checkbox stays cleared under arbitrary .checked writes", () =>
             expect(checkbox.checked).toBe(false);
           }
           checkoutCheckboxSanitizeRule.teardown();
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
         },
       ),
     );
@@ -77,7 +77,7 @@ describe("non-cleared checkbox is unaffected by the prototype patch", () => {
           // Marker was never stamped on a box that started unchecked.
           expect(checkbox.hasAttribute(CLEARED_ATTR)).toBe(false);
           checkoutCheckboxSanitizeRule.teardown();
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
         },
       ),
     );
@@ -106,7 +106,7 @@ describe("URL gate releases the defense off checkout", () => {
           } finally {
             history.replaceState({}, "", "/checkout");
             checkoutCheckboxSanitizeRule.teardown();
-            document.body.innerHTML = "";
+            document.body.replaceChildren();
           }
         },
       ),

--- a/extension/src/rules/__tests__/checkout-checkbox-sanitize.test.ts
+++ b/extension/src/rules/__tests__/checkout-checkbox-sanitize.test.ts
@@ -34,7 +34,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/closed-shadow-root-annotate.test.ts
+++ b/extension/src/rules/__tests__/closed-shadow-root-annotate.test.ts
@@ -68,7 +68,7 @@ function mockZeroRect(element: Element): void {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/comments-redact.test.ts
+++ b/extension/src/rules/__tests__/comments-redact.test.ts
@@ -61,7 +61,7 @@ describe("selectorsFor", () => {
 
 describe("commentsRedactRule.apply", () => {
   beforeEach(() => {
-    document.body.innerHTML = "";
+    document.body.replaceChildren();
   });
 
   it("replaces always-on comment containers with a placeholder", () => {

--- a/extension/src/rules/__tests__/confirmshame-sanitize.test.ts
+++ b/extension/src/rules/__tests__/confirmshame-sanitize.test.ts
@@ -11,7 +11,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/cookie-banner-hide.test.ts
+++ b/extension/src/rules/__tests__/cookie-banner-hide.test.ts
@@ -5,7 +5,7 @@ import { cookieBannerHideRule } from "../cookie-banner-hide";
 const RULE_ID = "cookie-banner-hide";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/countdown-timer-redact.test.ts
+++ b/extension/src/rules/__tests__/countdown-timer-redact.test.ts
@@ -17,7 +17,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/cross-origin-frame-redact.property.test.ts
+++ b/extension/src/rules/__tests__/cross-origin-frame-redact.property.test.ts
@@ -68,7 +68,7 @@ const INERT_URL = fc.constantFrom(
 );
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {
@@ -79,7 +79,7 @@ describe("cross-origin-frame-redact (property)", () => {
   it("redacts any http(s) cross-origin iframe regardless of host or path", () => {
     fc.assert(
       fc.property(CROSS_ORIGIN_URL, (src) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const iframe = document.createElement("iframe");
         iframe.setAttribute("src", src);
         document.body.append(iframe);
@@ -97,7 +97,7 @@ describe("cross-origin-frame-redact (property)", () => {
   it("redacts any http(s) cross-origin <object data=…>", () => {
     fc.assert(
       fc.property(CROSS_ORIGIN_URL, (data) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const object = document.createElement("object");
         object.setAttribute("data", data);
         document.body.append(object);
@@ -115,7 +115,7 @@ describe("cross-origin-frame-redact (property)", () => {
   it("redacts any http(s) cross-origin <embed src=…>", () => {
     fc.assert(
       fc.property(CROSS_ORIGIN_URL, (src) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const embed = document.createElement("embed");
         embed.setAttribute("src", src);
         document.body.append(embed);
@@ -136,7 +136,7 @@ describe("cross-origin-frame-redact (property)", () => {
         SAME_ORIGIN_URL,
         fc.constantFrom("iframe", "object", "embed"),
         (url, tag) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const element = document.createElement(tag);
           element.setAttribute(tag === "object" ? "data" : "src", url);
           document.body.append(element);
@@ -158,7 +158,7 @@ describe("cross-origin-frame-redact (property)", () => {
         INERT_URL,
         fc.constantFrom("iframe", "object", "embed"),
         (url, tag) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const element = document.createElement(tag);
           element.setAttribute(tag === "object" ? "data" : "src", url);
           document.body.append(element);
@@ -189,7 +189,7 @@ describe("cross-origin-frame-redact (property)", () => {
         fc.string({ minLength: 1, maxLength: 64 }),
         ANY_SRC,
         (srcdocBody, src) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const iframe = document.createElement("iframe");
           iframe.setAttribute("srcdoc", `<p>${srcdocBody}</p>`);
           if (src !== undefined) {

--- a/extension/src/rules/__tests__/cross-origin-frame-redact.test.ts
+++ b/extension/src/rules/__tests__/cross-origin-frame-redact.test.ts
@@ -13,7 +13,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/disguised-ad-flag.property.test.ts
+++ b/extension/src/rules/__tests__/disguised-ad-flag.property.test.ts
@@ -26,7 +26,7 @@ const LABEL_PHRASES = [
 
 afterEach(() => {
   disguisedAdFlagRule.teardown();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 function buildFeed(
@@ -60,7 +60,7 @@ describe("disguisedAdFlagRule feed-wrapper invariants (property)", () => {
         fc.integer({ min: 2, max: 6 }),
         fc.constantFrom(...LABEL_PHRASES),
         (cardCount, labelText) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const wrapper = buildFeed(cardCount, labelText, 0);
           document.body.append(wrapper);
 
@@ -92,7 +92,7 @@ describe("disguisedAdFlagRule feed-wrapper invariants (property)", () => {
         fc.integer({ min: 1, max: 5 }),
         (totalCards, headlessRaw) => {
           const headlessCount = Math.min(headlessRaw, totalCards - 1);
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const wrapper = buildFeed(totalCards, "Promoted", headlessCount);
           document.body.append(wrapper);
 
@@ -130,7 +130,7 @@ describe("disguisedAdFlagRule feed-wrapper invariants (property)", () => {
         fc.integer({ min: 1, max: 5 }),
         fc.constantFrom(...LABEL_PHRASES),
         (wrapperDepth, labelText) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const card = document.createElement("article");
           card.dataset.fixture = "card";
           const label = document.createElement("span");
@@ -171,7 +171,7 @@ describe("disguisedAdFlagRule feed-wrapper invariants (property)", () => {
         fc.integer({ min: 1, max: 5 }),
         fc.constantFrom(...LABEL_PHRASES),
         (cardCount, labelText) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const wrapper = buildFeed(cardCount, labelText, cardCount);
           wrapper.setAttribute("role", "feed");
           document.body.append(wrapper);

--- a/extension/src/rules/__tests__/disguised-ad-flag.test.ts
+++ b/extension/src/rules/__tests__/disguised-ad-flag.test.ts
@@ -34,7 +34,7 @@ function articleCard({
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/encoded-payload-redact.property.test.ts
+++ b/extension/src/rules/__tests__/encoded-payload-redact.property.test.ts
@@ -79,7 +79,7 @@ const highEntropyBytesArb = fc
   });
 
 function applyToText(text: string): HTMLElement {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   const p = document.createElement("p");
   p.textContent = text;
   document.body.append(p);
@@ -89,7 +89,7 @@ function applyToText(text: string): HTMLElement {
 
 afterEach(() => {
   encodedPayloadRedactRule.teardown();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("encoded-payload-redact (property)", () => {
@@ -173,7 +173,7 @@ function applyToSpanSplitText(
   encoded: string,
   splits: readonly number[],
 ): HTMLElement {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   const p = document.createElement("p");
   let cursor = 0;
   for (const split of splits) {
@@ -439,7 +439,7 @@ describe("encoded-payload-redact cross-node detection (property)", () => {
         // legitimately fire on one half alone — not a cross-block leak.
         expect(mid).toBeLessThan(MIN_BASE64_LENGTH);
 
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const a = document.createElement("p");
         const b = document.createElement("p");
         a.textContent = encoded.slice(0, mid);

--- a/extension/src/rules/__tests__/encoded-payload-redact.test.ts
+++ b/extension/src/rules/__tests__/encoded-payload-redact.test.ts
@@ -197,7 +197,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
   history.replaceState(null, "", "/initial");
   __resetRouteChangeForTesting();

--- a/extension/src/rules/__tests__/footer-redact.test.ts
+++ b/extension/src/rules/__tests__/footer-redact.test.ts
@@ -13,7 +13,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/form-prefill-annotate.property.test.ts
+++ b/extension/src/rules/__tests__/form-prefill-annotate.property.test.ts
@@ -76,7 +76,7 @@ const NON_GEO_SELECT_NAMES: readonly string[] = [
 
 afterEach(() => {
   formPrefillAnnotateRule.teardown();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("autocomplete-token gating (property)", () => {
@@ -86,7 +86,7 @@ describe("autocomplete-token gating (property)", () => {
         fc.constantFrom(...AUTOFILL_TOKENS),
         fc.stringMatching(/^[A-Za-z][A-Za-z0-9 @.-]{0,30}$/),
         (token, value) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const form = document.createElement("form");
           const label = document.createElement("label");
           const input = document.createElement("input");
@@ -113,7 +113,7 @@ describe("autocomplete-token gating (property)", () => {
         fc.constantFrom(...NON_AUTOFILL_TOKENS),
         fc.stringMatching(/^[A-Za-z][A-Za-z0-9 @.-]{0,30}$/),
         (token, value) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const form = document.createElement("form");
           const label = document.createElement("label");
           const input = document.createElement("input");
@@ -142,7 +142,7 @@ describe("isGeoSelect (property)", () => {
         fc.constantFrom(...GEO_NAMES),
         fc.constantFrom("name", "id", "aria-label"),
         (geo, where) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const select = document.createElement("select");
           select.setAttribute(where, `user_${geo}_picker`);
           document.body.append(select);
@@ -159,7 +159,7 @@ describe("isGeoSelect (property)", () => {
         fc.constantFrom(...NON_GEO_SELECT_NAMES),
         fc.constantFrom("name", "id", "aria-label"),
         (nonGeo, where) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const select = document.createElement("select");
           select.setAttribute(where, nonGeo);
           document.body.append(select);
@@ -187,7 +187,7 @@ describe("<select> first-option invariant (property)", () => {
       fc.property(
         fc.array(selectArb, { minLength: 1, maxLength: 6 }),
         (specs) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const form = document.createElement("form");
           let expected = 0;
           for (const spec of specs) {
@@ -233,7 +233,7 @@ describe("idempotency (property)", () => {
           { minLength: 1, maxLength: 6 },
         ),
         (specs) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const form = document.createElement("form");
           for (const [i, spec] of specs.entries()) {
             if (spec.kind === "text") {

--- a/extension/src/rules/__tests__/form-prefill-annotate.test.ts
+++ b/extension/src/rules/__tests__/form-prefill-annotate.test.ts
@@ -13,7 +13,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/hidden-affiliate-sanitize.property.test.ts
+++ b/extension/src/rules/__tests__/hidden-affiliate-sanitize.property.test.ts
@@ -80,7 +80,7 @@ const SECURITY_TOKENS: readonly string[] = [
 
 afterEach(() => {
   hiddenAffiliateSanitizeRule.teardown();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("allowlist / denylist disjointness (property)", () => {
@@ -145,7 +145,7 @@ describe("promo / coupon / discount preservation (property)", () => {
         fc.constantFrom(...PROMO_NAMES),
         fc.stringMatching(/^[A-Z0-9-]{4,16}$/),
         (name, code) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const form = document.createElement("form");
           const promo = document.createElement("input");
           promo.type = "hidden";
@@ -178,7 +178,7 @@ describe("URL-gate invariance (property)", () => {
     try {
       fc.assert(
         fc.property(fc.constantFrom(...AFFILIATE_NAMES), (name) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const form = document.createElement("form");
           const input = document.createElement("input");
           input.type = "hidden";
@@ -223,7 +223,7 @@ describe("idempotency (property)", () => {
         NAMES_ARB,
         fc.stringMatching(/^[A-Za-z0-9-]{1,15}$/),
         (names, value) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const form = document.createElement("form");
           const inputs: HTMLInputElement[] = [];
           for (const name of names) {

--- a/extension/src/rules/__tests__/hidden-affiliate-sanitize.test.ts
+++ b/extension/src/rules/__tests__/hidden-affiliate-sanitize.test.ts
@@ -17,7 +17,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/hidden-fee-annotate.property.test.ts
+++ b/extension/src/rules/__tests__/hidden-fee-annotate.property.test.ts
@@ -44,7 +44,7 @@ const EXCLUDE_TERMS: readonly string[] = [
 
 afterEach(() => {
   hiddenFeeAnnotateRule.teardown();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("matchFeePhrase precision (property)", () => {
@@ -222,7 +222,7 @@ describe("single-item-cart invariant (property)", () => {
     const nonFeeRowsArb = fc.array(rowArb, { minLength: 0, maxLength: 5 });
     fc.assert(
       fc.property(nonFeeRowsArb, (nonFeeRows) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const feeRow: SyntheticRow = {
           label: "Resort Fee",
           amount: 45,
@@ -255,7 +255,7 @@ describe("idempotency (property)", () => {
     const nonFeeRowsArb = fc.array(rowArb, { minLength: 1, maxLength: 5 });
     fc.assert(
       fc.property(nonFeeRowsArb, (nonFeeRows) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const feeRow: SyntheticRow = {
           label: "Service Fee",
           amount: 5,

--- a/extension/src/rules/__tests__/hidden-fee-annotate.test.ts
+++ b/extension/src/rules/__tests__/hidden-fee-annotate.test.ts
@@ -19,7 +19,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/hidden-text-strip.property.test.ts
+++ b/extension/src/rules/__tests__/hidden-text-strip.property.test.ts
@@ -45,7 +45,7 @@ const PAYLOAD = fc.constantFrom(
 const CHILD_COUNT = fc.integer({ min: 0, max: 6 });
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {
@@ -60,7 +60,7 @@ describe("hidden-text-strip (property)", () => {
         PAYLOAD,
         CHILD_COUNT,
         (style, payload, childCount) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const target = document.createElement("div");
           target.id = "target";
           target.setAttribute("style", style);
@@ -125,7 +125,7 @@ describe("hidden-text-strip (property)", () => {
         PAYLOAD,
         CHILD_COUNT,
         (attributes, payload, childCount) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const target = document.createElement("div");
           target.id = "target";
           target.setAttribute("style", "display: none");
@@ -183,7 +183,7 @@ describe("hidden-text-strip (property)", () => {
   it("strips text under any transform whose x or y scale collapses to zero", () => {
     fc.assert(
       fc.property(COLLAPSING_TRANSFORM, PAYLOAD, (transform, payload) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const target = document.createElement("div");
         target.id = "target";
         target.setAttribute("style", `transform: ${transform}`);
@@ -219,7 +219,7 @@ describe("hidden-text-strip (property)", () => {
   it("preserves text whose transform leaves both axes non-zero", () => {
     fc.assert(
       fc.property(NON_COLLAPSING_TRANSFORM, (transform) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const target = document.createElement("div");
         target.id = "target";
         target.setAttribute("style", `transform: ${transform}`);
@@ -264,7 +264,7 @@ describe("hidden-text-strip (property)", () => {
         fc.array(TRANSPARENT_COLOR, { minLength: 2, maxLength: 5 }),
         PAYLOAD,
         (kind, stops, payload) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const target = document.createElement("div");
           target.id = "target";
           target.setAttribute(
@@ -297,7 +297,7 @@ describe("hidden-text-strip (property)", () => {
           if (stops.length < 2) {
             stops.push(opaqueStops[0] ?? "black");
           }
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const target = document.createElement("div");
           target.id = "target";
           target.setAttribute(
@@ -366,7 +366,7 @@ describe("hidden-text-strip (property)", () => {
         TRIGGER_AND_TRAP_TRANSITION,
         PAYLOAD,
         ({ style }, payload) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const target = document.createElement("div");
           target.id = "target";
           target.setAttribute("style", style);
@@ -414,7 +414,7 @@ describe("hidden-text-strip (property)", () => {
         NON_POSITIONAL_TRIGGER,
         PAYLOAD,
         (tag, positional, positionalStyle, nonPositionalStyle, payload) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const target = document.createElement(tag);
           target.id = "target";
           target.setAttribute(
@@ -443,7 +443,7 @@ describe("hidden-text-strip (property)", () => {
         NON_POSITIONAL_TRIGGER,
         PAYLOAD,
         (positional, positionalStyle, nonPositionalStyle, payload) => {
-          document.body.innerHTML = "";
+          document.body.replaceChildren();
           const wrapper = document.createElement("div");
           wrapper.setAttribute("aria-hidden", "true");
           const target = document.createElement("span");
@@ -472,7 +472,7 @@ describe("hidden-text-strip (property)", () => {
     // detector families.
     fc.assert(
       fc.property(PAYLOAD, CHILD_COUNT, (payload, childCount) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const wrapper = document.createElement("section");
         wrapper.setAttribute("style", "background-color: rgb(20, 20, 20)");
         const target = document.createElement("span");

--- a/extension/src/rules/__tests__/hidden-text-strip.test.ts
+++ b/extension/src/rules/__tests__/hidden-text-strip.test.ts
@@ -6,7 +6,7 @@ import {
 import { FIXTURES } from "./injection-fixtures";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/html-comment-strip.property.test.ts
+++ b/extension/src/rules/__tests__/html-comment-strip.property.test.ts
@@ -50,7 +50,7 @@ const FRAMEWORK_MARKER = fc.constantFrom(
 const EXCLUDED_PARENT_TAG = fc.constantFrom("script", "style", "noscript");
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {
@@ -61,7 +61,7 @@ describe("html-comment-strip (property)", () => {
   it("blanks any comment whose data carries injection text", () => {
     fc.assert(
       fc.property(POISONED, (payload) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const comment = document.createComment(payload);
         document.body.append(comment);
 
@@ -76,7 +76,7 @@ describe("html-comment-strip (property)", () => {
   it("leaves framework markers and benign comments untouched", () => {
     fc.assert(
       fc.property(FRAMEWORK_MARKER, (data) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const comment = document.createComment(data);
         document.body.append(comment);
 

--- a/extension/src/rules/__tests__/html-comment-strip.test.ts
+++ b/extension/src/rules/__tests__/html-comment-strip.test.ts
@@ -2,7 +2,7 @@ import { htmlCommentStripRule } from "../html-comment-strip";
 import { FIXTURES } from "./injection-fixtures";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/irrelevant-sections-redact.test.ts
+++ b/extension/src/rules/__tests__/irrelevant-sections-redact.test.ts
@@ -128,7 +128,7 @@ async function applyAndSettle(): Promise<void> {
 // src/__test-mocks__/jsdom-extras.ts via the global setupFiles hook.
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
   mockClassify.mockReset();
 });

--- a/extension/src/rules/__tests__/json-ld-sanitize.test.ts
+++ b/extension/src/rules/__tests__/json-ld-sanitize.test.ts
@@ -20,7 +20,7 @@ function parseScript(script: HTMLScriptElement): unknown {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/link-spoof-annotate.test.ts
+++ b/extension/src/rules/__tests__/link-spoof-annotate.test.ts
@@ -22,7 +22,7 @@ function makeAnchor(text: string, href: string): HTMLAnchorElement {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/meta-injection-strip.property.test.ts
+++ b/extension/src/rules/__tests__/meta-injection-strip.property.test.ts
@@ -53,7 +53,7 @@ function resetHead(): void {
 
 afterEach(() => {
   metaInjectionStripRule.teardown();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   resetHead();
 });
 

--- a/extension/src/rules/__tests__/meta-injection-strip.test.ts
+++ b/extension/src/rules/__tests__/meta-injection-strip.test.ts
@@ -33,7 +33,7 @@ function resetHead(): void {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   resetHead();
   jest.useFakeTimers();
 });

--- a/extension/src/rules/__tests__/newsletter-modal-hide.test.ts
+++ b/extension/src/rules/__tests__/newsletter-modal-hide.test.ts
@@ -5,7 +5,7 @@ import { newsletterModalHideRule } from "../newsletter-modal-hide";
 const RULE_ID = "newsletter-modal-hide";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/noscript-strip.test.ts
+++ b/extension/src/rules/__tests__/noscript-strip.test.ts
@@ -7,7 +7,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   document.head.querySelectorAll("noscript").forEach((n) => {
     n.remove();
   });

--- a/extension/src/rules/__tests__/pii-redact.property.test.ts
+++ b/extension/src/rules/__tests__/pii-redact.property.test.ts
@@ -48,7 +48,7 @@ const invalidCardDigitsArb = cardDigitsArb.map((valid) => {
 });
 
 function applyPiiToText(text: string): HTMLElement {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   const p = document.createElement("p");
   p.textContent = text;
   document.body.append(p);
@@ -58,7 +58,7 @@ function applyPiiToText(text: string): HTMLElement {
 
 afterEach(() => {
   piiRedactRule.teardown();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("pii-redact Luhn detection (property)", () => {
@@ -96,7 +96,7 @@ function applyPiiToSpanSplitText(
   text: string,
   splits: readonly number[],
 ): HTMLElement {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   const p = document.createElement("p");
   let cursor = 0;
   for (const split of splits) {
@@ -157,7 +157,7 @@ describe("pii-redact cross-node detection (property)", () => {
   it("never masks card digits split across two block elements", () => {
     fc.assert(
       fc.property(cardDigitsArb, (card) => {
-        document.body.innerHTML = "";
+        document.body.replaceChildren();
         const a = document.createElement("p");
         const b = document.createElement("p");
         const mid = Math.floor(card.length / 2);

--- a/extension/src/rules/__tests__/pii-redact.test.ts
+++ b/extension/src/rules/__tests__/pii-redact.test.ts
@@ -14,7 +14,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
   history.replaceState(null, "", "/initial");
   __resetRouteChangeForTesting();

--- a/extension/src/rules/__tests__/prompt-injection-redact.test.ts
+++ b/extension/src/rules/__tests__/prompt-injection-redact.test.ts
@@ -4,7 +4,7 @@ import { promptInjectionRedactRule } from "../prompt-injection-redact";
 import { FIXTURES } from "./injection-fixtures";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("prompt-injection-redact", () => {
@@ -238,7 +238,7 @@ describe("prompt-injection-redact", () => {
     // would black out the whole page. findContainer returns null on the
     // BODY/HTML guard.
     it("does not redact text that is a direct child of <body>", () => {
-      document.body.innerHTML = "";
+      document.body.replaceChildren();
       document.body.append(document.createTextNode(FIXTURES.IGNORE_ALL));
 
       promptInjectionRedactRule.apply(document.body);

--- a/extension/src/rules/__tests__/reviews-redact.amazon.test.ts
+++ b/extension/src/rules/__tests__/reviews-redact.amazon.test.ts
@@ -6,7 +6,7 @@ import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { reviewsRedactRule } from "../reviews-redact";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("reviews-redact on amazon.com", () => {

--- a/extension/src/rules/__tests__/reviews-redact.rei.test.ts
+++ b/extension/src/rules/__tests__/reviews-redact.rei.test.ts
@@ -6,7 +6,7 @@ import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { reviewsRedactRule } from "../reviews-redact";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("reviews-redact on rei.com", () => {

--- a/extension/src/rules/__tests__/reviews-redact.target.test.ts
+++ b/extension/src/rules/__tests__/reviews-redact.target.test.ts
@@ -6,7 +6,7 @@ import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { reviewsRedactRule } from "../reviews-redact";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("reviews-redact on target.com", () => {

--- a/extension/src/rules/__tests__/reviews-redact.test.ts
+++ b/extension/src/rules/__tests__/reviews-redact.test.ts
@@ -3,7 +3,7 @@ import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { reviewsRedactRule, selectorsFor } from "../reviews-redact";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("selectorsFor", () => {

--- a/extension/src/rules/__tests__/reviews-redact.walmart.test.ts
+++ b/extension/src/rules/__tests__/reviews-redact.walmart.test.ts
@@ -6,7 +6,7 @@ import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { reviewsRedactRule } from "../reviews-redact";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("reviews-redact on walmart.com", () => {

--- a/extension/src/rules/__tests__/roach-motel-annotate.test.ts
+++ b/extension/src/rules/__tests__/roach-motel-annotate.test.ts
@@ -18,7 +18,7 @@ const LANDMARK_SELECTOR = 'section[data-abs-rule="roach-motel-annotate"]';
 const recordDetectionMock = recordDetection as jest.Mock;
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/scarcity-redact.test.ts
+++ b/extension/src/rules/__tests__/scarcity-redact.test.ts
@@ -9,7 +9,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/schema-trust-sanitize-skip.test.ts
+++ b/extension/src/rules/__tests__/schema-trust-sanitize-skip.test.ts
@@ -12,8 +12,8 @@ import { schemaTrustSanitizeRule } from "../schema-trust-sanitize";
 
 afterEach(() => {
   schemaTrustSanitizeRule.teardown();
-  document.body.innerHTML = "";
-  document.head.innerHTML = "";
+  document.body.replaceChildren();
+  document.head.replaceChildren();
 });
 
 it("leaves a mismatched publisher claim alone when the page host is a known syndicator", () => {

--- a/extension/src/rules/__tests__/schema-trust-sanitize.test.ts
+++ b/extension/src/rules/__tests__/schema-trust-sanitize.test.ts
@@ -22,8 +22,8 @@ function parseScript(script: HTMLScriptElement): unknown {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
-  document.head.innerHTML = "";
+  document.body.replaceChildren();
+  document.head.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/search-url-helper.test.ts
+++ b/extension/src/rules/__tests__/search-url-helper.test.ts
@@ -8,7 +8,7 @@ import { findRecipe, searchUrlHelperRule } from "../search-url-helper";
 const LANDMARK_SELECTOR = 'section[data-abs-rule="search-url-helper"]';
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/secrets-redact.test.ts
+++ b/extension/src/rules/__tests__/secrets-redact.test.ts
@@ -26,7 +26,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
   history.replaceState(null, "", "/initial");
   __resetRouteChangeForTesting();

--- a/extension/src/rules/__tests__/social-embed-redact.owner-host.test.ts
+++ b/extension/src/rules/__tests__/social-embed-redact.owner-host.test.ts
@@ -6,7 +6,7 @@ import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { socialEmbedRedactRule } from "../social-embed-redact";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/social-embed-redact.test.ts
+++ b/extension/src/rules/__tests__/social-embed-redact.test.ts
@@ -3,7 +3,7 @@ import { PLACEHOLDER_CLASS } from "../../lib/placeholder";
 import { socialEmbedRedactRule } from "../social-embed-redact";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/svg-sprite-strip.test.ts
+++ b/extension/src/rules/__tests__/svg-sprite-strip.test.ts
@@ -1,7 +1,7 @@
 import { svgSpriteStripRule } from "../svg-sprite-strip";
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/__tests__/svg-text-strip.test.ts
+++ b/extension/src/rules/__tests__/svg-text-strip.test.ts
@@ -8,7 +8,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/trust-badge-annotate.test.ts
+++ b/extension/src/rules/__tests__/trust-badge-annotate.test.ts
@@ -36,7 +36,7 @@ function makeSvgWithTitle(titleText: string): SVGElement {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/unicode-invisibles-strip.test.ts
+++ b/extension/src/rules/__tests__/unicode-invisibles-strip.test.ts
@@ -30,7 +30,7 @@ async function flushMutations(): Promise<void> {
 }
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   jest.useFakeTimers();
 });
 

--- a/extension/src/rules/__tests__/webdriver-probe-annotate.test.ts
+++ b/extension/src/rules/__tests__/webdriver-probe-annotate.test.ts
@@ -33,7 +33,7 @@ const requestInjectMock = requestPageWorldInject as jest.Mock;
 const recordDetectionMock = recordDetection as jest.Mock;
 
 beforeEach(() => {
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 afterEach(() => {

--- a/extension/src/rules/confirmshame-sanitize.ts
+++ b/extension/src/rules/confirmshame-sanitize.ts
@@ -239,7 +239,6 @@ function neutralize(element: HTMLElement): boolean {
       // argument back to Element and loses the `instanceof` narrowing that
       // `rewriteInput` needs; an `if`/`else` would trip `prefer-ternary`.
       const changed =
-        // eslint-disable-next-line unicorn/prefer-minimal-ternary -- instanceof narrowing
         element instanceof HTMLInputElement
           ? rewriteInput(element)
           : rewriteButtonLike(element);

--- a/extension/src/rules/schema-trust-sanitize.ts
+++ b/extension/src/rules/schema-trust-sanitize.ts
@@ -76,7 +76,7 @@ function sanitizeAuthorityNode(
   mutated: { value: boolean },
 ): void {
   for (const key of SANITIZE_KEYS) {
-    if (!(key in node && node[key] !== "")) {
+    if (!(key in node) || node[key] === "") {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Bumps `eslint-plugin-unicorn` from 68 to 70 in both `/extension` and `/demo-site`, superseding the two Dependabot PRs (#324, #321) which failed CI on the new rules. unicorn 70 turns on four new recommended rules; all were resolvable cleanly in-tree, so they stay at their recommended `error` with **no config overrides** — advancing the ratchet effort in #279.

## Changes

- **Bump** `eslint-plugin-unicorn` 68 → 70 (`/extension`, `/demo-site`) + lockfiles.
- **`prefer-dom-node-replace-children`** — autofixed the `el.innerHTML = ""` DOM-reset idiom in test `beforeEach` teardown (~150 sites) to `el.replaceChildren()`. Test-owned jsdom nodes only; no production/framework-owned nodes touched.
- **`prefer-simplified-conditions`** — autofixed two equivalent De Morgan negations (`!(a && !b)` → `!a || b`) in `rule-engine.ts` and `schema-trust-sanitize.ts`.
- **`prefer-toggle-attribute`** — rewrote a `checked` `setAttribute("", "")`/`removeAttribute` if/else pair in `page-tree.ts` as `toggleAttribute("checked", element.checked)`.
- **`no-unnecessary-array-flat-map`** — rewrote a `flatMap(x => cond ? [v] : [])` filter-map fusion in `page-world-hooks.ts` as `.map().filter(x => x !== undefined).map()`; the TS 6 inferred type predicate narrows without a non-null assertion.
- **`eslint.config.js`** — documented the v70 batch in the same style as the v66/v68 notes.

All production-code changes are behavior-preserving refactors.

## Testing

- [x] `bun run preflight` (build-site-data, build-injection-patterns, check, typecheck, knip, test:coverage — 2059 tests pass) + `bun run build` in `/extension`
- [x] `bun run check` + `bun run build` in `/demo-site`
- [ ] Manually loaded the extension and exercised the affected rule(s) — not needed; dev-dependency bump with no runtime behavior change

## CLA

- [x] I have signed the PixieBrix Contributor License Agreement (carries over to future PRs).